### PR TITLE
Incoporate gpu_iface changes needed for prefill

### DIFF
--- a/libflashinfer/include/gpu_iface/gpu_runtime_compat.hpp
+++ b/libflashinfer/include/gpu_iface/gpu_runtime_compat.hpp
@@ -21,9 +21,11 @@
 
 // Basic type mappings
 #if defined(PLATFORM_CUDA_DEVICE)
+#define gpuEvent_t cudaEvent_t
 #define gpuError_t cudaError_t
 #define gpuStream_t cudaStream_t
 #elif defined(PLATFORM_HIP_DEVICE)
+#define gpuEvent_t hipEvent_t
 #define gpuError_t hipError_t
 #define gpuStream_t hipStream_t
 #endif
@@ -38,7 +40,8 @@
 #elif defined(PLATFORM_HIP_DEVICE)
 #define gpuGetDevice hipGetDevice
 #define gpuLaunchKernel hipLaunchKernel
-#define gpuFuncSetAttribute hipFuncSetAttribute
+#define gpuFuncSetAttribute(func, attr, val) \
+  hipFuncSetAttribute(reinterpret_cast<const void*>(func), attr, val)
 #define gpuDeviceGetAttribute hipDeviceGetAttribute
 #define gpuDeviceSynchronize hipDeviceSynchronize
 #endif
@@ -46,6 +49,7 @@
 #if defined(PLATFORM_CUDA_DEVICE)
 #define gpuMemcpy cudaMemcpy
 #define gpuMalloc cudaMalloc
+#define gpuMemset cudaMemset
 #define gpFree cudaFree
 #define gpuMemCpyAsync cudaMemcpyAsync
 #define gpuMemcpyHostToDevice cudaMemcpyHostToDevice
@@ -53,6 +57,7 @@
 #elif defined(PLATFORM_HIP_DEVICE)
 #define gpuMemcpy hipMemcpy
 #define gpuMalloc hipMalloc
+#define gpuMemset hipMemset
 #define gpuFree hipFree
 #define gpuMemcpyAsync hipMemcpyAsync
 #define gpuMemcpyHostToDevice hipMemcpyHostToDevice
@@ -79,6 +84,30 @@
 #define gpuOccupancyMaxActiveBlocksPerMultiprocessor hipOccupancyMaxActiveBlocksPerMultiprocessor
 #endif
 
+// Event iface
+#if defined(PLATFORM_CUDA_DEVICE)
+#define gpuEventCreate cudaEventCreate
+#define gpuEventDestroy cudaEventDestroy
+#define gpuEventRecord cudaEventRecord
+#define gpuEventSynchronize cudaEventSynchronize
+#define gpuEventElapsedTime cudaEventElapsedTime
+#elif defined(PLATFORM_HIP_DEVICE)
+#define gpuEventCreate hipEventCreate
+#define gpuEventDestroy hipEventDestroy
+#define gpuEventRecord hipEventRecord
+#define gpuEventSynchronize hipEventSynchronize
+#define gpuEventElapsedTime hipEventElapsedTime
+#endif
+
+// Stream iface
+#if defined(PLATFORM_CUDA_DEVICE)
+#define gpuStreamCreate cudaStreamCreate
+#define gpuStreamDestroy cudaStreamDestroy
+#elif defined(PLATFORM_HIP_DEVICE)
+#define gpuStreamCreate hipStreamCreate
+#define gpuStreamDestroy hipStreamDestroy
+#endif
+
 // Error handling (for FI_GPU_CALL)
 #if defined(PLATFORM_CUDA_DEVICE)
 #define gpuGetErrorString cudaGetErrorString
@@ -95,6 +124,7 @@
 #define gpuLaunchConfig_t hipLaunchConfig_t
 #define gpuLaunchAttribute hipLaunchAttribute
 #endif
+
 // CUDA error checking macro (replaces FLASHINFER_CUDA_CALL)
 #define FI_GPU_CALL(call)                                                                          \
   do {                                                                                             \
@@ -105,3 +135,17 @@
       throw std::runtime_error(err_msg.str());                                                     \
     }                                                                                              \
   } while (0)
+
+inline int getMaxSharedMemPerMultiprocessor(int dev_id) {
+  int max_smem_per_sm = 0;
+#if defined(PLATFORM_CUDA_DEVICE)
+  FI_GPU_CALL(
+      gpuDeviceGetAttribute(&max_smem_per_sm, gpuDevAttrMaxSharedMemoryPerMultiProcessor, dev_id));
+#elif defined(PLATFORM_HIP_DEVICE)
+  hipDeviceProp_t deviceProp;
+  FI_GPU_CALL(hipGetDeviceProperties(&deviceProp, dev_id));
+  max_smem_per_sm = deviceProp.sharedMemPerMultiprocessor;
+#endif
+
+  return max_smem_per_sm;
+}

--- a/libflashinfer/include/gpu_iface/gpu_runtime_compat.hpp
+++ b/libflashinfer/include/gpu_iface/gpu_runtime_compat.hpp
@@ -50,7 +50,7 @@
 #define gpuMemcpy cudaMemcpy
 #define gpuMalloc cudaMalloc
 #define gpuMemset cudaMemset
-#define gpFree cudaFree
+#define gpuFree cudaFree
 #define gpuMemCpyAsync cudaMemcpyAsync
 #define gpuMemcpyHostToDevice cudaMemcpyHostToDevice
 #define gpuMemcpyDeviceToHost cudaMemcpyDeviceToHost

--- a/libflashinfer/include/gpu_iface/macros.hpp
+++ b/libflashinfer/include/gpu_iface/macros.hpp
@@ -15,6 +15,11 @@
 #ifndef __forceinline__
 #define __forceinline__ inline
 #endif
+
+#ifndef __grid_constant__
+#define __grid_constant__
+#endif
+
 #elif defined(__CUDACC__) || defined(__CUDA_ARCH__)
 #define PLATFORM_CUDA_DEVICE
 #endif

--- a/libflashinfer/include/gpu_iface/memory_ops.hpp
+++ b/libflashinfer/include/gpu_iface/memory_ops.hpp
@@ -28,16 +28,16 @@ enum class PrefetchMode {
 // Include platform-specific implementations
 #if defined(PLATFORM_CUDA_DEVICE)
 #include "backend/cuda/memory_ops.cuh"
-namespace detail = flashinfer::gpu_iface::memory::detail::cuda;
+namespace mem_detail = flashinfer::gpu_iface::memory::detail::cuda;
 #elif defined(PLATFORM_HIP_DEVICE)
 #include "backend/hip/memory_ops_hip.h"
-namespace detail = flashinfer::gpu_iface::memory::detail::hip;
+namespace mem_detail = flashinfer::gpu_iface::memory::detail::hip;
 #endif
 
 /**
  * @brief Commits pending asynchronous memory operations to a group
  */
-__device__ __forceinline__ void commit_group() { detail::commit_group(); }
+__device__ __forceinline__ void commit_group() { mem_detail::commit_group(); }
 
 /**
  * @brief Waits until N most recent groups of async operations are complete
@@ -46,7 +46,7 @@ __device__ __forceinline__ void commit_group() { detail::commit_group(); }
  */
 template <size_t N>
 __device__ __forceinline__ void wait_group() {
-  detail::wait_group<N>();
+  mem_detail::wait_group<N>();
 }
 
 /**
@@ -59,13 +59,13 @@ __device__ __forceinline__ void wait_group() {
  */
 template <PrefetchMode PrefetchOpt, typename T>
 __device__ __forceinline__ void load_128b(T* smem_ptr, const T* gmem_ptr) {
-  detail::load_128b<PrefetchOpt>(smem_ptr, gmem_ptr);
+  mem_detail::load_128b<PrefetchOpt>(smem_ptr, gmem_ptr);
 }
 
 template <PrefetchMode PrefetchOpt, typename T>
 __device__ __forceinline__ void load_64b(T* smem_ptr, const T* gmem_ptr) {
 #if defined(PLATFORM_HIP_DEVICE)
-  detail::load_64b<PrefetchOpt>(smem_ptr, gmem_ptr);
+  mem_detail::load_64b<PrefetchOpt>(smem_ptr, gmem_ptr);
 #else
 #error "load_64b not implemented for this platform"
 #endif
@@ -83,13 +83,13 @@ __device__ __forceinline__ void load_64b(T* smem_ptr, const T* gmem_ptr) {
  */
 template <PrefetchMode PrefetchOpt, SharedMemFillMode FillOpt, typename T>
 __device__ __forceinline__ void pred_load_128b(T* smem_ptr, const T* gmem_ptr, bool predicate) {
-  detail::pred_load_128b<PrefetchOpt, FillOpt>(smem_ptr, gmem_ptr, predicate);
+  mem_detail::pred_load_128b<PrefetchOpt, FillOpt>(smem_ptr, gmem_ptr, predicate);
 }
 
 template <PrefetchMode PrefetchOpt, SharedMemFillMode FillOpt, typename T>
 __device__ __forceinline__ void pred_load_64b(T* smem_ptr, const T* gmem_ptr, bool predicate) {
 #if defined(PLATFORM_HIP_DEVICE)
-  detail::pred_load_64b<PrefetchOpt, FillOpt>(smem_ptr, gmem_ptr, predicate);
+  mem_detail::pred_load_64b<PrefetchOpt, FillOpt>(smem_ptr, gmem_ptr, predicate);
 #else
 #error "pred_load_64b not implemented for this platform"
 #endif
@@ -106,7 +106,7 @@ __device__ __forceinline__ void pred_load_64b(T* smem_ptr, const T* gmem_ptr, bo
  */
 template <size_t NumBits, PrefetchMode PrefetchOpt, typename T>
 __device__ __forceinline__ void load(T* smem_ptr, const T* gmem_ptr) {
-  detail::load<NumBits, PrefetchOpt>(smem_ptr, gmem_ptr);
+  mem_detail::load<NumBits, PrefetchOpt>(smem_ptr, gmem_ptr);
 }
 
 /**
@@ -122,7 +122,7 @@ __device__ __forceinline__ void load(T* smem_ptr, const T* gmem_ptr) {
  */
 template <size_t NumBits, PrefetchMode PrefetchOpt, SharedMemFillMode FillOpt, typename T>
 __device__ __forceinline__ void pred_load(T* smem_ptr, const T* gmem_ptr, bool predicate) {
-  detail::pred_load<NumBits, PrefetchOpt, FillOpt>(smem_ptr, gmem_ptr, predicate);
+  mem_detail::pred_load<NumBits, PrefetchOpt, FillOpt>(smem_ptr, gmem_ptr, predicate);
 }
 
 }  // namespace memory


### PR DESCRIPTION
Migrate more changes from `feature/hipified_prefill_v3` into `amd_integration`.

a) Updated `gpu_runtime_compat.hpp` with more CUDA/HIP runtime API wrappers.
b) Define the `__grid_constant__` macro for CUDA compatibility.
c) Namespace fix for memory_ops.hpp