### PR TITLE
Change base image to rocm/dev-ubuntu

### DIFF
--- a/docker/Dockerfile.rocm_ci
+++ b/docker/Dockerfile.rocm_ci
@@ -25,11 +25,12 @@ WORKDIR /root/
 COPY . /root/flashinfer/
 
 RUN curl -L micro.mamba.pm/install.sh | bash && \
-~/.local/bin/micromamba create -n ${MAMBA_ENV_NAME} python=${PY_VERSION} cmake ninja pybind11 -c conda-forge --override-channels -y && \
-~/.local/bin/micromamba run -n ${MAMBA_ENV_NAME} pip install ninja scikit-build-core setuptools-scm numpy pytest && \
-~/.local/bin/micromamba run -n ${MAMBA_ENV_NAME} pip install torch==${TORCH_VERSION} -f https://repo.radeon.com/rocm/manylinux/rocm-rel-${ROCM_VERSION}/ && \
-/bin/bash -c "eval \"\$(~/.local/bin/micromamba shell hook --shell bash)\" && \
+    ~/.local/bin/micromamba create -n ${MAMBA_ENV_NAME} python=${PY_VERSION} cmake ninja pybind11 -c conda-forge --override-channels -y && \
+    ~/.local/bin/micromamba run -n ${MAMBA_ENV_NAME} pip install ninja scikit-build-core setuptools-scm numpy pytest && \
+    ~/.local/bin/micromamba run -n ${MAMBA_ENV_NAME} pip install torch==${TORCH_VERSION} -f https://repo.radeon.com/rocm/manylinux/rocm-rel-${ROCM_VERSION}/
+
+RUN /bin/bash -c "eval \"\$(/root/.local/bin/micromamba shell hook --shell bash)\" && \
     micromamba activate ${MAMBA_ENV_NAME} && \
     cd /root/flashinfer/ && \
-    FLASHINFER_HIP_ARCHITECTURES=${GFX_ARCH} python -m pip wheel . --wheel-dir=./dist/ --no-deps --no-build-isolation -v 2>&1 | tee build_log_aot_whl.log && \
+    FLASHINFER_HIP_ARCHITECTURES=${GFX_ARCH} python -m pip wheel . --wheel-dir=./dist/ --no-deps --no-build-isolation -v && \
     pip install dist/flashinfer-*.whl"


### PR DESCRIPTION
The Dockerfile.rocm_ci was using `rocm/pytorch:rocm${ROCM_VERSION}_ubuntu${UBUNTU_VERSION}_py${PY_VERSION}_pytorch_release_${TORCH_VERSION}` as the base version, but then creating a micromamba env and reinstall torch from ` https://repo.radeon.com/rocm/manylinux/rocm-rel-${ROCM_VERSION}`.

The PR changes the base image to `rocm/dev-ubuntu-${UBUNTU_VERSION}:${ROCM_VERSION}-complete`. Doing the change will make the build quicker as the new base image is smaller (30G vs 90G) and we can keep installing torch from  ` https://repo.radeon.com/rocm/manylinux/` as before.