### PR TITLE
Update logging for using JIT in absence of AOT

### DIFF
--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -156,7 +156,7 @@ def _check_torch_rocm_compatibility():
 try:
     from .__aot_prebuilt_uris__ import prebuilt_ops_uri
 except ImportError:
-    logger.info("AOT prebuilt URIs not found. JIT backend will be used instead.")
+    logger.info("Prebuilt AOT kernels not found, using JIT backend.")
     prebuilt_ops_uri = None
 
 try:

--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -129,6 +129,3 @@ try:
 
 except ImportError:
     pass
-
-if not has_prebuilt_ops:
-    logger.info("Prebuilt kernels not found, using JIT backend")


### PR DESCRIPTION
When we run a script using JIT in the absence of prebuilt AOT, it prints a confusing message `Failed to import __aot_prebuilt_uris__: No module named 'flashinfer.__aot_prebuilt_uris__'`. This PR updates the message and add it to the logger instead.

Now, when we run an example script, for example, `python examples/batch_prefill_example.py`, it does not print the old message on the console, rather prints the following from the logger:

<img width="1027" height="174" alt="image" src="https://github.com/user-attachments/assets/c3379721-4596-4f0b-b35d-d3431c3e90b5" />


Closes #91 