### PR TITLE
Remove xfail markers about HIP support from pytests

### DIFF
--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -44,7 +44,6 @@ def warmup_jit():
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])
 @pytest.mark.parametrize("enable_pdl", [True, False])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_fused_silu_mul(dim, batch_size, seq_len, enable_pdl):
     x = torch.randn(batch_size, seq_len, 2 * dim).to(0).to(torch.float16)
     major, _ = get_compute_capability(x.device)
@@ -59,7 +58,6 @@ def test_fused_silu_mul(dim, batch_size, seq_len, enable_pdl):
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])
 @pytest.mark.parametrize("enable_pdl", [True, False])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_fused_gelu_tanh_mul(dim, batch_size, seq_len, enable_pdl):
     x = torch.randn(batch_size, seq_len, 2 * dim).to(0).to(torch.float16)
     major, _ = get_compute_capability(x.device)
@@ -74,7 +72,6 @@ def test_fused_gelu_tanh_mul(dim, batch_size, seq_len, enable_pdl):
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])
 @pytest.mark.parametrize("enable_pdl", [True, False])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_fused_gelu_mul(dim, batch_size, seq_len, enable_pdl):
     x = torch.randn(batch_size, seq_len, 2 * dim).to(0).to(torch.float16)
     major, _ = get_compute_capability(x.device)
@@ -85,4 +82,5 @@ def test_fused_gelu_mul(dim, batch_size, seq_len, enable_pdl):
     torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
 
 
-test_fused_silu_mul(128, 1, 1, True)
+if __name__ == "__main__":
+    test_fused_silu_mul(128, 1, 1, True)

--- a/tests/test_alibi.py
+++ b/tests/test_alibi.py
@@ -60,7 +60,6 @@ def warmup_jit():
 @pytest.mark.parametrize("seq_len", [1, 9, 81, 729])
 @pytest.mark.parametrize("num_heads", [4, 8, 32])
 @pytest.mark.parametrize("head_dim", [128, 256])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_single_decode_alibi(
     seq_len,
     num_heads,
@@ -81,7 +80,6 @@ def test_single_decode_alibi(
 @pytest.mark.parametrize("num_heads", [4, 8, 32])
 @pytest.mark.parametrize("head_dim", [128, 256])
 @pytest.mark.parametrize("causal", [False, True])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_single_prefill_alibi(
     q_len,
     kv_len,

--- a/tests/test_batch_decode_kernels.py
+++ b/tests/test_batch_decode_kernels.py
@@ -75,7 +75,6 @@ def warmup_jit():
 @pytest.mark.parametrize("q_dtype", [torch.float16])
 @pytest.mark.parametrize("kv_dtype", [torch.float16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("contiguous_kv", [True])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_decode_with_paged_kv_cache(
     batch_size,
     kv_len,
@@ -209,7 +208,6 @@ def test_batch_decode_with_paged_kv_cache(
 @pytest.mark.parametrize("q_dtype", [torch.float16])
 @pytest.mark.parametrize("kv_dtype", [torch.float16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("contiguous_kv", [True])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_decode_with_tuple_paged_kv_cache(
     batch_size,
     kv_len,
@@ -346,7 +344,6 @@ def test_batch_decode_with_tuple_paged_kv_cache(
 @pytest.mark.parametrize("q_dtype", [torch.float16])
 @pytest.mark.parametrize("kv_dtype", [torch.float16, torch.float8_e4m3fn])
 @pytest.mark.parametrize("contiguous_kv", [True])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_cuda_graph_batch_decode_with_paged_kv_cache(
     batch_size,
     kv_len,

--- a/tests/test_batch_decode_kernels_hip.py
+++ b/tests/test_batch_decode_kernels_hip.py
@@ -1,18 +1,6 @@
-"""
-Copyright (c) 2023 by FlashInfer team.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# SPDX-FileCopyrightText : 2023-2055 FlashInfer team.
+# SPDX-FileCopyrightText : 2025 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier : Apache-2.0
 
 import pytest
 import torch

--- a/tests/test_block_sparse.py
+++ b/tests/test_block_sparse.py
@@ -86,7 +86,6 @@ def bsr_attention_ref(
 @pytest.mark.parametrize("num_kv_heads", [1, 4, 16])
 @pytest.mark.parametrize("head_dim", [128, 256])
 @pytest.mark.parametrize("mask_inside_block", [True, False])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_block_sparse_attention(
     R, C, M, N, num_qo_heads, num_kv_heads, head_dim, mask_inside_block
 ):

--- a/tests/test_block_sparse_indices_to_vector_sparse_offsets.py
+++ b/tests/test_block_sparse_indices_to_vector_sparse_offsets.py
@@ -25,7 +25,6 @@ import flashinfer.page
 @pytest.mark.parametrize("block_size", [1, 3, 7, 16, 64, 79, 128])
 @pytest.mark.parametrize("stride_block", [128])
 @pytest.mark.parametrize("stride_n", [1])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_block_sparse_indices_to_vector_sparse_offsets(
     batch_size, kv_len, block_size, stride_block, stride_n
 ):

--- a/tests/test_bmm_fp8.py
+++ b/tests/test_bmm_fp8.py
@@ -17,7 +17,6 @@ def to_float8(x, dtype=torch.float8_e4m3fn):
 @pytest.mark.parametrize("input_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
 @pytest.mark.parametrize("mat2_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
 @pytest.mark.parametrize("res_dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_bmm_fp8(input_dtype, mat2_dtype, res_dtype):
     if input_dtype == torch.float8_e5m2 and mat2_dtype == torch.float8_e5m2:
         pytest.skip("Invalid combination: both input and mat2 are e5m2")

--- a/tests/test_custom_allreduce.py
+++ b/tests/test_custom_allreduce.py
@@ -200,7 +200,6 @@ class CudaRTLibrary:
         return devPtr
 
 
-@pytest.mark.xfail(reason="Some configurations are not supported yet")
 def _run_correctness_worker(
     world_size, rank, distributed_init_port, test_sizes, num_ctas_list
 ):

--- a/tests/test_decode_fp8_calibration_scale.py
+++ b/tests/test_decode_fp8_calibration_scale.py
@@ -27,7 +27,6 @@ import flashinfer
 @pytest.mark.parametrize("kv_layout", ["NHD"])  # ["HND", "NHD"])
 @pytest.mark.parametrize("pos_encoding_mode", ["NONE"])  # , "ROPE_LLAMA", "ALIBI"])
 @pytest.mark.parametrize("fp8_dtype", [torch.float8_e4m3fn])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_single_decode_fp8_calibration_scale(
     kv_len,
     num_kv_heads,
@@ -81,7 +80,6 @@ def test_single_decode_fp8_calibration_scale(
 @pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
 @pytest.mark.parametrize("pos_encoding_mode", ["NONE", "ROPE_LLAMA"])
 @pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_decode_with_paged_kv_cache_fp8_calibration_scale(
     batch_size,
     kv_len,

--- a/tests/test_deepseek_mla.py
+++ b/tests/test_deepseek_mla.py
@@ -157,7 +157,6 @@ def attention_ref(
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("backend", ["fa2", "fa3"])
 @pytest.mark.parametrize("dtype", [torch.half])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_single_prefill_with_kv_cache(
     kv_len,
     qo_len,
@@ -191,7 +190,6 @@ def test_single_prefill_with_kv_cache(
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("backend", ["fa2", "fa3"])
 @pytest.mark.parametrize("dtype", [torch.half])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_prefill_with_ragged_kv_cache(
     batch_size,
     kv_len,
@@ -282,7 +280,6 @@ def generate_kv_from_cache(ckv, kpe, kv_len, batch_size, num_heads):
 @pytest.mark.parametrize("page_size", [1])
 @pytest.mark.parametrize("backend", ["fa2", "fa3"])
 @pytest.mark.parametrize("dtype", [torch.half])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_mla_varlen_page_attention(
     batch_size,
     kv_len_0,
@@ -416,7 +413,6 @@ def test_batch_mla_varlen_page_attention(
 @pytest.mark.parametrize("page_size", [16, 32])
 @pytest.mark.parametrize("backend", ["fa2", "fa3"])
 @pytest.mark.parametrize("dtype", [torch.half])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_mla_oob_kv_nan(
     batch_size, kv_len, qo_len, num_heads, causal, page_size, backend, dtype
 ):
@@ -498,7 +494,6 @@ def test_batch_mla_oob_kv_nan(
 @pytest.mark.parametrize("backend", ["fa2", "fa3"])
 @pytest.mark.parametrize("use_cuda_graph", [False])
 @pytest.mark.parametrize("dtype", [torch.half])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_mla_page_attention(
     batch_size,
     kv_len,

--- a/tests/test_fp8_prefill.py
+++ b/tests/test_fp8_prefill.py
@@ -29,7 +29,6 @@ import flashinfer
 @pytest.mark.parametrize("head_dim", [128, 256])
 @pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
 @pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_prefill_with_paged_kv_cache_fp8_calibration_scale(
     batch_size,
     qo_len,
@@ -123,7 +122,6 @@ def test_batch_prefill_with_paged_kv_cache_fp8_calibration_scale(
 @pytest.mark.parametrize("head_dim", [128, 256])
 @pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
 @pytest.mark.parametrize("dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_decode_with_prefill_with_paged_kv_cache(
     batch_size,
     kv_len,

--- a/tests/test_group_gemm.py
+++ b/tests/test_group_gemm.py
@@ -52,7 +52,6 @@ def warmup_jit():
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("device", CUDA_DEVICES)
 @pytest.mark.parametrize("backend", ["sm90", "sm80"])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_segment_gemm(
     batch_size,
     num_rows_per_batch,

--- a/tests/test_hopper.py
+++ b/tests/test_hopper.py
@@ -27,7 +27,6 @@ from flashinfer.utils import is_sm90a_supported
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
 @pytest.mark.parametrize("logits_soft_cap", [0.0, 30.0])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_single_prefill(
     seq_len, num_qo_heads, num_kv_heads, causal, head_dim, logits_soft_cap
 ):
@@ -64,7 +63,6 @@ def test_single_prefill(
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("head_dim", [128])  # [64, 128, 256])
 @pytest.mark.parametrize("logits_soft_cap", [0.0, 30.0])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_ragged_prefill(
     batch_size, seq_len, num_qo_heads, num_kv_heads, causal, head_dim, logits_soft_cap
 ):
@@ -130,7 +128,6 @@ def test_batch_ragged_prefill(
 @pytest.mark.parametrize("num_heads", [4, 32, 128])
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_deepseek_prefill(
     batch_size,
     seq_len,
@@ -209,7 +206,6 @@ def test_deepseek_prefill(
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
 @pytest.mark.parametrize("logits_soft_cap", [0.0, 30.0])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_paged_prefill(
     batch_size,
     seq_len,

--- a/tests/test_logits_cap.py
+++ b/tests/test_logits_cap.py
@@ -71,7 +71,6 @@ def attention_logits_soft_cap_torch(q, k, v, soft_cap):
 @pytest.mark.parametrize("num_heads", [4, 8, 32])
 @pytest.mark.parametrize("head_dim", [128, 256])
 @pytest.mark.parametrize("soft_cap", [1.0, 30.0, 50.0])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_single_decode_logits_soft_cap(
     seq_len,
     num_heads,
@@ -92,7 +91,6 @@ def test_single_decode_logits_soft_cap(
 @pytest.mark.parametrize("num_heads", [4, 8, 32])
 @pytest.mark.parametrize("head_dim", [128, 256])
 @pytest.mark.parametrize("soft_cap", [1.0, 30.0, 50.0])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_single_prefill_logits_soft_cap(
     q_len,
     kv_len,

--- a/tests/test_mla_page.py
+++ b/tests/test_mla_page.py
@@ -26,7 +26,6 @@ kv_len_configs = [
 
 @pytest.mark.parametrize("kv_len", kv_len_configs)
 @pytest.mark.parametrize("page_size", [1, 16, 64])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_append_mla_paged_kv_cache(kv_len, page_size):
     nnz_kv = sum(kv_len)
     ckv_append = torch.randn(nnz_kv, CKV_DIM, dtype=torch.float16, device="cuda:0")

--- a/tests/test_non_contiguous_decode.py
+++ b/tests/test_non_contiguous_decode.py
@@ -46,7 +46,6 @@ def warmup_jit():
 @pytest.mark.parametrize("num_kv_heads", [1, 4, 8])
 @pytest.mark.parametrize("num_qo_heads", [4, 8])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_paged_decode_packed_input(
     batch_size,
     page_size,

--- a/tests/test_non_contiguous_prefill.py
+++ b/tests/test_non_contiguous_prefill.py
@@ -50,7 +50,6 @@ def warmup_jit():
 @pytest.mark.parametrize("num_qo_heads", [4, 8, 32])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
 @pytest.mark.parametrize("causal", [True, False])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_single_prefill_packed_input(
     seq_len, num_kv_heads, num_qo_heads, head_dim, causal
 ):
@@ -86,7 +85,6 @@ def test_single_prefill_packed_input(
 @pytest.mark.parametrize("num_qo_heads", [4, 8])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
 @pytest.mark.parametrize("causal", [True, False])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_ragged_prefill_packed_input(
     batch_size, seq_len, num_kv_heads, num_qo_heads, head_dim, causal
 ):
@@ -131,7 +129,6 @@ def test_batch_ragged_prefill_packed_input(
 @pytest.mark.parametrize("num_qo_heads", [4, 8])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
 @pytest.mark.parametrize("causal", [True, False])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_paged_prefill_packed_input(
     batch_size,
     page_size,

--- a/tests/test_norm.py
+++ b/tests/test_norm.py
@@ -71,7 +71,6 @@ def fused_add_rms_norm(x, residual, weight, eps):
 @pytest.mark.parametrize("specify_out", [True, False])
 @pytest.mark.parametrize("enable_pdl", [True, False])
 @pytest.mark.parametrize("contiguous", [True, False])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_norm(batch_size, hidden_size, dtype, specify_out, enable_pdl, contiguous):
     if contiguous:
         x = torch.randn(batch_size, hidden_size).to(0).to(dtype)
@@ -100,7 +99,6 @@ def test_norm(batch_size, hidden_size, dtype, specify_out, enable_pdl, contiguou
 @pytest.mark.parametrize("dtype", [torch.float16])
 @pytest.mark.parametrize("enable_pdl", [True, False])
 @pytest.mark.parametrize("contiguous", [True, False])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_fused_add_rmsnorm(batch_size, hidden_size, dtype, enable_pdl, contiguous):
     eps = 1e-6
 
@@ -137,7 +135,6 @@ def test_fused_add_rmsnorm(batch_size, hidden_size, dtype, enable_pdl, contiguou
 @pytest.mark.parametrize("specify_out", [True, False])
 @pytest.mark.parametrize("enable_pdl", [True, False])
 @pytest.mark.parametrize("contiguous", [True, False])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_gemma_norm(
     batch_size, hidden_size, dtype, specify_out, enable_pdl, contiguous
 ):
@@ -168,7 +165,6 @@ def test_gemma_norm(
 @pytest.mark.parametrize("dtype", [torch.float16])
 @pytest.mark.parametrize("enable_pdl", [True, False])
 @pytest.mark.parametrize("contiguous", [True, False])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_gemma_fused_add_rmsnorm(
     batch_size, hidden_size, dtype, enable_pdl, contiguous
 ):

--- a/tests/test_pod_kernels.py
+++ b/tests/test_pod_kernels.py
@@ -92,7 +92,6 @@ def warmup_jit():
 @pytest.mark.parametrize("q_dtype", [torch.float16])
 @pytest.mark.parametrize("kv_dtype", [torch.float16])
 @pytest.mark.parametrize("contiguous_kv", [True])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_pod_with_paged_kv_cache(
     # Prefill params
     kv_len_p,

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -29,7 +29,6 @@ def numpy_packbits_ref(x_cpu: torch.Tensor, bitorder: str):
 
 @pytest.mark.parametrize("num_elements", [1, 10, 99, 128, 999, 5000, 131072, 999999])
 @pytest.mark.parametrize("bitorder", ["big", "little"])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_packbits(num_elements, bitorder):
     torch.manual_seed(42)
     x_cpu = torch.rand(num_elements) < 0.5
@@ -42,7 +41,6 @@ def test_packbits(num_elements, bitorder):
 
 @pytest.mark.parametrize("batch_size", [1, 10, 99, 128, 777, 999])
 @pytest.mark.parametrize("bitorder", ["big", "little"])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_segment_packbits(batch_size, bitorder):
     torch.manual_seed(42)
     old_indptr = torch.cumsum(torch.arange(batch_size + 1), 0).to(0)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -48,7 +48,6 @@ def gumbel_distribution(beta):
     ],
 )
 @pytest.mark.parametrize("zero_ratio", [0.0, 0.5, 0.9])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_sampling_freq(vocab_size, distribution, zero_ratio):
     torch.manual_seed(42)
     num_trials = 5000000
@@ -79,7 +78,6 @@ def test_sampling_freq(vocab_size, distribution, zero_ratio):
     ],
 )
 @pytest.mark.parametrize("p", [0.1, 0.5, 0.9])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_top_p_sampling_freq(vocab_size, distribution, p):
     # use torch profiler to check the performance of the code
     torch.manual_seed(42)
@@ -115,7 +113,6 @@ def test_top_p_sampling_freq(vocab_size, distribution, p):
     ],
 )
 @pytest.mark.parametrize("k", [10, 100, 500])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_top_k_sampling_freq(vocab_size, distribution, k):
     if k > vocab_size:
         pytest.skip("k should be less than vocab_size")
@@ -157,7 +154,6 @@ def test_sampling(batch_size, vocab_size):
 @pytest.mark.parametrize("batch_size", [1, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("p", [0.1, 0.5, 0.9])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_top_p_sampling(batch_size, vocab_size, p):
     torch.manual_seed(42)
     eps = 1e-4
@@ -178,7 +174,6 @@ def test_top_p_sampling(batch_size, vocab_size, p):
 @pytest.mark.parametrize("batch_size", [1, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("k", [10, 100, 500])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_top_k_sampling(batch_size, vocab_size, k):
     if k > vocab_size:
         pytest.skip("k should be less than vocab_size")
@@ -201,7 +196,6 @@ def test_top_k_sampling(batch_size, vocab_size, k):
 @pytest.mark.parametrize("batch_size", [1, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("p", [0.05, 0.1, 0.2, 0.7, 1])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_min_p_sampling(batch_size, vocab_size, p):
     torch.manual_seed(42)
     pre_norm_prob = torch.rand(batch_size, vocab_size, device="cuda:0")
@@ -230,7 +224,6 @@ def test_min_p_sampling(batch_size, vocab_size, p):
 @pytest.mark.parametrize("batch_size", [1, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("p", [0.1, 0.5])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_top_k_top_p_joint_sampling_from_probs(batch_size, vocab_size, p):
     torch.manual_seed(42)
     if p == 0.1:
@@ -274,7 +267,6 @@ def test_top_k_top_p_joint_sampling_from_probs(batch_size, vocab_size, p):
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("k", [100])
 @pytest.mark.parametrize("p", [0.1, 0.5])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_top_k_top_p_sampling_from_probs_logits_alignment(batch_size, vocab_size, k, p):
     torch.manual_seed(42)
     logits = torch.randn(batch_size, vocab_size, device="cuda:0") * 5
@@ -296,7 +288,6 @@ def test_top_k_top_p_sampling_from_probs_logits_alignment(batch_size, vocab_size
 @pytest.mark.parametrize("batch_size", [1, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("p", [0.1, 0.5])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_top_k_top_p_joint_sampling_from_logits(batch_size, vocab_size, p):
     torch.manual_seed(42)
     logits = torch.rand(batch_size, vocab_size, device="cuda:0") * 5
@@ -326,7 +317,6 @@ def test_top_k_top_p_joint_sampling_from_logits(batch_size, vocab_size, p):
 @pytest.mark.parametrize("batch_size", [1, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("p", [0.1, 0.5, 0.9])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_top_p_renorm_probs(batch_size, vocab_size, p):
     torch.manual_seed(42)
     pre_norm_prob = torch.rand(batch_size, vocab_size, device="cuda:0")
@@ -353,7 +343,6 @@ def test_top_p_renorm_probs(batch_size, vocab_size, p):
 @pytest.mark.parametrize("batch_size", [1, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("k", [10, 100, 500])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_top_k_renorm_probs(batch_size, vocab_size, k):
     if k > vocab_size:
         pytest.skip("k should be less than vocab_size")
@@ -382,7 +371,6 @@ def test_top_k_renorm_probs(batch_size, vocab_size, k):
 @pytest.mark.parametrize("batch_size", [1, 99, 989])
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("k", [10, 100, 500])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_top_k_mask_logits(batch_size, vocab_size, k):
     if k > vocab_size:
         pytest.skip("k should be less than vocab_size")
@@ -405,7 +393,6 @@ def test_top_k_mask_logits(batch_size, vocab_size, k):
 @pytest.mark.parametrize("vocab_size", [111, 32000, 128256])
 @pytest.mark.parametrize("num_speculate_tokens", [1, 3, 5, 7])
 @pytest.mark.parametrize("onehot_target", [False, True])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_chain_speculative_sampling(
     batch_size,
     vocab_size,

--- a/tests/test_shared_prefix_kernels.py
+++ b/tests/test_shared_prefix_kernels.py
@@ -69,7 +69,6 @@ def ceil_div(a, b):
 @pytest.mark.parametrize("causal", [False])
 @pytest.mark.parametrize("head_dim", [128, 256])
 @pytest.mark.parametrize("page_size", [1, 16])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_attention_with_shared_prefix_paged_kv_cache(
     stage,
     batch_size,
@@ -237,7 +236,6 @@ def test_batch_attention_with_shared_prefix_paged_kv_cache(
 
 @pytest.mark.parametrize("seed", [0])
 @pytest.mark.parametrize("num_tries", [50])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_merge_state_in_place_with_mask(seed, num_tries):
     seq_len = 512
     num_heads = 32

--- a/tests/test_sliding_window.py
+++ b/tests/test_sliding_window.py
@@ -61,7 +61,6 @@ def warmup_jit():
 @pytest.mark.parametrize("num_kv_heads", [1, 4])
 @pytest.mark.parametrize("num_qo_heads", [4, 8])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_single_decode_sliding_window(
     seq_len, window_left, num_kv_heads, num_qo_heads, head_dim
 ):
@@ -89,7 +88,6 @@ def test_single_decode_sliding_window(
 @pytest.mark.parametrize("num_qo_heads", [4, 8])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
 @pytest.mark.parametrize("page_size", [1, 16])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_decode_sliding_window(
     batch_size, kv_len, window_left, num_kv_heads, num_qo_heads, head_dim, page_size
 ):
@@ -171,7 +169,6 @@ def test_batch_decode_sliding_window(
 @pytest.mark.parametrize("num_kv_heads", [1, 4])
 @pytest.mark.parametrize("num_qo_heads", [4, 8])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_single_decode_prefill_sliding_window_match(
     seq_len, window_left, num_kv_heads, num_qo_heads, head_dim
 ):
@@ -196,7 +193,6 @@ def test_single_decode_prefill_sliding_window_match(
 @pytest.mark.parametrize("num_kv_heads", [1, 4])
 @pytest.mark.parametrize("num_qo_heads", [4, 8])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_single_prefill_sliding_window(
     seq_len, window_left, num_kv_heads, num_qo_heads, head_dim
 ):
@@ -229,7 +225,6 @@ def test_single_prefill_sliding_window(
 @pytest.mark.parametrize("num_qo_heads", [4, 8])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
 @pytest.mark.parametrize("page_size", [1, 16])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_paged_prefill_sliding_window(
     batch_size,
     kv_len,
@@ -330,7 +325,6 @@ def test_batch_paged_prefill_sliding_window(
 @pytest.mark.parametrize("num_kv_heads", [1, 4])
 @pytest.mark.parametrize("num_qo_heads", [4, 8])
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_ragged_prefill_sliding_window(
     batch_size, kv_len, qo_len, window_left, num_kv_heads, num_qo_heads, head_dim
 ):

--- a/tests/test_sm_constraint_gemm.py
+++ b/tests/test_sm_constraint_gemm.py
@@ -29,7 +29,6 @@ def torch_addmm(a, b, c, alpha=1.0, beta=0.0):
 @pytest.mark.parametrize(
     "EPILOGUE_SUBTILE", [True, False]
 )  # only for descriptor persistent
-@pytest.mark.xfail(reason="Some configurations are not supported yet")
 def test_sm_constraint_gemm(M, N, K, alpha, beta, num_sms, dtype, EPILOGUE_SUBTILE):
     out_dtype = dtype if dtype != torch.float8_e4m3fn else torch.bfloat16
     a = torch.randn((M, K), device="cuda", dtype=torch.float16).to(dtype)

--- a/tests/test_tensor_cores_decode.py
+++ b/tests/test_tensor_cores_decode.py
@@ -62,7 +62,6 @@ def warmup_jit():
 @pytest.mark.parametrize("head_dim", [64, 128, 256])
 @pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
 @pytest.mark.parametrize("pos_encoding_mode", ["NONE", "ROPE_LLAMA"])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_single_decode_tensor_cores(
     kv_len: int,
     num_kv_heads: int,
@@ -110,7 +109,6 @@ def test_single_decode_tensor_cores(
 @pytest.mark.parametrize("head_dim", [128, 256])
 @pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
 @pytest.mark.parametrize("pos_encoding_mode", ["NONE", "ROPE_LLAMA"])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_decode_tensor_cores(
     batch_size: int,
     kv_len: int,
@@ -206,7 +204,6 @@ def test_batch_decode_tensor_cores(
 @pytest.mark.parametrize("head_dim", [128, 256])
 @pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
 @pytest.mark.parametrize("pos_encoding_mode", ["NONE", "ROPE_LLAMA"])
-@pytest.mark.xfail(reason="Not supported for the HIP backend for CDNA3")
 def test_batch_decode_tensor_cores_cuda_graph(
     batch_size: int,
     kv_len: int,

--- a/tests/test_triton_cascade.py
+++ b/tests/test_triton_cascade.py
@@ -8,7 +8,6 @@ import flashinfer.triton
 @pytest.mark.parametrize("seq_len", [2048])
 @pytest.mark.parametrize("num_heads", [32])
 @pytest.mark.parametrize("head_dim", [128])
-@pytest.mark.xfail(reason="Some configurations are not supported yet")
 def test_merge_state(seq_len, num_heads, head_dim):
     va = torch.randn(seq_len, num_heads, head_dim).half().to("cuda:0")
     sa = torch.randn(seq_len, num_heads, dtype=torch.float32).to("cuda:0")
@@ -24,7 +23,6 @@ def test_merge_state(seq_len, num_heads, head_dim):
 @pytest.mark.parametrize("seq_len", [2048])
 @pytest.mark.parametrize("num_heads", [32])
 @pytest.mark.parametrize("head_dim", [128])
-@pytest.mark.xfail(reason="Some configurations are not supported yet")
 def test_merge_state_in_place(seq_len, num_heads, head_dim):
     v = torch.randn(seq_len, num_heads, head_dim).half()
     v_std = v.clone()
@@ -45,7 +43,6 @@ def test_merge_state_in_place(seq_len, num_heads, head_dim):
 @pytest.mark.parametrize("num_heads", [32])
 @pytest.mark.parametrize("head_dim", [128])
 @pytest.mark.parametrize("num_states", [100])
-@pytest.mark.xfail(reason="Some configurations are not supported yet")
 def test_merge_states(seq_len, num_states, num_heads, head_dim):
     v = torch.randn(seq_len, num_states, num_heads, head_dim).half().to("cuda:0")
     s = torch.randn(seq_len, num_states, num_heads, dtype=torch.float32).to("cuda:0")
@@ -59,7 +56,6 @@ def test_merge_states(seq_len, num_states, num_heads, head_dim):
 @pytest.mark.parametrize("seq_len", [2048])
 @pytest.mark.parametrize("num_heads", [32])
 @pytest.mark.parametrize("head_dim", [128])
-@pytest.mark.xfail(reason="Some configurations are not supported yet")
 def test_variable_length_merge_states(seq_len, num_heads, head_dim):
     max_index_sets = 512
     lengths = torch.randint(low=1, high=max_index_sets, size=(seq_len,))


### PR DESCRIPTION
This PR removes xfail markers about HIP support from pytests. It was added during Sept release without use, so they are dead code now.