### PR TITLE
Chore/migrate to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,18 +35,6 @@ repos:
       - id: remove-crlf
 
   # Formatters
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0
-    hooks:
-      - id: black
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile=black"]
-        exclude: ^flashinfer/(cascade\.py|_version\.py)$
-
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v19.1.1
     hooks:
@@ -60,6 +48,22 @@ repos:
     hooks:
       - id: cmake-format
         additional_dependencies: [pyyaml>=5.1]
+
+  -   repo: https://github.com/pre-commit/mirrors-mypy
+      rev: 'v1.17.1'  # Use the sha / tag you want to point at
+      hooks:
+      -   id: mypy
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.12.8
+    hooks:
+      # Run the linter.
+      - id: ruff-check
+      # Run the formatter.
+      - id: ruff-format
+        types_or: [ python, pyi ]
+
   # REUSE compliance check for specific directories only
   - repo: local
     hooks:

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -162,7 +162,6 @@ elif IS_CUDA:
     from .gemm import SegmentGEMMWrapper as SegmentGEMMWrapper
     from .gemm import bmm_fp8 as bmm_fp8
     from .gemm import mm_fp4 as mm_fp4
-    from .get_include_paths import get_csrc_dir, get_include
     from .mla import BatchMLAPagedAttentionWrapper as BatchMLAPagedAttentionWrapper
     from .norm import fused_add_rmsnorm as fused_add_rmsnorm
     from .norm import gemma_fused_add_rmsnorm as gemma_fused_add_rmsnorm

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -133,29 +133,25 @@ elif IS_CUDA:
     from .decode import (
         CUDAGraphBatchDecodeWithPagedKVCacheWrapper as CUDAGraphBatchDecodeWithPagedKVCacheWrapper,
     )
-    from .decode import (
-        cudnn_batch_decode_with_kv_cache as cudnn_batch_decode_with_kv_cache,
-    )
-    from .decode import (
-        single_decode_with_kv_cache as single_decode_with_kv_cache,
-    )
+    from .decode import cudnn_batch_decode_with_kv_cache as cudnn_batch_decode_with_kv_cache
+    from .decode import single_decode_with_kv_cache as single_decode_with_kv_cache
     from .fp4_quantization import (
         SfLayout,
         block_scale_interleave,
+        nvfp4_block_scale_interleave,
         e2m1_and_ufp8sf_scale_to_float,
         fp4_quantize,
-        mxfp4_dequantize,
         mxfp4_dequantize_host,
+        mxfp4_dequantize,
         mxfp4_quantize,
-        nvfp4_block_scale_interleave,
         nvfp4_quantize,
         shuffle_matrix_a,
         shuffle_matrix_sf_a,
     )
     from .fp8_quantization import mxfp8_dequantize_host, mxfp8_quantize
     from .fused_moe import (
-        GatedActType,
         RoutingMethodType,
+        GatedActType,
         cutlass_fused_moe,
         reorder_rows_for_gated_act_gemm,
         trtllm_fp4_block_scale_moe,
@@ -167,9 +163,7 @@ elif IS_CUDA:
     from .gemm import bmm_fp8 as bmm_fp8
     from .gemm import mm_fp4 as mm_fp4
     from .get_include_paths import get_csrc_dir, get_include
-    from .mla import (
-        BatchMLAPagedAttentionWrapper as BatchMLAPagedAttentionWrapper,
-    )
+    from .mla import BatchMLAPagedAttentionWrapper as BatchMLAPagedAttentionWrapper
     from .norm import fused_add_rmsnorm as fused_add_rmsnorm
     from .norm import gemma_fused_add_rmsnorm as gemma_fused_add_rmsnorm
     from .norm import gemma_rmsnorm as gemma_rmsnorm
@@ -185,9 +179,7 @@ elif IS_CUDA:
     from .prefill import (
         BatchPrefillWithRaggedKVCacheWrapper as BatchPrefillWithRaggedKVCacheWrapper,
     )
-    from .prefill import (
-        single_prefill_with_kv_cache as single_prefill_with_kv_cache,
-    )
+    from .prefill import single_prefill_with_kv_cache as single_prefill_with_kv_cache
     from .prefill import (
         single_prefill_with_kv_cache_return_lse as single_prefill_with_kv_cache_return_lse,
     )
@@ -203,15 +195,11 @@ elif IS_CUDA:
     from .rope import apply_rope_inplace as apply_rope_inplace
     from .rope import apply_rope_pos_ids as apply_rope_pos_ids
     from .rope import apply_rope_pos_ids_inplace as apply_rope_pos_ids_inplace
-    from .rope import (
-        apply_rope_with_cos_sin_cache as apply_rope_with_cos_sin_cache,
-    )
+    from .rope import apply_rope_with_cos_sin_cache as apply_rope_with_cos_sin_cache
     from .rope import (
         apply_rope_with_cos_sin_cache_inplace as apply_rope_with_cos_sin_cache_inplace,
     )
-    from .sampling import (
-        chain_speculative_sampling as chain_speculative_sampling,
-    )
+    from .sampling import chain_speculative_sampling as chain_speculative_sampling
     from .sampling import min_p_sampling_from_probs as min_p_sampling_from_probs
     from .sampling import sampling_from_logits as sampling_from_logits
     from .sampling import sampling_from_probs as sampling_from_probs
@@ -222,14 +210,10 @@ elif IS_CUDA:
     from .sampling import (
         top_k_top_p_sampling_from_logits as top_k_top_p_sampling_from_logits,
     )
-    from .sampling import (
-        top_k_top_p_sampling_from_probs as top_k_top_p_sampling_from_probs,
-    )
+    from .sampling import top_k_top_p_sampling_from_probs as top_k_top_p_sampling_from_probs
     from .sampling import top_p_renorm_probs as top_p_renorm_probs
     from .sampling import top_p_sampling_from_probs as top_p_sampling_from_probs
-    from .sparse import (
-        BlockSparseAttentionWrapper as BlockSparseAttentionWrapper,
-    )
+    from .sparse import BlockSparseAttentionWrapper as BlockSparseAttentionWrapper
     from .sparse import (
         VariableBlockSparseAttentionWrapper as VariableBlockSparseAttentionWrapper,
     )

--- a/flashinfer/aot_hip.py
+++ b/flashinfer/aot_hip.py
@@ -95,7 +95,6 @@ def gen_attention(
     use_sliding_window_: List[bool],
     use_logits_soft_cap_: List[bool],
 ) -> Iterator:
-
     # FA2 MHA / MQA / GQA
     for (
         (head_dim_qk, head_dim_vo),

--- a/flashinfer/hip_utils.py
+++ b/flashinfer/hip_utils.py
@@ -253,7 +253,8 @@ def check_torch_rocm_compatibility() -> None:
             "  2. Install PyTorch for ROCm:\n"
             "     pip install torch==2.7.1 --index-url https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4/\n\n"
             "See https://github.com/rocm/flashinfer for detailed installation instructions.\n"
-            + "=" * 70
+            + "="
+            * 70
         )
 
     # ROCm version compatibility warning
@@ -265,7 +266,7 @@ def check_torch_rocm_compatibility() -> None:
 
     if system_rocm and torch_rocm_major_minor != system_rocm:
         warnings.warn(
-            f"\n{'='*70}\n"
+            f"\n{'=' * 70}\n"
             f"WARNING: ROCm version mismatch detected!\n\n"
             f"  System ROCm version: {system_rocm}\n"
             f"  PyTorch ROCm version: {torch_rocm_major_minor}\n\n"
@@ -277,7 +278,7 @@ def check_torch_rocm_compatibility() -> None:
             f"  export FLASHINFER_ROCM_VERSION={system_rocm}\n"
             f"  uv pip install torch==2.7.1 --index-url "
             f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{system_rocm}/\n"
-            f"{'='*70}",
+            f"{'=' * 70}",
             RuntimeWarning,
             stacklevel=2,
         )

--- a/flashinfer/jit/attention/pytorch_hip.py
+++ b/flashinfer/jit/attention/pytorch_hip.py
@@ -25,8 +25,6 @@ from ..core import (
     check_hip_availability,
     gen_jit_spec,
     load_cuda_ops,
-    logger,
-    sm90a_nvcc_flags,
 )
 from ..env import FLASHINFER_CSRC_DIR, FLASHINFER_GEN_SRC_DIR
 from ..utils import (
@@ -176,9 +174,9 @@ def gen_single_decode_module(
         ["double", "double", "double", "double"],  # additional_scalar_dtypes
         f"DefaultAttention<false, {str(use_sliding_window).lower()}, {str(use_logits_soft_cap).lower()}, {str(pos_encoding_mode == 2).lower()}>",  # variant_name
         (
-            f"#include<flashinfer/attention/generic/variants.cuh>"
+            "#include<flashinfer/attention/generic/variants.cuh>"
             if check_hip_availability()
-            else f"#include<flashinfer/attention/variants.cuh>"
+            else "#include<flashinfer/attention/variants.cuh>"
         ),  # variant_decl
         pos_encoding_mode=pos_encoding_mode,
         use_sliding_window=use_sliding_window,
@@ -222,9 +220,9 @@ def gen_single_prefill_module(
         additional_scalar_dtypes = ["double", "double", "double", "double"]
         variant_name = f"DefaultAttention<use_custom_mask, {str(use_sliding_window).lower()}, {str(use_logits_soft_cap).lower()}, {str(pos_encoding_mode == 2).lower()}>"
         variant_decl = (
-            f"#include<flashinfer/attention/generic/variants.cuh>"
+            "#include<flashinfer/attention/generic/variants.cuh>"
             if check_hip_availability()
-            else f"#include<flashinfer/attention/variants.cuh>"
+            else "#include<flashinfer/attention/variants.cuh>"
         )
     else:
         additional_tensor_names = []
@@ -232,7 +230,7 @@ def gen_single_prefill_module(
         additional_scalar_names = ["logits_soft_cap", "sm_scale"]
         additional_scalar_dtypes = ["double", "double"]
         variant_name = f"DefaultAttention<{str(use_logits_soft_cap).lower()}>"
-        variant_decl = f"#include<flashinfer/attention/hopper/variants.cuh>"
+        variant_decl = "#include<flashinfer/attention/hopper/variants.cuh>"
 
     return gen_customize_single_prefill_module(
         backend,
@@ -296,9 +294,9 @@ def gen_batch_decode_module(
         ["double", "double", "double", "double"],  # additional_scalar_dtypes
         f"DefaultAttention<false, {str(use_sliding_window).lower()}, {str(use_logits_soft_cap).lower()}, {str(pos_encoding_mode == 2).lower()}>",  # variant_name
         (
-            f"#include<flashinfer/attention/generic/variants.cuh>"
+            "#include<flashinfer/attention/generic/variants.cuh>"
             if check_hip_availability()
-            else f"#include<flashinfer/attention/variants.cuh>"
+            else "#include<flashinfer/attention/variants.cuh>"
         ),  # variant_decl
         pos_encoding_mode=pos_encoding_mode,
         use_sliding_window=use_sliding_window,
@@ -353,9 +351,9 @@ def gen_batch_prefill_module(
         additional_scalar_dtypes = ["double", "double", "double", "double"]
         variant_name = f"DefaultAttention<use_custom_mask, {str(use_sliding_window).lower()}, {str(use_logits_soft_cap).lower()}, {str(pos_encoding_mode == 2).lower()}>"
         variant_decl = (
-            f"#include<flashinfer/attention/generic/variants.cuh>"
+            "#include<flashinfer/attention/generic/variants.cuh>"
             if check_hip_availability()
-            else f"#include<flashinfer/attention/variants.cuh>"
+            else "#include<flashinfer/attention/variants.cuh>"
         )
     else:
         additional_tensor_names = []
@@ -363,7 +361,7 @@ def gen_batch_prefill_module(
         additional_scalar_names = ["logits_soft_cap", "sm_scale"]
         additional_scalar_dtypes = ["double", "double"]
         variant_name = f"DefaultAttention<{str(use_logits_soft_cap).lower()}>"
-        variant_decl = f"#include<flashinfer/attention/hopper/variants.cuh>"
+        variant_decl = "#include<flashinfer/attention/hopper/variants.cuh>"
 
     return gen_customize_batch_prefill_module(
         backend,
@@ -896,7 +894,6 @@ def gen_customize_batch_prefill_module(
                 else "batch_prefill_jit_pybind.cu"
             ),
         ]:
-
             src_path = FLASHINFER_CSRC_DIR / filename
             dest_path = gen_directory / filename
             source_paths.append(dest_path)

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -17,10 +17,8 @@ from torch.utils.cpp_extension import (
     _TORCH_PATH,
     CUDA_HOME,
     ROCM_HOME,
-    _get_cuda_arch_flags,
     _get_num_workers,
     _get_pybind11_abi_build_flags,
-    _get_rocm_arch_flags,
 )
 
 from . import env as jit_env

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -189,9 +189,7 @@ def get_batch_prefill_module(backend):
                     plan_func = (
                         _kernels_sm90.batch_prefill_with_kv_cache_sm90_plan.default
                     )
-                    ragged_run_func = (
-                        _kernels_sm90.batch_prefill_with_ragged_kv_cache_sm90_run.default
-                    )
+                    ragged_run_func = _kernels_sm90.batch_prefill_with_ragged_kv_cache_sm90_run.default
                     paged_run_func = (
                         _kernels_sm90.batch_prefill_with_paged_kv_cache_sm90_run.default
                     )

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -442,7 +442,6 @@ def has_cuda_cudart() -> bool:
 
 
 def is_sm90a_supported(device: torch.device) -> bool:
-
     if torch.version.hip is not None:
         return False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,15 +129,6 @@ skip = [
     ".venv"
 ]
 
-[tool.isort]
-ensure_newline_before_comments = true
-force_grid_wrap = 0
-include_trailing_comma = true
-line_length = 80
-multi_line_output = 3
-skip = ["flashinfer/_version.py", "flashinfer/cascade.py"]
-use_parentheses = true
-
 
 [tool.mypy]
 ignore_missing_imports = false
@@ -188,8 +179,11 @@ ignore = [
     "B020",
     # Return te negated condition directly
     "SIM103",
+    # Function definition does not bind loop variable
+    "B023",
 ]
-
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
 
 [tool.pytest.ini_options]
 # Ignore deprecation warnings

--- a/scripts/git_describe_rocm.py
+++ b/scripts/git_describe_rocm.py
@@ -7,6 +7,7 @@ Output format:
   (embeds .devN in local part, sets distance to 0 to prevent version_scheme modification)
 - Otherwise: tag-distance-ghash (standard git describe --long format)
 """
+
 import subprocess
 import sys
 

--- a/tests/test_aot_hip.py
+++ b/tests/test_aot_hip.py
@@ -168,9 +168,9 @@ def test_module_naming_convention():
                 found_patterns[pattern] = True
 
     # At least some expected patterns should be found
-    assert any(
-        found_patterns.values()
-    ), f"No expected module patterns found in: {[s.name for s in jit_specs]}"
+    assert any(found_patterns.values()), (
+        f"No expected module patterns found in: {[s.name for s in jit_specs]}"
+    )
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])

--- a/tests/test_batch_decode_vllm.py
+++ b/tests/test_batch_decode_vllm.py
@@ -160,6 +160,7 @@ def test_flashinfer_decode_with_paged_kv(
         scale=scale,
         soft_cap=soft_cap,
     )
-    torch.testing.assert_close(
-        output, ref_output, atol=1e-2, rtol=1e-2
-    ), f"{torch.max(torch.abs(output - ref_output))}"
+    (
+        torch.testing.assert_close(output, ref_output, atol=1e-2, rtol=1e-2),
+        f"{torch.max(torch.abs(output - ref_output))}",
+    )


### PR DESCRIPTION
Migrates formatters to `ruff` from `black` and `isort`. Updated pyproject.toml, pre-commit-config and applied fixes.