### PR TITLE
Update/devcontainer dockerfile

### DIFF
--- a/.devcontainer/rocm/Dockerfile
+++ b/.devcontainer/rocm/Dockerfile
@@ -32,8 +32,7 @@ ENV MAMBA_ROOT_PREFIX="/opt/conda"
 ENV MAMBA_EXE="/bin/micromamba"
 
 # Silence warning where the UID and GID are out of the usual range,
-# create a non-root user, and configure SSH server to allow SSH connections into
-# a detached container instance.
+# create a non-root user.
 RUN sed -i 's/^\(UID_MAX\s*\).*$/\11000000000/' /etc/login.defs && \
     sed -i 's/^\(GID_MAX\s*\).*$/\11000000000/' /etc/login.defs && \
     groupadd --gid $USER_GID $USERNAME && \


### PR DESCRIPTION
## Motivation

This PR enhances the `.devcontainer/rocm/Dockerfile` to provide a smoother development experience, particularly for HPC cluster environments with shared filesystems.

### Key Improvements

1. **Fixed environment activation**: The conda environment now properly activates when attaching to the container
2. **Proper git configuration**: Fixed git alias setup to work correctly

### Use Case

This Dockerfile is designed for ROCm-based FlashInfer development on shared HPC clusters where:
- Users have a shared `HOME` directory accessible across multiple nodes
- Development needs to happen in isolated environments with specific ROCm/PyTorch versions
- Code changes should be seamlessly synchronized between the container and host filesystem

## Technical Details
Possible way to build the image:

```bash
docker build \
  --build-arg USER_UID=$(id -u) \
  --build-arg USER_GID=$(id -g) \
  --build-arg USERNAME=$USER \
  -t flashinfer-rocm-devel \
  -f .devcontainer/rocm/Dockerfile .
```
The create a detached container:

```bash
docker run -d --name=flashinfer_rocm6.4.1_devel \
  --privileged \
  --device=/dev/kfd \
  --device=/dev/dri \
  --group-add video \
  --cap-add=SYS_PTRACE \
  --security-opt seccomp=unconfined \
  --ipc=host \
  --shm-size 128G \
  -v <PATH-TO_LOCAL_DEVELOPMENT_DIR>:/devel \
  -v $HOME/.gitconfig:/home/$USER/.gitconfig:ro \
 -v $HOME/.ssh:/home/$USER/.ssh:ro \
  flashinfer-rocm6.4.1-dev \
  sleep infinity
```
Then use docker exec to attach to the container:

```bash
docker exec -it -w /devel flashinfer_rocm6.4.1_devel /bin/bash
```