### PR TITLE
Fix Log-sum-exp (LSE) write back for single prefill kernels for CDNA3

### DIFF
--- a/libflashinfer/include/flashinfer/attention/generic/prefill.cuh
+++ b/libflashinfer/include/flashinfer/attention/generic/prefill.cuh
@@ -1668,7 +1668,6 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
     [[maybe_unused]] constexpr uint32_t HALF_ELEMS_PER_THREAD = KTraits::HALF_ELEMS_PER_THREAD;
     [[maybe_unused]] constexpr uint32_t NUM_ACCUM_ROWS_PER_THREAD =
         KTraits::NUM_ACCUM_ROWS_PER_THREAD;
-    [[maybe_unused]] constexpr uint32_t LOGITS_INDEX_STRIDE = KTraits::LOGITS_INDEX_STRIDE;
     [[maybe_unused]] constexpr uint32_t THREADS_PER_BMATRIX_ROW_SET =
         KTraits::THREADS_PER_BMATRIX_ROW_SET;
     [[maybe_unused]] constexpr uint32_t VECTOR_BIT_WIDTH = KTraits::VECTOR_BIT_WIDTH;
@@ -1862,9 +1861,12 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
 #pragma unroll
             for (uint32_t j = 0; j < NUM_ACCUM_ROWS_PER_THREAD; ++j) {
               uint32_t q, r;
-              group_size.divmod(qo_packed_idx_base + lane_idx / THREADS_PER_BMATRIX_ROW_SET +
-                                    j * LOGITS_INDEX_STRIDE + mma_q * 16,
-                                q, r);
+
+              group_size.divmod(
+                  qo_packed_idx_base +
+                      (lane_idx / THREADS_PER_BMATRIX_ROW_SET) * NUM_ACCUM_ROWS_PER_THREAD + j +
+                      mma_q * 16,
+                  q, r);
               const uint32_t qo_head_idx = kv_head_idx * group_size + r;
               const uint32_t qo_idx = q;
               if (qo_idx < qo_len) {


### PR DESCRIPTION
Fixes the LSE write back for the single prefill kernel. The existing indexing miscalculated the query index whose LSE value a particular thread writes back to global memory. For CDNA3, the `m` (max) and `d` (denominator) terms of online softmax are distributed across a wavefront based on CDNA3 B/C/D matrix layout. That is, each thread stores the values for 4 rows of the attention matrix across `NUM_MMA_Q` MMA tiles.

The existing index was:

`qo_packed_idx_base + lane_idx / 16+  j * 4 + mma_q * 16`, where `mma_q` iterates over MMA tile-rows and `j` iterates over the elements in the B-matrix fragment. The indexing leads to the following offsets:

```
T0-T15 : 0-3 (for j 0:3) <--- CORRECT
T16-T31 : (1,2,3,4) <--- WRONG!
T32-T47 : (2,3,4,5) <--- WRONG!
T48-T63 : (3,4,5,6) <--- WRONG!
```

Instead we need to do: `qo_packed_idx_base + (lane_idx / 16)*4 +  j + mma_q * 16`.




