### PR TITLE
Fix partition-kv=True case and memory allocation issues in batch prefill

### DIFF
--- a/libflashinfer/include/flashinfer/attention/generic/cascade.cuh
+++ b/libflashinfer/include/flashinfer/attention/generic/cascade.cuh
@@ -128,6 +128,9 @@ __device__ __forceinline__ void threadblock_sync_state(state_t<vec_size>& st, DT
     v.cast_load(v_smem + iter * head_dim + tx * vec_size);
     st.merge(v, s, 1);
   }
+  // Ensure all threads finish reading shared memory before any thread
+  // proceeds to potentially reuse the shared memory in the next iteration.
+  __syncthreads();
 }
 
 template <uint32_t bdx, uint32_t bdy, uint32_t vec_size, typename DTypeIn>
@@ -147,6 +150,8 @@ __device__ __forceinline__ void threadblock_sum(vec_t<float, vec_size>& v, DType
       v[i] += v_iter[i];
     }
   }
+  // Ensure all threads finish reading shared memory before proceeding.
+  __syncthreads();
 }
 
 template <uint32_t vec_size, typename DTypeIn, typename DTypeO>

--- a/libflashinfer/include/flashinfer/attention/generic/prefill.cuh
+++ b/libflashinfer/include/flashinfer/attention/generic/prefill.cuh
@@ -551,6 +551,7 @@ __device__ __forceinline__ void page_produce_kv(
                                             thr_local_kv_offset, kv_len, tid);
 #endif
 }
+
 template <uint32_t HEAD_DIM>
 __device__ __forceinline__ uint32_t get_feature_index(uint32_t mma_d, uint32_t lane_idx,
                                                       uint32_t j) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,7 @@ testpaths = [
     "tests/test_page.py",
     "tests/test_rope.py",
     "tests/test_single_prefill_kernels_hip.py",
+    "tests/test_batch_prefill_paged_kernels_hip.py",
     "tests/test_sliding_window_hip.py",
 ]
 python_classes = ["Test*"]

--- a/tests/test_batch_prefill_ragged_kernels_hip.py
+++ b/tests/test_batch_prefill_ragged_kernels_hip.py
@@ -90,7 +90,7 @@ def test_batch_prefill_with_ragged_kv_cache(
         torch.arange(0, batch_size + 1, device="cuda:0", dtype=torch.int32) * kv_len
     )
 
-    workspace_buffer = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
+    workspace_buffer = torch.empty(512 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
     wrapper = flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper(
         workspace_buffer, kv_layout
     )
@@ -172,7 +172,7 @@ def test_batch_prefill_with_ragged_kv_cache_custom_mask(
         torch.arange(0, batch_size + 1, device="cuda:0", dtype=torch.int32) * kv_len
     )
 
-    workspace_buffer = torch.empty(256 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
+    workspace_buffer = torch.empty(512 * 1024 * 1024, dtype=torch.int8, device="cuda:0")
     wrapper = flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper(
         workspace_buffer, kv_layout
     )


### PR DESCRIPTION
This PR fixes the remaining pytests for the 
- batch prefill with paged kv cache and 
- batch prefill with tuple paged kv cache. 

So we add the script `test_batch_prefill_paged_kernels_hip.py` to our CI pipeline as well (through `pyproject.toml`).

I removed the pytests for the masked batch prefill from the pytest script as it is not ported yet!

With this change, 100% of the 2304 tests either pass or are skipped (since `qo_len > kv_len` and `causal=True` for those tests) and closes the gap from PR #63 .

<img width="455" height="30" alt="image" src="https://github.com/user-attachments/assets/a4d06162-6fce-489b-a0d6-a2cfdd6618ab" />


**How to test**:
- Run `python examples/batch_prefill_examples.py` and it should print `ALL SEQUENCES PASSED` for all tests.
- Run `python -m pytest tests/test_batch_prefill_paged_kernels_hip.py` and all tests should pass.
