### PR TITLE
Improvements to the S-matrix (s_frag) materialization to LDS for debugging

### DIFF
--- a/libflashinfer/include/gpu_iface/backend/hip/mma_debug_utils_hip.h
+++ b/libflashinfer/include/gpu_iface/backend/hip/mma_debug_utils_hip.h
@@ -7,6 +7,11 @@
 #include "gpu_iface/backend/hip/mma_hip.h"
 #include "gpu_iface/gpu_runtime_compat.hpp"
 
+namespace {
+constexpr uint32_t MMA_COLS = 16;
+constexpr uint32_t MMA_ROWS_PER_THREAD = 4;
+}  // namespace
+
 namespace flashinfer::gpu_iface::debug_utils::hip {
 
 enum class MatrixLayout { A, B };
@@ -37,8 +42,8 @@ template <typename T>
 __device__ void load_amatrix_layout(T* lds_array, uint32_t* R, uint32_t dimX) {
   static_assert(std::is_same_v<T, __half>, "Only supported for __half types");
   const int lane_id = threadIdx.x % 64;
-  const int row = lane_id % 16;
-  const int col_start = (lane_id / 16) * 4;
+  const int row = lane_id % MMA_COLS;
+  const int col_start = (lane_id / MMA_COLS) * MMA_ROWS_PER_THREAD;
 
   auto offset = lds_array + row * dimX + col_start;
   mma_impl::hip::load_fragment(R, offset);
@@ -56,7 +61,9 @@ template <typename T>
 __device__ void load_bmatrix_layout(T* arr, uint32_t* R, uint32_t dimY) {
   static_assert(std::is_same_v<T, __half>, "Only supported for __half types");
   const int lane_id = threadIdx.x % 64;
-  int b_idx = ((lane_id % 4) + 4 * (lane_id / 16)) * dimY + ((lane_id % 16) / 4) * 4;
+  int b_idx =
+      ((lane_id % MMA_ROWS_PER_THREAD) + MMA_ROWS_PER_THREAD * (lane_id / MMA_COLS)) * dimY +
+      ((lane_id % MMA_COLS) / MMA_ROWS_PER_THREAD) * MMA_ROWS_PER_THREAD;
   mma_impl::hip::load_quad_transposed_fragment<__half>(R, &arr[b_idx]);
 }
 
@@ -71,16 +78,35 @@ __device__ void print_register(uint32_t* R) {
          __half2float(values[2]), __half2float(values[3]));
 }
 
+/// @brief Prints the full s_frag array from a single thread's registers.
+template <typename T, uint32_t NUM_MMA_Q, uint32_t NUM_MMA_KV, uint32_t ELEMS_PER_FRAGMENT>
+__device__ void print_s_frag_register(const T (*s_frag)[NUM_MMA_KV][ELEMS_PER_FRAGMENT],
+                                      const dim3 tid = threadIdx) {
+  if (tid.x == 0 && tid.y == 0 && tid.z == 0) {
+    printf("Thread (0,0,0) s_frag registers:\n");
+    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+      for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
+        const T* values = s_frag[mma_q][mma_kv];
+        printf("  frag[%u][%u]: [%8.3f, %8.3f, %8.3f, %8.3f]\n", mma_q, mma_kv, float(values[0]),
+               float(values[1]), float(values[2]), float(values[3]));
+      }
+    }
+    printf("\n");
+  }
+  __syncthreads();
+}
+
 /// @brief Prints a 2D LDS array to the console from a single thread.
 /// @tparam T The data type of the LDS array, must be `__half`.
 /// @param lds_array Pointer to the shared memory array.
 /// @param dimY The height of the 2D array.
 /// @param dimX The width of the 2D array.
 template <typename T>
-__device__ void print_lds_array(T* lds_array, uint32_t dimY, uint32_t dimX) {
+__device__ void print_lds_array(T* lds_array, uint32_t dimY, uint32_t dimX,
+                                const char* title = "LDS Array") {
   static_assert(std::is_same_v<T, __half>, "Only supported for __half types");
   if (threadIdx.x == 0) {
-    printf("LDS Array (%dx%d):\n", dimX, dimY);
+    printf("%s (%dx%d):\n", title, dimX, dimY);
     for (int y = 0; y < dimY; ++y) {
       for (int x = 0; x < dimX; ++x) {
         printf("%5.1f ", __half2float(lds_array[y * dimX + x]));
@@ -92,51 +118,107 @@ __device__ void print_lds_array(T* lds_array, uint32_t dimY, uint32_t dimX) {
   __syncthreads();
 }
 
-/// @brief Writes the 4 `half` values from each thread's registers back to LDS.
-/// @details This function is the inverse of the `load_*_layout` functions. It materializes
-///          the in-register matrix layout into shared memory.
-///
-///          A-Layout Pattern:
-///          Each thread `T_(16*c + r)` writes its 4 values to `LDS[r, 4*c : 4*c+3]`.
-///          This reconstructs the standard row-major matrix.
-///
-///          B-Layout Pattern:
-///          Each thread `T_(16*br + 4*bc + ti)` (where br=block_row, bc=block_col,
-///          ti=thread_in_block) writes its 4 values to `LDS[4*br + ti, 4*bc : 4*bc+3]`. This
-///          creates a block-transposed matrix in shared memory.
-/// @tparam T The data type of the LDS array, must be `__half`.
-/// @param R Pointer to the thread's registers (uint32_t[2]).
-/// @param lds_array Pointer to the shared memory array.
-/// @param dimY The height of the LDS array.
-/// @param dimX The width of the LDS array.
-/// @param layout The target memory layout (A or B) to use for writing.
-template <typename T>
-__device__ void write_matrix_frag_to_lds(const uint32_t* R, T* lds_array, uint32_t dimY,
-                                         uint32_t dimX, MatrixLayout layout) {
-  static_assert(std::is_same_v<T, __half>, "Only supported for __half types");
-
-  const int lane_id = threadIdx.x % 64;
-  const T* values = reinterpret_cast<const T*>(R);
-  int row, col_start;
-
-  if (layout == MatrixLayout::A) {
-    // A-matrix layout: each thread owns a 1x4 strip of a row
-    row = lane_id % 16;
-    col_start = (lane_id / 16) * 4;
-  } else {  // MatrixLayout::B
-    // B-matrix layout: each thread owns a 1x4 strip of a column block
-    const uint32_t block_row = (lane_id % 16) / 4;
-    const uint32_t block_col = (lane_id / 16);
-    const uint32_t thread_in_block = lane_id % 4;
-    row = block_col * 4 + thread_in_block;
-    col_start = block_row * 4;
+/// @brief Prints a 2D LDS array of floats to the console from a single thread.
+__device__ void print_lds_array(float* lds_array, uint32_t dimY, uint32_t dimX,
+                                const char* title = "LDS Array (float)") {
+  if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
+    printf("%s (%dx%d):\n", title, dimX, dimY);
+    for (int y = 0; y < dimY; ++y) {
+      for (int x = 0; x < dimX; ++x) {
+        printf("%8.3f ", lds_array[y * dimX + x]);
+      }
+      printf("\n");
+    }
+    printf("\n");
   }
+  __syncthreads();
+}
 
-  half* offset = lds_array + row * dimX + col_start;
-  offset[0] = values[0];
-  offset[1] = values[1];
-  offset[2] = values[2];
-  offset[3] = values[3];
+/// @brief Materializes a 2D array of accumulator fragments from each thread's registers into a
+///        2D shared memory array.
+/// @details This function is the inverse of the hardware's distribution of accumulator results.
+///          It reconstructs a logical tile of the S = Q * K^T matrix in shared memory,
+///          accounting for the partitioning of work across multiple warps.
+/// @tparam T The data type of the fragments and LDS array (e.g., float or half).
+/// @tparam NUM_MMA_Q The number of fragments along the Q dimension (rows) per thread.
+/// @tparam NUM_MMA_KV The number of fragments along the KV dimension (columns) per thread.
+/// @tparam ELEMS_PER_FRAGMENT The number of elements per fragment (typically 4 for float/half).
+/// @param s_frag The 3D fragment array from the thread's registers.
+/// @param lds_scratchpad Pointer to the shared memory array.
+/// @param lds_stride The width/stride of the lds_scratchpad (e.g., CTA_TILE_KV).
+/// @param tid The thread's index within the block (threadIdx).
+template <typename T, uint32_t NUM_MMA_Q, uint32_t NUM_MMA_KV, uint32_t ELEMS_PER_FRAGMENT = 4>
+__device__ void write_s_frag_to_lds(const T (*s_frag)[NUM_MMA_KV][ELEMS_PER_FRAGMENT],
+                                    T* lds_scratchpad, const uint32_t lds_stride,
+                                    const dim3 tid = threadIdx) {
+  const int lane_id = tid.x % 64;
+  const int warp_idx_q = tid.y;
+
+  // Calculate the starting row in the LDS tile for this entire warp.
+  const uint32_t warp_base_row = warp_idx_q * NUM_MMA_Q * MMA_COLS;
+
+#pragma unroll
+  for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+#pragma unroll
+    for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
+      // -- Calculate the top-left corner of the 16x16 fragment this thread contributes to --
+      const uint32_t frag_row_offset = mma_q * MMA_COLS;
+      const uint32_t frag_col_offset = mma_kv * MMA_COLS;
+
+      // -- Calculate the specific 4x1 element strip this thread writes within that fragment --
+      // This logic correctly materializes a B-layout fragment (column strip).
+      // Each thread T_c handles column 'c' of the fragment.
+      // The 4 threads in a "column" of the warp (e.g., lanes 0, 16, 32, 48)
+      // handle the 4 rows of that column strip.
+      const uint32_t thread_start_row_in_frag = (lane_id / MMA_COLS) * MMA_ROWS_PER_THREAD;
+      const uint32_t thread_col_in_frag = (lane_id % MMA_COLS);
+
+      // -- Combine all offsets and write the 4x1 column strip to LDS --
+      const T* values = s_frag[mma_q][mma_kv];
+      for (int i = 0; i < MMA_ROWS_PER_THREAD; ++i) {
+        // The row for this element is the thread's starting row + the element's index in the strip.
+        const uint32_t final_row = warp_base_row + frag_row_offset + thread_start_row_in_frag + i;
+        // The column is fixed for all 4 elements in the strip.
+        const uint32_t final_col = frag_col_offset + thread_col_in_frag;
+
+        // Calculate destination and write the value.
+        T* dest = lds_scratchpad + final_row * lds_stride + final_col;
+        *dest = values[i];
+      }
+    }
+  }
+}
+
+template <typename T, uint32_t NUM_MMA_Q, uint32_t NUM_ACCUM_ROWS_PER_THREAD>
+__device__ void write_m_new_to_lds(const T (*m)[NUM_ACCUM_ROWS_PER_THREAD], T* lds_scratchpad,
+                                   const dim3 tid = threadIdx) {
+  const int lane_idx = tid.x;
+  const int warp_idx_q = tid.y;
+
+  // Each group of 16 threads (a "row group") computes the max for 4 rows.
+  // We only need one thread from each group to write the results.
+  if (lane_idx % MMA_COLS == 0) {
+    // Base row index for this warp's Q tile
+    const uint32_t warp_base_row = warp_idx_q * NUM_MMA_Q * MMA_COLS;
+
+#pragma unroll
+    for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
+      // Base row for this specific MMA instruction within the warp's tile
+      const uint32_t mma_base_row = mma_q * MMA_COLS;
+
+#pragma unroll
+      for (uint32_t j = 0; j < NUM_ACCUM_ROWS_PER_THREAD; ++j) {
+        // The thread's lane_idx determines which group of 4 rows it is in.
+        // e.g., lane 0 is in group 0, lane 16 is in group 1, etc.
+        const uint32_t row_group_offset = (lane_idx / MMA_COLS) * NUM_ACCUM_ROWS_PER_THREAD;
+
+        // The final row index in the logical S matrix
+        const uint32_t final_row_idx = warp_base_row + mma_base_row + row_group_offset + j;
+
+        lds_scratchpad[final_row_idx] = m[mma_q][j];
+      }
+    }
+  }
 }
 
 }  // namespace flashinfer::gpu_iface::debug_utils::hip


### PR DESCRIPTION
## Motivation

The PR adds a new `write_s_frag_to_lds` function to `mma_debug_utils_hip.h`. The function "materializes" the attention score matrix (`S`) to LDS from an array of registers per thread in a way that aligns with how `S` fragments are generated by each thread in a warp in the `SinglePrefillWithKVCacheDevice` kernel.

The function was needed to avoid calling the existing debug function `write_matrix_frag_to_lds` with lot of extra boilerplate code.
