### PR TITLE
Improvements to Python packaging infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 [project]
 name = "amd-flashinfer"
 dynamic = ["version"]
-description = "ROCm Fast Attention Algorithms for LLM Inference"
+description = "Fast Attention Algorithms for LLM Inference on ROCm"
 requires-python = ">=3.12"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,21 +1,44 @@
 # SPDX - FileCopyrightText : 2024 Flashinfer team.
 # SPDX - FileCopyrightText : 2025 Advanced Micro Devices, Inc.
-#
 # SPDX - License - Identifier : Apache 2.0
 
 [project]
-name = "flashinfer"
+name = "amd-flashinfer"
 dynamic = ["version"]
-description = "Fast Attention Algorithms for LLM Inference"
-requires-python = ">=3.9"
+description = "ROCm Fast Attention Algorithms for LLM Inference"
+requires-python = ">=3.12"
 readme = "README.md"
 license = "Apache-2.0"
 authors = [
-    {name = "FlashInfer Team"}
+    {name = "AMD, Inc."}
 ]
+
+# Runtime dependencies
+# NOTE: torch is intentionally NOT listed here because ROCm users must install
+# torch from AMD's ROCm repository, not from PyPI. For example,
+#   pip install torch==2.7.1 --index-url https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4/
+# See README.md for complete installation instructions.
 dependencies = [
-    "numpy",
+    "numpy>=1.20",
 ]
+
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: C++",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Operating System :: POSIX :: Linux",
+]
+
+[project.urls]
+Homepage = "https://github.com/rocm/flashinfer"
+Repository = "https://github.com/rocm/flashinfer"
+Documentation = "https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/3rd-party/flashinfer-install.html"
+"Bug Tracker" = "https://github.com/rocm/flashinfer/issues"
 
 [project.optional-dependencies]
 dev = [
@@ -26,7 +49,7 @@ dev = [
 requires = [
     "scikit-build-core>=0.4.3",
     "setuptools_scm>=8.0.0",
-    "torch >= 2.6",
+    "torch >= 2.7",
     "numpy",
     "setuptools-scm >=9.2"
 ]
@@ -40,7 +63,9 @@ logging.level = "INFO"
 build-dir = "_skbuild"
 experimental = true
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-wheel.py-api = "cp39"
+wheel.py-api = "cp312"
+wheel.license-files = ["LICENSE"]
+wheel.packages = ["flashinfer"]
 
 [tool.scikit-build.sdist]
 cmake = false


### PR DESCRIPTION
Package Configuration Changes:
- Update package name to 'amd-flashinfer' for AMD PyPI distribution
- Upgrade Python requirement from >=3.9 to >=3.12
- Update wheel.py-api from cp39 to cp312 to match Python version
- Add wheel.license-files and wheel.packages configuration
- Update torch build requirement from >=2.6 to >=2.7
- Add numpy version constraint (>=1.20)
- Add project metadata: URLs (homepage, repository, docs, bug tracker)
- Add PyPI classifiers for better package discovery

Dependency Management:
- Document that torch is intentionally excluded from runtime dependencies
- Users must install torch from AMD's ROCm repository, not PyPI
- Add explanatory comments in pyproject.toml about ROCm requirements

Runtime Validation:
- Add comprehensive torch compatibility check in __init__.py
- Verify torch installation with ROCm/HIP support (not CPU-only)
- Detect system ROCm version via multiple methods:
  - /opt/rocm/.info/version file
  - rocminfo command output
  - dpkg package information
- Warn users about ROCm version mismatch between system and PyTorch
- Provide detailed error messages with installation instructions
- Include both pip and uv installation examples in error messages

This ensures users get helpful guidance when torch is missing or incorrectly installed, improving the out-of-box experience for ROCm-based deployments.
