### PR TITLE
Fixes to the single prefill dispatch for HIP devices

### DIFF
--- a/libflashinfer/include/gpu_iface/gpu_runtime_compat.hpp
+++ b/libflashinfer/include/gpu_iface/gpu_runtime_compat.hpp
@@ -146,3 +146,20 @@ inline int getMaxSharedMemPerMultiprocessor(int dev_id) {
 
   return max_smem_per_sm;
 }
+
+/// Returns the maximum shared memory per thread block
+///
+/// @param dev_id Device ID
+/// @return Maximum shared memory per block in bytes
+inline int getMaxSharedMemPerBlock(int dev_id) {
+#if defined(PLATFORM_CUDA_DEVICE)
+  cudaDeviceProp deviceProp;
+  FI_GPU_CALL(cudaGetDeviceProperties(&deviceProp, dev_id));
+#elif defined(PLATFORM_HIP_DEVICE)
+  // CDNA3/MI300X: sharedMemPerBlock = 65,536 bytes (64 KB) - the actual per-block limit
+  //               sharedMemPerMultiprocessor = 19,922,944 bytes (~19 MB) - total LDS per CU
+  hipDeviceProp_t deviceProp;
+  FI_GPU_CALL(hipGetDeviceProperties(&deviceProp, dev_id));
+#endif
+  return deviceProp.sharedMemPerBlock;
+}


### PR DESCRIPTION
The PR makes a set of initial changes to the kernel dispatch logic for the `SinglePrefillWithKVCacheDispatched` launcher.

1. The existing code had a bug in the max shared memory per block calculation. The ported over code from CUDA was using the 
`getMaxSharedMemPerBlock` and then diving by a heuristically derived number of CTA per SM to compute the maximum allowable shared memory per thread block. The `getMaxSharedMemPerBlock` on HIP was pointing to `sharedMemPerMultiprocessor` and was returning 19MB and setting the number of CTAs to 2 was leading to a per thread block maximum shared limit to be much higher than the 64KB actual hardware limit.

Instead, we now directly use the `sharedMemPerBlock` property to get the maximum allowed shared memory per block.

2. The heuristics to compute `max_num_mma_kv_reg` was also hard coding the register count to `8`. The value works for CUDA's 32 thread warp as each fragment stores eight elements. For CDNA3, the number is actually `4` since there are 64 threads per wavefront. The PR parameterized the value to be computed based on MMA tile size (16x16) / WARP_SIZE.