### PR TITLE
Bugfix: Use device contextmanager instead of setting default context globally

### DIFF
--- a/tests/test_batch_decode_vllm.py
+++ b/tests/test_batch_decode_vllm.py
@@ -89,77 +89,77 @@ def test_flashinfer_decode_with_paged_kv(
     block_size: int,
     soft_cap: Optional[float],
 ) -> None:
-    torch.set_default_device("cuda")
-    seed_val = 47
-    torch.manual_seed(seed_val)
-    num_seqs = len(kv_lens)
-    num_query_heads = num_heads[0]
-    num_kv_heads = num_heads[1]
-    assert num_query_heads % num_kv_heads == 0
-    max_kv_len = max(kv_lens)
-    scale = head_size**-0.5
+    with torch.device("cuda"):
+        seed_val = 47
+        torch.manual_seed(seed_val)
+        num_seqs = len(kv_lens)
+        num_query_heads = num_heads[0]
+        num_kv_heads = num_heads[1]
+        assert num_query_heads % num_kv_heads == 0
+        max_kv_len = max(kv_lens)
+        scale = head_size**-0.5
 
-    query = torch.randn(num_seqs, num_query_heads, head_size, dtype=dtype)
+        query = torch.randn(num_seqs, num_query_heads, head_size, dtype=dtype)
 
-    key_value_cache = torch.randn(
-        NUM_BLOCKS, 2, block_size, num_kv_heads, head_size, dtype=dtype
-    )
-    key_cache = key_value_cache[:, 0, :, :, :].squeeze(1)
-    value_cache = key_value_cache[:, 1, :, :, :].squeeze(1)
+        key_value_cache = torch.randn(
+            NUM_BLOCKS, 2, block_size, num_kv_heads, head_size, dtype=dtype
+        )
+        key_cache = key_value_cache[:, 0, :, :, :].squeeze(1)
+        value_cache = key_value_cache[:, 1, :, :, :].squeeze(1)
 
-    max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
-    block_tables = torch.randint(
-        0, NUM_BLOCKS, (num_seqs, max_num_blocks_per_seq), dtype=torch.int32
-    )
+        max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
+        block_tables = torch.randint(
+            0, NUM_BLOCKS, (num_seqs, max_num_blocks_per_seq), dtype=torch.int32
+        )
 
-    kv_indptr = [0]
-    kv_indices = []
-    kv_last_page_lens = []
-    for i in range(num_seqs):
-        seq_len = kv_lens[i]
-        assert seq_len > 0
-        num_blocks = (seq_len + block_size - 1) // block_size
-        kv_indices.extend(block_tables[i, :num_blocks])
-        kv_indptr.append(kv_indptr[-1] + num_blocks)
-        kv_last_page_len = seq_len % block_size
-        if kv_last_page_len == 0:
-            kv_last_page_len = block_size
-        kv_last_page_lens.append(kv_last_page_len)
+        kv_indptr = [0]
+        kv_indices = []
+        kv_last_page_lens = []
+        for i in range(num_seqs):
+            seq_len = kv_lens[i]
+            assert seq_len > 0
+            num_blocks = (seq_len + block_size - 1) // block_size
+            kv_indices.extend(block_tables[i, :num_blocks])
+            kv_indptr.append(kv_indptr[-1] + num_blocks)
+            kv_last_page_len = seq_len % block_size
+            if kv_last_page_len == 0:
+                kv_last_page_len = block_size
+            kv_last_page_lens.append(kv_last_page_len)
 
-    kv_indptr = torch.tensor(kv_indptr, dtype=torch.int32)
-    kv_indices = torch.tensor(kv_indices, dtype=torch.int32)
-    kv_last_page_lens = torch.tensor(kv_last_page_lens, dtype=torch.int32)
+        kv_indptr = torch.tensor(kv_indptr, dtype=torch.int32)
+        kv_indices = torch.tensor(kv_indices, dtype=torch.int32)
+        kv_last_page_lens = torch.tensor(kv_last_page_lens, dtype=torch.int32)
 
-    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8)
-    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
-        workspace_buffer, "NHD", use_tensor_cores=False
-    )
-    wrapper.plan(
-        kv_indptr,
-        kv_indices,
-        kv_last_page_lens,
-        num_query_heads,
-        num_kv_heads,
-        head_size,
-        block_size,
-        "NONE",
-        q_data_type=dtype,
-        kv_data_type=dtype,
-        logits_soft_cap=soft_cap,
-    )
+        workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8)
+        wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+            workspace_buffer, "NHD", use_tensor_cores=False
+        )
+        wrapper.plan(
+            kv_indptr,
+            kv_indices,
+            kv_last_page_lens,
+            num_query_heads,
+            num_kv_heads,
+            head_size,
+            block_size,
+            "NONE",
+            q_data_type=dtype,
+            kv_data_type=dtype,
+            logits_soft_cap=soft_cap,
+        )
 
-    output = wrapper.run(query, key_value_cache)
+        output = wrapper.run(query, key_value_cache)
 
-    ref_output = ref_paged_attn(
-        query=query,
-        key_cache=key_cache,
-        value_cache=value_cache,
-        query_lens=[1] * num_seqs,
-        kv_lens=kv_lens,
-        block_tables=block_tables,
-        scale=scale,
-        soft_cap=soft_cap,
-    )
-    torch.testing.assert_close(
-        output, ref_output, atol=1e-2, rtol=1e-2
-    ), f"{torch.max(torch.abs(output - ref_output))}"
+        ref_output = ref_paged_attn(
+            query=query,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            query_lens=[1] * num_seqs,
+            kv_lens=kv_lens,
+            block_tables=block_tables,
+            scale=scale,
+            soft_cap=soft_cap,
+        )
+        torch.testing.assert_close(
+            output, ref_output, atol=1e-2, rtol=1e-2
+        ), f"{torch.max(torch.abs(output - ref_output))}"


### PR DESCRIPTION
`test_batch_decode_vllm.py` was setting the `set_default_device` to `cuda` globally and due to that any subsequent tests in our test suite that requires the default device to be CPU starts failing. When run individually the tests do not cause a problem, but the issue manifests when run together in the same pytest global context.

Fixes the issue by using a `device` contextmanager instead of setting device context globally.