### PR TITLE
Skip failing C++ tests and fix mma_debug_utils

### DIFF
--- a/libflashinfer/include/gpu_iface/backend/hip/mma_debug_utils_hip.h
+++ b/libflashinfer/include/gpu_iface/backend/hip/mma_debug_utils_hip.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "gpu_iface/backend/hip/mma_hip.h"
+#include "gpu_iface/fastdiv.cuh"
 #include "gpu_iface/gpu_runtime_compat.hpp"
 
 namespace {

--- a/libflashinfer/tests/CMakeLists.txt
+++ b/libflashinfer/tests/CMakeLists.txt
@@ -28,13 +28,20 @@ endif(FLASHINFER_ENABLE_HIP)
 # === Test Discovery and Targets ===
 message(STATUS "All unit test targets: ${ALL_TEST_TARGETS}")
 
+# A list of tests to skip
+set(SKIPPED_TESTS test_batch_prefill_hip test_mfma_fp32_16x16x16fp16_hip)
+
 # Use GoogleTest's discover_tests to find all test cases
 foreach(test_target IN LISTS ALL_TEST_TARGETS)
-  if(TARGET ${test_target})
+  if(TARGET ${test_target} AND NOT ${test_target} IN_LIST SKIPPED_TESTS)
     gtest_discover_tests(${test_target})
   endif()
 endforeach()
 
 # Create target to build all tests
 add_custom_target(build_tests)
-add_dependencies(build_tests ${ALL_TEST_TARGETS})
+foreach(test_target IN LISTS ALL_TEST_TARGETS)
+  if(NOT ${test_target} IN_LIST SKIPPED_TESTS)
+    add_dependencies(build_tests ${test_target})
+  endif()
+endforeach()


### PR DESCRIPTION
The PR adds a list to tests to skip from the CMake `build_tests` target. The tests in the skip list can still be individually built.

E.g.
```bash
# The `test_batch_prefill.cpp` is currently broken and added to the skip list.
cmake -DFLASHINFER_ENABLE_HIP=ON -DFLASHINFER_UNITTESTS=ON  -GNinja ..
ninja build_tests # does not build the test_batch_prefill.cpp tests
# The test file can still be built individually using
ninja test_batch_prefill_hip
```
Also added the fix to `mma_debug_utils_hip.hpp` from #52

Supersedes #52, #57 