### PR TITLE
Support only gfx942 arch for ROCm

### DIFF
--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -62,9 +62,6 @@ def check_cuda_arch():
 
 def check_rocm_arch():
     allowd_arch = [
-        "--offload-arch=gfx90a",
-        "--offload-arch=gfx940",
-        "--offload-arch=gfx941",
         "--offload-arch=gfx942",
     ]
     hip_arch_flags = torch_cpp_ext._get_rocm_arch_flags()


### PR DESCRIPTION
We remove other CDNA3 architectures in favor of supporting only `gfx942` now.

Other architecture supports may be planned in the future.