### PR TITLE
Update devcontainer dockerfile to rocm7.0.2

### DIFF
--- a/.devcontainer/rocm/Dockerfile
+++ b/.devcontainer/rocm/Dockerfile
@@ -1,4 +1,4 @@
-ARG ROCM_VERSION=6.4.1
+ARG ROCM_VERSION=7.0.2
 
 FROM mambaorg/micromamba:2.1.1 as micromamba
 
@@ -9,7 +9,7 @@ ARG PY_VERSION=3.12
 ARG TORCH_VERSION=2.7.1
 
 # Update package lists and install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     clang-format \
     clangd-19 \
     curl \


### PR DESCRIPTION
Update the dockerfile inside devcontainer (`.devcontainer/rocm/DockerFile` ) to rocm7 and torch2.8. 

It's a follow up of the PR: https://github.com/ROCm/flashinfer/pull/23. Here, we are using `zsh`, but you can use `bash` similarly.

> [!NOTE]
>  An important change is in the base rocm docker image. We moved from barebone `rocm/dev-ubuntu-24.04:${ROCM_VERSION}-complete` to official rocm+torch docker image: `rocm/pytorch:rocm${ROCM_VERSION}_ubuntu24.04_py${PY_VERSION}_pytorch_release_${TORCH_VERSION}` that helps to avoid a separate installation of `torch` in the docker and any potential issues.

1. As mentioned there, build the image in the following way to maintain your host `userid` inside the container and have no access conflicts with non-root user inside the container about ssh, git, etc.
```
docker build \
  --build-arg USER_UID=$(id -u) \
  --build-arg USER_GID=$(id -g) \
  --build-arg USERNAME=$USER \
  -t flashinfer-rocm-devel \
  -f .devcontainer/rocm/Dockerfile .
```
2. While creating the detached container as follows, feel free to mount any development environment you have locally about tmux, zsh, vim, etc
```
docker run -d \
    --privileged \
    --device=/dev/kfd \
    --device=/dev/dri \
    --group-add video \
    --cap-add=SYS_PTRACE \
    --security-opt seccomp=unconfined \
    --ipc=host \
    --shm-size 128G \
    -v $HOME/dockerx:/home/$USER/dockerx \
    -v $HOME/devel/flashinfer:/home/$USER/devel/flashinfer \
    -v $HOME/.ssh:/home/$USER/.ssh:ro \
    -v $HOME/.oh-my-zsh:/home/$USER/.oh-my-zsh:ro \
    -v $HOME/.gitconfig:/home/$USER/.gitconfig \
    -v $HOME/.tmux.conf:/home/$USER/.tmux.conf \
    -v $HOME/.vimrc:/home/$USER/.vimrc \
    -v $HOME/.zshrc.docker:/home/$USER/.zshrc \
    --name=flashinfer_rocm7_dev \
    flashinfer-rocm7:latest \
    sleep infinity
```
3. Finally, attach to the container (notice that I am using `zsh` instead of the default `bash` from the docker image.
```
docker exec -it -w /home/$USER/devel/flashinfer flashinfer_rocm7_dev /bin/zsh
```