### PR TITLE
Remove changes in cascade.py as cascade attention is not supported

### DIFF
--- a/flashinfer/cascade.py
+++ b/flashinfer/cascade.py
@@ -34,7 +34,7 @@ def get_cascade_module():
     global _cascade_module
     if _cascade_module is None:
         if has_prebuilt_ops:
-            _kernels = torch.ops.flashinfer_hip_kernels
+            _kernels = torch.ops.flashinfer_kernels
 
             _cascade_module = _kernels
         else:


### PR DESCRIPTION
This small PR removes the changes in cascade.py as cascade attention is not supported. This will help to improve the code coverage as we currently count all the lines for any file that is updated by the amd-flashinfer in order to measure code coverage.