### PR TITLE
Update build instructions for C++ tests in README.md

### DIFF
--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -80,7 +80,7 @@ from .core import logger
 
 # Try and Except to break circular dependencies
 try:
-    from ..__aot_prebuilt_uris__ import prebuilt_ops_uri  # type: ignore
+    from ..__aot_prebuilt_uris__ import prebuilt_ops_uri
 except ImportError:
     prebuilt_ops_uri = None
 
@@ -89,8 +89,7 @@ try:
 
     if __config__.get_info("aot_torch_exts_cuda"):
         try:
-            # The import is intentionally unused - it's just loading the module to ensure the kernels are registered.
-            from .. import flashinfer_kernels  # noqa: F401
+            from .. import flashinfer_kernels
 
             has_prebuilt_ops = True
             kernels_path = _get_extension_path("flashinfer.flashinfer_kernels")


### PR DESCRIPTION
### Changes
- Corrected formatting in the README by adding a space in the "Step 3" header for consistency.
- Updated the build instructions for C++ tests.
- Fixed linter issues in `__init__.py`.

Note that the following tests are failing in the current trunk (`amd-integration`)
<img width="524" height="86" alt="image" src="https://github.com/user-attachments/assets/b2970f62-f7f8-4f67-b3f4-630e41ee4031" />
