### PR TITLE
Port changes to vec_dtypes from prefill branch to amd-integration

### DIFF
--- a/libflashinfer/include/gpu_iface/backend/cuda/vec_dtypes.cuh
+++ b/libflashinfer/include/gpu_iface/backend/cuda/vec_dtypes.cuh
@@ -23,7 +23,8 @@
 
 #include <type_traits>
 
-namespace flashinfer {
+namespace detail {
+namespace cuda {
 
 #if (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 900))
 #define FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED
@@ -1388,6 +1389,7 @@ struct vec_t<float, vec_size> {
   }
 };
 
-}  // namespace flashinfer
+}  // namespace cuda
+}  // namespace detail
 
 #endif  // VEC_DTYPES_CUH_

--- a/libflashinfer/include/gpu_iface/backend/hip/vec_dtypes_hip.h
+++ b/libflashinfer/include/gpu_iface/backend/hip/vec_dtypes_hip.h
@@ -20,6 +20,7 @@
 
 #define FLASHINFER_INLINE inline __attribute__((always_inline)) __device__
 
+namespace {
 __host__ __device__ inline __hip_bfloat162 __float2bfloat162_rn(const float a) {
   return __hip_bfloat162{__float2bfloat16(a), __float2bfloat16(a)};
 }
@@ -30,6 +31,7 @@ FLASHINFER_INLINE __hip_bfloat162 make_bfloat162(const __hip_bfloat16 x, const _
   t.y = y;
   return t;
 }
+}  // namespace
 
 namespace detail {
 namespace hip {
@@ -1628,6 +1630,5 @@ struct vec_t<float, vec_size> {
     }
   }
 };
-
-}  // namespace flashinfer
+}
 }

--- a/libflashinfer/include/gpu_iface/vec_dtypes.hpp
+++ b/libflashinfer/include/gpu_iface/vec_dtypes.hpp
@@ -15,16 +15,17 @@ namespace vec_dtypes {
 // Include the appropriate backend implementation
 #if defined(PLATFORM_CUDA_DEVICE)
 #include "backend/cuda/vec_dtypes.cuh"
-namespace detail = flashinfer::gpu_iface::vec_dtypes::detail::cuda;
+namespace vec_t_detail = flashinfer::gpu_iface::vec_dtypes::detail::cuda;
 #elif defined(PLATFORM_HIP_DEVICE)
 #include "backend/hip/vec_dtypes_hip.h"
 #define HIP_ENABLE_WARP_SYNC_BUILTINS 1
-namespace detail_t = flashinfer::gpu_iface::vec_dtypes::detail::hip;
+namespace vec_t_detail = flashinfer::gpu_iface::vec_dtypes::detail::hip;
 #endif
 
 // Re-export types and functions from the appropriate backend
 // This allows code to use flashinfer::gpu_iface::vec_dtypes::vec_t<float, 4>
-using detail_t::vec_t;
+using vec_t_detail::vec_cast;
+using vec_t_detail::vec_t;
 
 }  // namespace vec_dtypes
 }  // namespace gpu_iface


### PR DESCRIPTION
Changes to the gpu_iface/vec_dtypes API.

- The header was using an internal detail namespace for the actual implementation. Using the same implementation namespace name (detail) is dangerous in the case where the same name is used in multiple headers and can cause unforeseen aliasing. The PR changes the implementation namespace name to vec_detail in line with changes in other headers.
- The CUDA header was never properly added to the new nested namespace design. The PR makes the changes.
- Minor changes to the vec_dtypes_hip.hpp header to use an anonymous namespace for private functions.

