### PR TITLE
Remove changes on cascade.py to merge-base

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,8 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
-        args: ["--profile=black"] # <-- this one
+        args: ["--profile=black"]
+        exclude: ^flashinfer/(cascade\.py|_version\.py)$
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v19.1.1

--- a/flashinfer/cascade.py
+++ b/flashinfer/cascade.py
@@ -21,10 +21,7 @@ import torch
 
 from .decode import BatchDecodeWithPagedKVCacheWrapper
 from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
-from .prefill import (
-    BatchPrefillWithPagedKVCacheWrapper,
-    single_prefill_with_kv_cache,
-)
+from .prefill import BatchPrefillWithPagedKVCacheWrapper, single_prefill_with_kv_cache
 from .utils import register_custom_op, register_fake_op
 
 _cascade_module = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ force_grid_wrap = 0
 include_trailing_comma = true
 line_length = 80
 multi_line_output = 3
-skip = ["flashinfer/_version.py"]
+skip = ["flashinfer/_version.py", "flashinfer/cascade.py"]
 use_parentheses = true
 
 


### PR DESCRIPTION
The previous PR #129 missed some changes from the merge-base about linting. iSort was not enabled earlier on the upstream and this changelist makes sure it's completely identical to the file in merge-base.

Coverage after this change:

```
$ pytest --cov --cov-report=html --cov-report=term-missing

===================================================================== tests coverage =====================================================================
____________________________________________________ coverage: platform linux, python 3.12.12-final-0 ____________________________________________________

Name                                   Stmts   Miss Branch BrPart   Cover   Missing
-----------------------------------------------------------------------------------
flashinfer/__init__.py                   115     30     16      3  67.18%   49-80, 98-99, 113, 135-137, 166-173
flashinfer/activation.py                  54     12     16      7  72.86%   64-66, 86, 95-99, 129, 131, 171, 173, 209, 211
flashinfer/decode.py                     352    169    140     29  47.56%   69-72, 127, 136-209, 217-220, 301, 324-342, 347-349, 492->495, 496, 498, 499->501, 501->503, 507, 510-540, 569, 571, 697-702, 722-736, 751, 780-782, 871-886, 908, 909->912, 922, 956, 1012-1018, 1118, 1119->1122, 1123, 1125, 1126->1128, 1128->1131, 1137, 1166, 1197, 1209, 1228-1234, 1247, 1309, 1369-1406, 1410, 1414, 1431-1433, 1496-1553, 1604-1666
flashinfer/get_include_paths.py           12      0      0      0 100.00%
flashinfer/jit/__init__.py                68     30      8      2  52.63%   60-66, 83-105, 110-123
flashinfer/jit/activation.py              18      1      2      1  90.00%   63
flashinfer/jit/attention/__init__.py      19      0      0      0 100.00%
flashinfer/jit/attention/pytorch.py      342    179     60      6  45.02%   99, 120-193, 213, 236-310, 352, 484-489, 526-553, 599-674, 780-785, 952, 1027-1089, 1240, 1336-1409
flashinfer/jit/core.py                   129     29     32      8  69.57%   37-38, 57-60, 70, 74-77, 99, 127-128, 147->156, 167-168, 180, 182, 203, 212-224
flashinfer/jit/cpp_ext.py                 89     14     30      9  77.31%   65, 91->94, 97, 104->107, 121, 133, 174, 211-214, 240, 253-257
flashinfer/jit/env.py                     21      1      0      0  95.24%   35
flashinfer/jit/utils.py                   35      8     12      3  72.34%   30-32, 44-45, 56-58
flashinfer/norm.py                        52      6     10      2  87.10%   30->43, 32-34, 109, 153, 211, 257
flashinfer/page.py                        64     12     10      3  79.73%   38-40, 56, 72, 111-116, 177, 297
flashinfer/prefill.py                    493    195    190     54  55.05%   72-79, 106, 157, 176-195, 261, 304, 369, 415, 433-582, 596-616, 793->795, 795->797, 797->799, 801, 806, 817->826, 871-885, 1066, 1076->1086, 1100-1122, 1157-1159, 1278->1280, 1284->1287, 1289, 1297, 1317-1365, 1378-1381, 1389, 1391->1401, 1419-1432, 1479-1487, 1577-1578, 1585, 1586->1588, 1589, 1590->1592, 1592->1594, 1600, 1614, 1624-1634, 1658, 1672, 1694-1702, 1706, 1712-1720, 1875, 1896-1906, 1940-1942, 2050->2052, 2053->2056, 2061, 2065, 2068, 2081-2110, 2115-2116, 2123, 2125->2135, 2195-2203, 2278, 2279->2281, 2281->2283, 2283->2285, 2291, 2299, 2304-2310, 2313, 2336, 2368-2376, 2380
flashinfer/rope.py                       110     22     26     11  74.26%   30->43, 32-34, 96, 150, 191, 229, 281, 365, 423, 519, 598, 709, 786, 896, 984, 1046-1062, 1103
flashinfer/utils.py                      156     52     66     18  59.46%   52, 55-64, 70, 73-82, 88, 93, 101-104, 123, 135-137, 185, 192, 200, 204, 211-226, 260-264, 297-309, 352, 362-363, 367, 378, 382, 386
-----------------------------------------------------------------------------------
TOTAL                                   2129    760    618    156  59.08%
```