### PR TITLE
Refactor: Python import refactoring for HIP/CUDA split (v0.3.0)

### DIFF
--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -61,6 +61,8 @@ if IS_HIP:
     from .prefill import (
         single_prefill_with_kv_cache_return_lse as single_prefill_with_kv_cache_return_lse,
     )
+    from .quantization import packbits as packbits
+    from .quantization import segment_packbits as segment_packbits
     from .rope import apply_llama31_rope as apply_llama31_rope
     from .rope import apply_llama31_rope_inplace as apply_llama31_rope_inplace
     from .rope import apply_llama31_rope_pos_ids as apply_llama31_rope_pos_ids
@@ -133,7 +135,9 @@ elif IS_CUDA:
     from .decode import (
         CUDAGraphBatchDecodeWithPagedKVCacheWrapper as CUDAGraphBatchDecodeWithPagedKVCacheWrapper,
     )
-    from .decode import cudnn_batch_decode_with_kv_cache as cudnn_batch_decode_with_kv_cache
+    from .decode import (
+        cudnn_batch_decode_with_kv_cache as cudnn_batch_decode_with_kv_cache,
+    )
     from .decode import single_decode_with_kv_cache as single_decode_with_kv_cache
     from .fp4_quantization import (
         SfLayout,
@@ -209,7 +213,9 @@ elif IS_CUDA:
     from .sampling import (
         top_k_top_p_sampling_from_logits as top_k_top_p_sampling_from_logits,
     )
-    from .sampling import top_k_top_p_sampling_from_probs as top_k_top_p_sampling_from_probs
+    from .sampling import (
+        top_k_top_p_sampling_from_probs as top_k_top_p_sampling_from_probs,
+    )
     from .sampling import top_p_renorm_probs as top_p_renorm_probs
     from .sampling import top_p_sampling_from_probs as top_p_sampling_from_probs
     from .sparse import BlockSparseAttentionWrapper as BlockSparseAttentionWrapper

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -18,13 +18,6 @@ if IS_HIP:
     from .hip_utils import check_torch_rocm_compatibility
     from .jit.core import logger
 
-    # FIXME: To be removed once we fully integrate the amd-flashinfer-jit-cache package
-    try:
-        from .__aot_prebuilt_uris__ import prebuilt_ops_uri
-    except ImportError:
-        logger.info("Prebuilt AOT kernels not found, using JIT backend.")
-        prebuilt_ops_uri = None
-
     # Checks compatibility with installed torch
     check_torch_rocm_compatibility()
 

--- a/flashinfer/activation.py
+++ b/flashinfer/activation.py
@@ -20,12 +20,9 @@ from typing import Optional
 
 import torch
 
-from .jit import (  # noqa: F401
-    gen_act_and_mul_module,
-    has_prebuilt_ops,
-    load_cuda_ops,
-)
-from .utils import register_custom_op, register_fake_op
+from .jit import JitSpec
+from .jit import gen_act_and_mul_module as gen_act_and_mul_module_impl
+from .utils import device_support_pdl, register_custom_op, register_fake_op
 
 silu_def_cu_str = r"""
 __device__ __forceinline__ float silu(const float& val) {
@@ -61,10 +58,7 @@ def gen_act_and_mul_module(act_func_name: str) -> JitSpec:
 
 @functools.cache
 def get_act_and_mul_module(act_func_name: str):
-    global _jit_modules
-    if act_func_name not in _jit_modules:
-        if has_prebuilt_ops:
-            _kernels = torch.ops.flashinfer_hip_kernels
+    module = gen_act_and_mul_module(act_func_name).build_and_load()
 
     # torch library for act_and_mul
     fname = f"{act_func_name}_and_mul"

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -18,22 +18,35 @@ import functools
 import math
 from types import SimpleNamespace
 from typing import Any, List, Literal, Optional, Tuple, Union, overload
-
+from .device_utils import IS_CUDA, IS_HIP
 import torch
 
-from .cudnn import cudnn_batch_decode_with_kv_cache as cudnn_batch_decode_with_kv_cache
-from .jit import (
-    gen_batch_decode_mla_module,
-    gen_batch_decode_module,
-    gen_customize_batch_decode_module,
-    gen_customize_batch_prefill_module,
-    gen_single_decode_module,
-    get_batch_decode_uri,
-    get_batch_prefill_uri,
-    get_single_decode_uri,
-    setup_cubin_loader,
-    trtllm_gen_fmha_module,
-)
+if IS_CUDA:
+    from .cudnn import (
+        cudnn_batch_decode_with_kv_cache as cudnn_batch_decode_with_kv_cache,
+    )
+    from .jit import (
+        gen_batch_decode_mla_module,
+        gen_batch_decode_module,
+        gen_customize_batch_decode_module,
+        gen_customize_batch_prefill_module,
+        gen_single_decode_module,
+        get_batch_decode_uri,
+        get_batch_prefill_uri,
+        get_single_decode_uri,
+        setup_cubin_loader,
+        trtllm_gen_fmha_module,
+    )
+elif IS_HIP:
+    from .jit import (
+        gen_batch_decode_module,
+        gen_customize_batch_decode_module,
+        gen_customize_batch_prefill_module,
+        gen_single_decode_module,
+        get_batch_decode_uri,
+        get_batch_prefill_uri,
+        get_single_decode_uri,
+    )
 from .page import get_seq_lens
 from .prefill import (
     get_batch_prefill_jit_module,
@@ -66,17 +79,11 @@ from .utils import (
 
 @functools.cache
 def get_single_decode_module(*args):
-    global _single_decode_modules
-    if args not in _single_decode_modules:
-        uri = get_single_decode_uri(*args)
-        if has_prebuilt_ops and uri in prebuilt_ops_uri:
-            print("JIT: Using prebuilt ops")
-            _kernels = torch.ops.flashinfer_hip_kernels
+    uri = get_single_decode_uri(*args)
+    module = gen_single_decode_module(*args).build_and_load()
+    run_func = module.run.default
 
-            run_func = _kernels.single_decode_with_kv_cache.default
-        else:
-            module = gen_single_decode_module(*args).build_and_load()
-            run_func = module.run.default
+    # torch library for single_decode_with_kv_cache
 
     @register_custom_op(f"flashinfer::{uri}_run", mutates_args=("tmp", "o"))
     def run_single_decode(
@@ -211,18 +218,12 @@ def get_batch_decode_jit_module(module_name: str, jit_module: Any):
 
 @functools.cache
 def get_batch_decode_module(*args):
-    global _batch_decode_modules
-    if args not in _batch_decode_modules:
-        uri = get_batch_decode_uri(*args)
-        if has_prebuilt_ops and uri in prebuilt_ops_uri:
-            _kernels = torch.ops.flashinfer_hip_kernels
+    uri = get_batch_decode_uri(*args)
+    mod = gen_batch_decode_module(*args).build_and_load()
+    plan_func = mod.plan.default
+    run_func = mod.run.default
 
-            plan_func = _kernels.batch_decode_with_paged_kv_cache_plan.default
-            run_func = _kernels.batch_decode_with_paged_kv_cache_run.default
-        else:
-            mod = gen_batch_decode_module(*args).build_and_load()
-            plan_func = mod.plan.default
-            run_func = mod.run.default
+    # torch library for batch_decode_with_paged_kv_cache_run
 
     @register_custom_op(
         f"flashinfer::{uri}_run",
@@ -312,12 +313,14 @@ def get_batch_decode_module(*args):
     )
 
 
-@functools.cache
-def get_trtllm_gen_fmha_module():
-    mod = trtllm_gen_fmha_module()
-    op = mod.build_and_load()
-    setup_cubin_loader(mod.get_library_path())
-    return op
+if IS_CUDA:
+
+    @functools.cache
+    def get_trtllm_gen_fmha_module():
+        mod = trtllm_gen_fmha_module()
+        op = mod.build_and_load()
+        setup_cubin_loader(mod.get_library_path())
+        return op
 
 
 def single_decode_with_kv_cache_with_jit_module(
@@ -351,9 +354,11 @@ def single_decode_with_kv_cache_with_jit_module(
     return o
 
 
-@functools.cache
-def get_batch_decode_mla_module(*args):
-    return gen_batch_decode_mla_module(*args).build_and_load()
+if IS_CUDA:
+
+    @functools.cache
+    def get_batch_decode_mla_module(*args):
+        return gen_batch_decode_mla_module(*args).build_and_load()
 
 
 @overload
@@ -743,10 +748,11 @@ class BatchDecodeWithPagedKVCacheWrapper:
             device="cpu",
         )
         self._kv_lens_buffer: Optional[torch.Tensor] = None
-        if backend == "trtllm-gen":
-            self._kv_lens_buffer = torch.empty(
-                (32768,), dtype=torch.int32, device=self.device
-            )
+        if IS_CUDA:
+            if backend == "trtllm-gen":
+                self._kv_lens_buffer = torch.empty(
+                    (32768,), dtype=torch.int32, device=self.device
+                )
 
         if use_cuda_graph:
             if not torch.is_tensor(paged_kv_indptr_buffer):
@@ -772,7 +778,10 @@ class BatchDecodeWithPagedKVCacheWrapper:
         self._paged_kv_indptr_buf = paged_kv_indptr_buffer
         self._paged_kv_indices_buf = paged_kv_indices_buffer
         self._paged_kv_last_page_len_buf = paged_kv_last_page_len_buffer
-        self._use_tensor_cores = use_tensor_cores or backend == "trtllm-gen"
+        if IS_CUDA:
+            self._use_tensor_cores = use_tensor_cores or backend == "trtllm-gen"
+        elif IS_HIP:
+            self._use_tensor_cores = use_tensor_cores
         self._use_cuda_graph = use_cuda_graph
 
         if use_tensor_cores:
@@ -968,7 +977,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
             kv_lens_arr_host = get_seq_lens(indptr_host, last_page_len_host, page_size)
         else:
             kv_lens_arr_host = seq_lens.cpu()
-        if self._backend == "trtllm-gen":
+        if IS_CUDA and self._backend == "trtllm-gen":
             assert self._kv_layout == "HND"
             assert logits_soft_cap == 0.0
             self._max_kv_len = max(kv_lens_arr_host).item()
@@ -1220,7 +1229,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
 
         pos_encoding_mode = self._pos_encoding_mode
         window_left = self._window_left if window_left is None else window_left
-        if self._backend != "trtllm-gen":
+        if IS_HIP or self._backend != "trtllm-gen":
             # NOTE(Siyuan): since window_left is appeared in the plan function, we need to make sure it is the same as the one in the plan function.
             # Remove this check if the backend supports dynamic window_left.
             assert window_left == self._window_left
@@ -1258,7 +1267,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         else:
             check_shape_dtype_device(out, q.shape, q.dtype, q.device, "out")
 
-        if self._backend == "trtllm-gen":
+        if IS_CUDA and self._backend == "trtllm-gen":
             q = q.view(q.size(0) // q_len_per_req, q_len_per_req, q.size(1), q.size(2))
 
         if self.use_tensor_cores:
@@ -1313,7 +1322,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
             self._cached_module.paged_run(*run_args)
         else:
             # trtllm-gen does not need plan info
-            if self._backend == "trtllm-gen" and self._plan_info is None:
+            if IS_CUDA and self._backend == "trtllm-gen" and self._plan_info is None:
                 plan_info: List[int] = []
             else:
                 plan_info = self._plan_info
@@ -1464,398 +1473,900 @@ class CUDAGraphBatchDecodeWithPagedKVCacheWrapper(BatchDecodeWithPagedKVCacheWra
         )
 
 
-class BatchDecodeMlaWithPagedKVCacheWrapper:
-    r"""Warning: this class is deprecated and will be removed in a future release.
-    Please use :class:`flashinfer.mla.BatchMLAPagedAttentionWrapper` instead, which provides
-    a more efficient and general MLA implementation that supports decode and incremental prefill.
-    """
+if IS_CUDA:
 
-    def __init__(
-        self,
-        float_workspace_buffer: torch.Tensor,
-        use_cuda_graph: bool = False,
-        use_tensor_cores: bool = False,
-        paged_kv_indptr_buffer: Optional[torch.Tensor] = None,
-        paged_kv_indices_buffer: Optional[torch.Tensor] = None,
-        paged_kv_last_page_len_buffer: Optional[torch.Tensor] = None,
-    ) -> None:
-        r"""Constructor of :class:`BatchDecodeWithPagedKVCacheWrapper`.
-
-        Parameters
-        ----------
-        float_workspace_buffer : torch.Tensor
-            The user reserved float workspace buffer used to store intermediate attention results
-            in the split-k algorithm. The recommended size is 128MB, the device of the workspace
-            buffer should be the same as the device of the input tensors.
-
-        use_cuda_graph : bool
-            Whether to enable CUDAGraph for batch decode attention, if enabled, the
-            auxiliary data structures will be stored as the provided buffers. The ``batch_size``
-            cannot change during the lifecycle of this wrapper when CUDAGraph is enabled.
-
-        use_tensor_cores : bool
-            Whether to use tensor cores for the computation. Will be faster for large group
-            size in grouped query attention. Defaults to ``False``.
-
-        paged_kv_indptr_buffer : Optional[torch.Tensor]
-            The user reserved buffer on GPU to store the indptr of the paged kv cache, the size
-            of the buffer should be ``[batch_size + 1]``.
-            Only needed when ``use_cuda_graph`` is ``True``.
-
-        paged_kv_indices_buffer : Optional[torch.Tensor]
-            The user reserved buffer on GPU to store the page indices of the paged kv cache,
-            should be large enough to store the maximum number of page indices
-            (``max_num_pages``) during the lifecycle of this wrapper.
-            Only needed when ``use_cuda_graph`` is ``True``.
-
-        paged_kv_last_page_len_buffer : Optional[torch.Tensor]
-            The user reserved buffer on GPU to store the number of entries in the last page, the
-            size of the buffer should be ``[batch_size]``.
-            Only needed when ``use_cuda_graph`` is ``True``.
+    class BatchDecodeMlaWithPagedKVCacheWrapper:
+        r"""Warning: this class is deprecated and will be removed in a future release.
+        Please use :class:`flashinfer.mla.BatchMLAPagedAttentionWrapper` instead, which provides
+        a more efficient and general MLA implementation that supports decode and incremental prefill.
         """
-        self._float_workspace_buffer = float_workspace_buffer
-        self.device = float_workspace_buffer.device
-        self._int_workspace_buffer = torch.empty(
-            (8 * 1024 * 1024,), dtype=torch.uint8, device=self.device
-        )
-        self._pin_memory_int_workspace_buffer = torch.empty(
-            (8 * 1024 * 1024,),
-            dtype=torch.uint8,
-            pin_memory=True,
-            device="cpu",
-        )
 
-        if use_cuda_graph:
-            if not torch.is_tensor(paged_kv_indptr_buffer):
-                raise ValueError(
-                    "paged_kv_indptr_buffer should be a torch.Tensor in cudagraph mode"
-                )
-            if not torch.is_tensor(paged_kv_indices_buffer):
-                raise ValueError(
-                    "paged_kv_indices_buffer should be a torch.Tensor in cudagraph mode"
-                )
-            if not torch.is_tensor(paged_kv_last_page_len_buffer):
-                raise ValueError(
-                    "paged_kv_last_page_len_buffer should be a torch.Tensor in cudagraph mode"
-                )
-            self._fixed_batch_size = len(paged_kv_last_page_len_buffer)
-            if len(paged_kv_indptr_buffer) != self._fixed_batch_size + 1:
-                raise ValueError(
-                    "The size of paged_kv_indptr_buffer should be batch_size + 1"
-                )
-        else:
-            self._fixed_batch_size = 0
+        def __init__(
+            self,
+            float_workspace_buffer: torch.Tensor,
+            use_cuda_graph: bool = False,
+            use_tensor_cores: bool = False,
+            paged_kv_indptr_buffer: Optional[torch.Tensor] = None,
+            paged_kv_indices_buffer: Optional[torch.Tensor] = None,
+            paged_kv_last_page_len_buffer: Optional[torch.Tensor] = None,
+        ) -> None:
+            r"""Constructor of :class:`BatchDecodeWithPagedKVCacheWrapper`.
 
-        self._use_tensor_cores = use_tensor_cores
-        self._paged_kv_indptr_buf = paged_kv_indptr_buffer
-        self._paged_kv_indices_buf = paged_kv_indices_buffer
-        self._paged_kv_last_page_len_buf = paged_kv_last_page_len_buffer
-        self._use_cuda_graph = use_cuda_graph
+            Parameters
+            ----------
+            float_workspace_buffer : torch.Tensor
+                The user reserved float workspace buffer used to store intermediate attention results
+                in the split-k algorithm. The recommended size is 128MB, the device of the workspace
+                buffer should be the same as the device of the input tensors.
 
-    @property
-    def is_cuda_graph_enabled(self) -> bool:
-        return self._use_cuda_graph
+            use_cuda_graph : bool
+                Whether to enable CUDAGraph for batch decode attention, if enabled, the
+                auxiliary data structures will be stored as the provided buffers. The ``batch_size``
+                cannot change during the lifecycle of this wrapper when CUDAGraph is enabled.
 
-    @property
-    def use_tensor_cores(self) -> bool:
-        return self._use_tensor_cores
+            use_tensor_cores : bool
+                Whether to use tensor cores for the computation. Will be faster for large group
+                size in grouped query attention. Defaults to ``False``.
 
-    def reset_workspace_buffer(
-        self, float_workspace_buffer: torch.Tensor, int_workspace_buffer: torch.Tensor
-    ) -> None:
-        r"""Reset the workspace buffer.
+            paged_kv_indptr_buffer : Optional[torch.Tensor]
+                The user reserved buffer on GPU to store the indptr of the paged kv cache, the size
+                of the buffer should be ``[batch_size + 1]``.
+                Only needed when ``use_cuda_graph`` is ``True``.
 
-        Parameters
-        ----------
-        float_workspace_buffer : torch.Tensor
-            The new float workspace buffer, the device of the new float workspace buffer should
-            be the same as the device of the input tensors.
+            paged_kv_indices_buffer : Optional[torch.Tensor]
+                The user reserved buffer on GPU to store the page indices of the paged kv cache,
+                should be large enough to store the maximum number of page indices
+                (``max_num_pages``) during the lifecycle of this wrapper.
+                Only needed when ``use_cuda_graph`` is ``True``.
 
-        int_workspace_buffer : torch.Tensor
-            The new int workspace buffer, the device of the new int workspace buffer should
-            be the same as the device of the input tensors.
-        """
-        self._float_workspace_buffer = float_workspace_buffer
-        self._int_workspace_buffer = int_workspace_buffer
-        self._pin_memory_int_workspace_buffer = torch.empty(
-            self._int_workspace_buffer.shape,
-            dtype=self._int_workspace_buffer.dtype,
-            device="cpu",
-            pin_memory=True,
-        )
-
-    def plan(
-        self,
-        indptr: torch.Tensor,
-        indices: torch.Tensor,
-        last_page_len: torch.Tensor,
-        num_qo_heads: int,
-        head_dim_compressed_kv: int,
-        page_size: int,
-        sm_scale: float,
-        window_left: int = -1,
-        logits_soft_cap: Optional[float] = None,
-        data_type: Union[str, torch.dtype] = "float16",
-        q_data_type: Optional[Union[str, torch.dtype]] = None,
-        rope_scale: Optional[float] = None,
-        rope_theta: Optional[float] = None,
-    ) -> None:
-        r"""Plan batch decode for given problem specification.
-
-        Parameters
-        ----------
-        indptr : torch.Tensor
-            The indptr of the paged kv cache, shape: ``[batch_size + 1]``
-        indices : torch.Tensor
-            The page indices of the paged kv cache, shape: ``[qo_indptr[-1]]``
-        last_page_len : torch.Tensor
-            The number of entries in the last page of each request in the paged kv
-            cache, shape: ``[batch_size]``
-        num_qo_heads : int
-            The number of query/output heads
-        head_dim_compressed_kv : int
-            The dimension of the compressed kv, is also kv_lora_rank
-        page_size : int
-            The page size of the paged kv cache
-        sm_scale : float
-            The scale of softmax, should be ``1 / sqrt(qk_nope_head_dim + qk_rope_head_dim)``
-        window_left : int
-            The left (inclusive) window size for the attention window, when set to ``-1``, the window
-            size will be set to the full length of the sequence. Defaults to ``-1``.
-        logits_soft_cap : Optional[float]
-            The attention logits soft capping value (used in Gemini, Grok and Gemma-2, etc.), if not
-            provided, will be set to ``0``. If greater than 0, the logits will be capped according to
-            formula:
-            :math:`\texttt{logits_soft_cap} \times \mathrm{tanh}(x / \texttt{logits_soft_cap})`,
-            where :math:`x` is the input logits.
-        data_type : Union[str, torch.dtype]
-            The data type of the paged kv cache. Defaults to ``float16``.
-        q_data_type : Optional[Union[str, torch.dtype]]
-            The data type of the query tensor. If None, will be set to
-            ``data_type``. Defaults to ``None``.
-
-        Note
-        ----
-        The :meth:`plan` method should be called before any :meth:`run` or
-        :meth:`run_return_lse` calls, auxiliary data structures will be created
-        during this call and cached for multiple run calls.
-        """
-        batch_size = len(last_page_len)
-        if logits_soft_cap is None:
-            logits_soft_cap = 0.0
-
-        if self.is_cuda_graph_enabled:
-            if batch_size != self._fixed_batch_size:
-                raise ValueError(
-                    "The batch size should be fixed in cudagraph mode, the runtime batch size {} "
-                    " mismatches the batch size set during initialization {}".format(
-                        batch_size, self._fixed_batch_size
-                    )
-                )
-            if len(indices) > len(self._paged_kv_indices_buf):
-                raise ValueError(
-                    "The size of indices should be less than or equal to the allocated buffer"
-                )
-            self._paged_kv_indptr_buf.copy_(indptr)
-            self._paged_kv_indices_buf[: len(indices)] = indices
-            self._paged_kv_last_page_len_buf.copy_(last_page_len)
-        else:
-            self._paged_kv_indptr_buf = indptr.to(self.device)
-            self._paged_kv_indices_buf = indices.to(self.device)
-            self._paged_kv_last_page_len_buf = last_page_len.to(self.device)
-
-        data_type = canonicalize_torch_dtype(data_type)
-        if not q_data_type:
-            q_data_type = data_type
-        q_data_type = canonicalize_torch_dtype(q_data_type)
-
-        indptr_host = indptr.to("cpu")
-
-        self._cached_module = get_batch_decode_mla_module(
-            q_data_type,
-            data_type,
-            q_data_type,
-            indptr.dtype,
-            head_dim_compressed_kv,
-            num_qo_heads,
-            window_left != -1,  # use_sliding_window
-            logits_soft_cap > 0,  # use_logits_soft_cap
-            self._use_tensor_cores,
-        )
-        self._plan_info = self._cached_module.plan(
-            self._float_workspace_buffer,
-            self._int_workspace_buffer,
-            self._pin_memory_int_workspace_buffer,
-            indptr_host,
-            batch_size,
-            num_qo_heads,
-            page_size,
-            self.is_cuda_graph_enabled,
-        )
-
-        self._sm_scale = sm_scale
-        self._window_left = window_left
-        self._logits_soft_cap = logits_soft_cap
-        self._rope_scale = rope_scale
-        self._rope_theta = rope_theta
-
-    def run(
-        self,
-        q_nope: torch.Tensor,
-        q_pe: torch.Tensor,
-        paged_ckv_cache: torch.Tensor,
-        paged_kpe_cache: torch.Tensor,
-        q_scale: Optional[float] = None,
-        k_scale: Optional[float] = None,
-        v_scale: Optional[float] = None,
-        out: Optional[torch.Tensor] = None,
-        lse: Optional[torch.Tensor] = None,
-        return_lse: bool = False,
-        enable_pdl: bool = False,  # fake placeholder (sm80)
-    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
-        r"""Compute batch decode attention between query and paged kv cache.
-
-        Parameters
-        ----------
-        q_nope : torch.Tensor
-            The query tensor not related to ROPE, shape: ``[batch_size, num_qo_heads, head_dim_ckv]``
-        q_pe : torch.Tensor
-            The query tensor related to ROPE, shape: ``[batch_size, num_qo_heads, head_dim_kpe]``
-        paged_ckv_cache : torch.Tensor
-            The paged compressed-KV-Cache stored as a single tensor:
-            * 3-D tensors, each with shape: ``[max_num_pages, page_size, head_dim_ckv]``.
-        paged_kpe_cache : torch.Tensor
-            The paged k-pe-Cache stored as a single tensor:
-            * 3-D tensors, each with shape: ``[max_num_pages, page_size, head_dim_kpe]``.
-        q_scale : Optional[float]
-            The calibration scale of query for fp8 input, if not provided, will be set to ``1.0``.
-        k_scale : Optional[float]
-            The calibration scale of key for fp8 input, if not provided, will be set to ``1.0``.
-        v_scale : Optional[float]
-            The calibration scale of value for fp8 input, if not provided, will be set to ``1.0``.
-        out : Optional[torch.Tensor]
-            The output tensor, if not provided, will be allocated internally.
-        lse : Optional[torch.Tensor]
-            The log-sum-exp of attention logits, if not provided, will be allocated internally.
-        return_lse : bool
-            Whether to return the logsumexp of attention scores, defaults to ``False``.
-        enable_pdl : bool
-            Whether to enable Programmatic Dependent Launch (PDL). See https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
-            Only supported for >= sm90, and currently only for FA2 and CUDA core decode.
-        Returns
-        -------
-        Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
-            If :attr:`return_lse` is ``False``, the attention output, shape: ``[batch_size, num_qo_heads, head_dim]``.
-            If :attr:`return_lse` is ``True``, a tuple of two tensors:
-
-            * attention output, shape: ``[batch_size, num_qo_heads, head_dim]``
-            * logsumexp of attention scores, shape: ``[batch_size, num_qo_heads]``.
-        """
-        window_left = self._window_left
-        logits_soft_cap = self._logits_soft_cap
-        sm_scale = self._sm_scale
-        rope_scale = self._rope_scale
-        rope_theta = self._rope_theta
-        if logits_soft_cap is None:
-            logits_soft_cap = 0.0
-        if q_scale is not None:
-            sm_scale *= q_scale
-        if k_scale is not None:
-            sm_scale *= k_scale
-        if rope_scale is None:
-            rope_scale = 1.0
-        if rope_theta is None:
-            rope_theta = 1e4
-
-        device = self.device
-        if out is None:
-            out = torch.empty_like(q_nope, device=device)
-        else:
-            check_shape_dtype_device(
-                out, q_nope.shape, q_nope.dtype, q_nope.device, "out"
+            paged_kv_last_page_len_buffer : Optional[torch.Tensor]
+                The user reserved buffer on GPU to store the number of entries in the last page, the
+                size of the buffer should be ``[batch_size]``.
+                Only needed when ``use_cuda_graph`` is ``True``.
+            """
+            self._float_workspace_buffer = float_workspace_buffer
+            self.device = float_workspace_buffer.device
+            self._int_workspace_buffer = torch.empty(
+                (8 * 1024 * 1024,), dtype=torch.uint8, device=self.device
+            )
+            self._pin_memory_int_workspace_buffer = torch.empty(
+                (8 * 1024 * 1024,),
+                dtype=torch.uint8,
+                pin_memory=True,
+                device="cpu",
             )
 
-        if return_lse:
-            if lse is None:
-                lse = torch.empty(
-                    (q_nope.size(0), q_nope.size(1)),
-                    dtype=torch.float32,
-                    device=device,
-                )
+            if use_cuda_graph:
+                if not torch.is_tensor(paged_kv_indptr_buffer):
+                    raise ValueError(
+                        "paged_kv_indptr_buffer should be a torch.Tensor in cudagraph mode"
+                    )
+                if not torch.is_tensor(paged_kv_indices_buffer):
+                    raise ValueError(
+                        "paged_kv_indices_buffer should be a torch.Tensor in cudagraph mode"
+                    )
+                if not torch.is_tensor(paged_kv_last_page_len_buffer):
+                    raise ValueError(
+                        "paged_kv_last_page_len_buffer should be a torch.Tensor in cudagraph mode"
+                    )
+                self._fixed_batch_size = len(paged_kv_last_page_len_buffer)
+                if len(paged_kv_indptr_buffer) != self._fixed_batch_size + 1:
+                    raise ValueError(
+                        "The size of paged_kv_indptr_buffer should be batch_size + 1"
+                    )
+            else:
+                self._fixed_batch_size = 0
+
+            self._use_tensor_cores = use_tensor_cores
+            self._paged_kv_indptr_buf = paged_kv_indptr_buffer
+            self._paged_kv_indices_buf = paged_kv_indices_buffer
+            self._paged_kv_last_page_len_buf = paged_kv_last_page_len_buffer
+            self._use_cuda_graph = use_cuda_graph
+
+        @property
+        def is_cuda_graph_enabled(self) -> bool:
+            return self._use_cuda_graph
+
+        @property
+        def use_tensor_cores(self) -> bool:
+            return self._use_tensor_cores
+
+        def reset_workspace_buffer(
+            self,
+            float_workspace_buffer: torch.Tensor,
+            int_workspace_buffer: torch.Tensor,
+        ) -> None:
+            r"""Reset the workspace buffer.
+
+            Parameters
+            ----------
+            float_workspace_buffer : torch.Tensor
+                The new float workspace buffer, the device of the new float workspace buffer should
+                be the same as the device of the input tensors.
+
+            int_workspace_buffer : torch.Tensor
+                The new int workspace buffer, the device of the new int workspace buffer should
+                be the same as the device of the input tensors.
+            """
+            self._float_workspace_buffer = float_workspace_buffer
+            self._int_workspace_buffer = int_workspace_buffer
+            self._pin_memory_int_workspace_buffer = torch.empty(
+                self._int_workspace_buffer.shape,
+                dtype=self._int_workspace_buffer.dtype,
+                device="cpu",
+                pin_memory=True,
+            )
+
+        def plan(
+            self,
+            indptr: torch.Tensor,
+            indices: torch.Tensor,
+            last_page_len: torch.Tensor,
+            num_qo_heads: int,
+            head_dim_compressed_kv: int,
+            page_size: int,
+            sm_scale: float,
+            window_left: int = -1,
+            logits_soft_cap: Optional[float] = None,
+            data_type: Union[str, torch.dtype] = "float16",
+            q_data_type: Optional[Union[str, torch.dtype]] = None,
+            rope_scale: Optional[float] = None,
+            rope_theta: Optional[float] = None,
+        ) -> None:
+            r"""Plan batch decode for given problem specification.
+
+            Parameters
+            ----------
+            indptr : torch.Tensor
+                The indptr of the paged kv cache, shape: ``[batch_size + 1]``
+            indices : torch.Tensor
+                The page indices of the paged kv cache, shape: ``[qo_indptr[-1]]``
+            last_page_len : torch.Tensor
+                The number of entries in the last page of each request in the paged kv
+                cache, shape: ``[batch_size]``
+            num_qo_heads : int
+                The number of query/output heads
+            head_dim_compressed_kv : int
+                The dimension of the compressed kv, is also kv_lora_rank
+            page_size : int
+                The page size of the paged kv cache
+            sm_scale : float
+                The scale of softmax, should be ``1 / sqrt(qk_nope_head_dim + qk_rope_head_dim)``
+            window_left : int
+                The left (inclusive) window size for the attention window, when set to ``-1``, the window
+                size will be set to the full length of the sequence. Defaults to ``-1``.
+            logits_soft_cap : Optional[float]
+                The attention logits soft capping value (used in Gemini, Grok and Gemma-2, etc.), if not
+                provided, will be set to ``0``. If greater than 0, the logits will be capped according to
+                formula:
+                :math:`\texttt{logits_soft_cap} \times \mathrm{tanh}(x / \texttt{logits_soft_cap})`,
+                where :math:`x` is the input logits.
+            data_type : Union[str, torch.dtype]
+                The data type of the paged kv cache. Defaults to ``float16``.
+            q_data_type : Optional[Union[str, torch.dtype]]
+                The data type of the query tensor. If None, will be set to
+                ``data_type``. Defaults to ``None``.
+
+            Note
+            ----
+            The :meth:`plan` method should be called before any :meth:`run` or
+            :meth:`run_return_lse` calls, auxiliary data structures will be created
+            during this call and cached for multiple run calls.
+            """
+            batch_size = len(last_page_len)
+            if logits_soft_cap is None:
+                logits_soft_cap = 0.0
+
+            if self.is_cuda_graph_enabled:
+                if batch_size != self._fixed_batch_size:
+                    raise ValueError(
+                        "The batch size should be fixed in cudagraph mode, the runtime batch size {} "
+                        " mismatches the batch size set during initialization {}".format(
+                            batch_size, self._fixed_batch_size
+                        )
+                    )
+                if len(indices) > len(self._paged_kv_indices_buf):
+                    raise ValueError(
+                        "The size of indices should be less than or equal to the allocated buffer"
+                    )
+                self._paged_kv_indptr_buf.copy_(indptr)
+                self._paged_kv_indices_buf[: len(indices)] = indices
+                self._paged_kv_last_page_len_buf.copy_(last_page_len)
+            else:
+                self._paged_kv_indptr_buf = indptr.to(self.device)
+                self._paged_kv_indices_buf = indices.to(self.device)
+                self._paged_kv_last_page_len_buf = last_page_len.to(self.device)
+
+            data_type = canonicalize_torch_dtype(data_type)
+            if not q_data_type:
+                q_data_type = data_type
+            q_data_type = canonicalize_torch_dtype(q_data_type)
+
+            indptr_host = indptr.to("cpu")
+
+            self._cached_module = get_batch_decode_mla_module(
+                q_data_type,
+                data_type,
+                q_data_type,
+                indptr.dtype,
+                head_dim_compressed_kv,
+                num_qo_heads,
+                window_left != -1,  # use_sliding_window
+                logits_soft_cap > 0,  # use_logits_soft_cap
+                self._use_tensor_cores,
+            )
+            self._plan_info = self._cached_module.plan(
+                self._float_workspace_buffer,
+                self._int_workspace_buffer,
+                self._pin_memory_int_workspace_buffer,
+                indptr_host,
+                batch_size,
+                num_qo_heads,
+                page_size,
+                self.is_cuda_graph_enabled,
+            )
+
+            self._sm_scale = sm_scale
+            self._window_left = window_left
+            self._logits_soft_cap = logits_soft_cap
+            self._rope_scale = rope_scale
+            self._rope_theta = rope_theta
+
+        def run(
+            self,
+            q_nope: torch.Tensor,
+            q_pe: torch.Tensor,
+            paged_ckv_cache: torch.Tensor,
+            paged_kpe_cache: torch.Tensor,
+            q_scale: Optional[float] = None,
+            k_scale: Optional[float] = None,
+            v_scale: Optional[float] = None,
+            out: Optional[torch.Tensor] = None,
+            lse: Optional[torch.Tensor] = None,
+            return_lse: bool = False,
+            enable_pdl: bool = False,  # fake placeholder (sm80)
+        ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+            r"""Compute batch decode attention between query and paged kv cache.
+
+            Parameters
+            ----------
+            q_nope : torch.Tensor
+                The query tensor not related to ROPE, shape: ``[batch_size, num_qo_heads, head_dim_ckv]``
+            q_pe : torch.Tensor
+                The query tensor related to ROPE, shape: ``[batch_size, num_qo_heads, head_dim_kpe]``
+            paged_ckv_cache : torch.Tensor
+                The paged compressed-KV-Cache stored as a single tensor:
+                * 3-D tensors, each with shape: ``[max_num_pages, page_size, head_dim_ckv]``.
+            paged_kpe_cache : torch.Tensor
+                The paged k-pe-Cache stored as a single tensor:
+                * 3-D tensors, each with shape: ``[max_num_pages, page_size, head_dim_kpe]``.
+            q_scale : Optional[float]
+                The calibration scale of query for fp8 input, if not provided, will be set to ``1.0``.
+            k_scale : Optional[float]
+                The calibration scale of key for fp8 input, if not provided, will be set to ``1.0``.
+            v_scale : Optional[float]
+                The calibration scale of value for fp8 input, if not provided, will be set to ``1.0``.
+            out : Optional[torch.Tensor]
+                The output tensor, if not provided, will be allocated internally.
+            lse : Optional[torch.Tensor]
+                The log-sum-exp of attention logits, if not provided, will be allocated internally.
+            return_lse : bool
+                Whether to return the logsumexp of attention scores, defaults to ``False``.
+            enable_pdl : bool
+                Whether to enable Programmatic Dependent Launch (PDL). See https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
+                Only supported for >= sm90, and currently only for FA2 and CUDA core decode.
+            Returns
+            -------
+            Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+                If :attr:`return_lse` is ``False``, the attention output, shape: ``[batch_size, num_qo_heads, head_dim]``.
+                If :attr:`return_lse` is ``True``, a tuple of two tensors:
+
+                * attention output, shape: ``[batch_size, num_qo_heads, head_dim]``
+                * logsumexp of attention scores, shape: ``[batch_size, num_qo_heads]``.
+            """
+            window_left = self._window_left
+            logits_soft_cap = self._logits_soft_cap
+            sm_scale = self._sm_scale
+            rope_scale = self._rope_scale
+            rope_theta = self._rope_theta
+            if logits_soft_cap is None:
+                logits_soft_cap = 0.0
+            if q_scale is not None:
+                sm_scale *= q_scale
+            if k_scale is not None:
+                sm_scale *= k_scale
+            if rope_scale is None:
+                rope_scale = 1.0
+            if rope_theta is None:
+                rope_theta = 1e4
+
+            device = self.device
+            if out is None:
+                out = torch.empty_like(q_nope, device=device)
             else:
                 check_shape_dtype_device(
-                    lse,
-                    (q_nope.size(0), q_nope.size(1)),
-                    q_nope.dtype,
-                    q_nope.device,
-                    "lse",
+                    out, q_nope.shape, q_nope.dtype, q_nope.device, "out"
                 )
-        self._cached_module.run(
-            self._float_workspace_buffer,
-            self._int_workspace_buffer,
-            self._plan_info,
-            q_nope,
-            q_pe,
-            paged_ckv_cache,
-            paged_kpe_cache,
-            self._paged_kv_indptr_buf,
-            self._paged_kv_indices_buf,
-            self._paged_kv_last_page_len_buf,
-            out,
-            sm_scale,
-            window_left,
-            logits_soft_cap,
-            rope_scale,
-            rope_theta,
-            lse,
-            enable_pdl,
+
+            if return_lse:
+                if lse is None:
+                    lse = torch.empty(
+                        (q_nope.size(0), q_nope.size(1)),
+                        dtype=torch.float32,
+                        device=device,
+                    )
+                else:
+                    check_shape_dtype_device(
+                        lse,
+                        (q_nope.size(0), q_nope.size(1)),
+                        q_nope.dtype,
+                        q_nope.device,
+                        "lse",
+                    )
+            self._cached_module.run(
+                self._float_workspace_buffer,
+                self._int_workspace_buffer,
+                self._plan_info,
+                q_nope,
+                q_pe,
+                paged_ckv_cache,
+                paged_kpe_cache,
+                self._paged_kv_indptr_buf,
+                self._paged_kv_indices_buf,
+                self._paged_kv_last_page_len_buf,
+                out,
+                sm_scale,
+                window_left,
+                logits_soft_cap,
+                rope_scale,
+                rope_theta,
+                lse,
+                enable_pdl,
+            )
+            out = [out, lse] if return_lse else [out]
+            if v_scale is not None:
+                out[0] *= v_scale
+
+            return tuple(out) if return_lse else out[0]
+
+        run_return_lse = functools.partialmethod(run, return_lse=True)
+
+    class TrtllmGenDecodeModule:
+        def __init__(self) -> None:
+            self._sm_count: Optional[int] = None
+            self._mod = trtllm_gen_fmha_module()
+            self._op = self._mod.build_and_load()
+            from flashinfer.jit.cubin_loader import setup_cubin_loader
+
+            setup_cubin_loader(self._mod.get_library_path())
+
+        def _paged_run(
+            self,
+            query: torch.Tensor,
+            k_cache: torch.Tensor,
+            v_cache: torch.Tensor,
+            workspace_buffer: torch.Tensor,
+            block_tables: torch.Tensor,
+            seq_lens: torch.Tensor,
+            max_seq_len: int,
+            bmm1_scale: float,  # todo(Yingyi): add dynamic scale tensor later
+            bmm2_scale: float,
+            workspace_size: int,
+            window_left: int = -1,
+            enable_pdl: bool = None,
+            out: Optional[torch.Tensor] = None,
+            sinks: Optional[torch.Tensor] = None,
+        ) -> torch.Tensor:
+            if out is None:
+                out = torch.empty_like(query)
+            if self._sm_count is None:
+                self._sm_count = get_device_sm_count(query.device)
+
+            self._op.trtllm_paged_attention_decode(
+                out,
+                None,  # fp4 output not supported in wrapper api yet.
+                query,  # [B, S, H, D], w/ MTP here so second dim is S
+                k_cache,
+                v_cache,
+                workspace_buffer,
+                block_tables,
+                seq_lens,
+                max_seq_len,
+                bmm1_scale,
+                bmm2_scale,
+                -1,  # o_sf_scale
+                -1,  # o_sf_vec_size
+                0,  # o_sf_start_index
+                window_left,
+                self._sm_count,
+                enable_pdl,
+                workspace_size,
+                sinks,
+            )
+            return out
+
+        def _plan(self, *args, **kwargs):
+            pass
+
+    @functools.cache
+    def get_trtllm_gen_decode_module(*args):
+        uri = get_batch_prefill_uri("trtllm-gen", *args)
+        module = TrtllmGenDecodeModule()
+
+        @register_custom_op(
+            f"flashinfer::{uri}_ragged_run",
+            mutates_args=(
+                "float_workspace_buffer",
+                "int_workspace_buffer",
+                "o",
+                "maybe_lse",
+            ),
         )
-        out = [out, lse] if return_lse else [out]
-        if v_scale is not None:
-            out[0] *= v_scale
+        def paged_run(
+            float_workspace_buffer: torch.Tensor,
+            int_workspace_buffer: torch.Tensor,
+            plan_info_vec: List[int],
+            q: torch.Tensor,
+            paged_k_cache: torch.Tensor,
+            paged_v_cache: torch.Tensor,
+            qo_indptr: torch.Tensor,
+            paged_kv_indptr: torch.Tensor,
+            paged_kv_indices: torch.Tensor,
+            paged_kv_last_page_len: torch.Tensor,
+            o: torch.Tensor,
+            maybe_lse: Optional[torch.Tensor],
+            mask_mode: int,
+            layout: int,
+            window_left: int,
+            enable_pdl: bool,
+            maybe_custom_mask: Optional[torch.Tensor],
+            maybe_mask_indptr: Optional[torch.Tensor],
+            maybe_alibi_slopes: Optional[torch.Tensor],
+            maybe_prefix_len_ptr: Optional[torch.Tensor],
+            maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
+            maybe_max_item_len_ptr: Optional[torch.Tensor],
+            logits_soft_cap: float,
+            sm_scale: float,
+            scale_q: Optional[torch.Tensor],
+            scale_k: Optional[torch.Tensor],
+            scale_v: Optional[torch.Tensor],
+            rope_scale: float,
+            rope_theta: float,
+            token_pos_in_items_len: int,
+            workspace_size: int,
+            paged_kv_cache: Optional[torch.Tensor] = None,
+            num_qo_heads: Optional[int] = None,
+            num_kv_heads: Optional[int] = None,
+            block_tables: Optional[torch.Tensor] = None,
+            kv_lens_buffer: Optional[torch.Tensor] = None,
+            page_size: Optional[int] = None,
+            max_kv_len: Optional[int] = None,
+            sinks: Optional[torch.Tensor] = None,
+        ) -> None:
+            assert maybe_lse is None
+            assert paged_kv_cache is not None
+            assert num_qo_heads is not None
+            assert num_kv_heads is not None
+            assert block_tables is not None
+            assert kv_lens_buffer is not None
+            assert page_size is not None
+            assert max_kv_len is not None
+            assert enable_pdl is not None
+            o = module._paged_run(
+                q.contiguous(),  # NOTE(Siyuan): without contiguous, the result is incorrect
+                paged_k_cache,
+                paged_v_cache,
+                int_workspace_buffer,
+                block_tables,
+                kv_lens_buffer,
+                max_kv_len,
+                sm_scale,
+                1.0,  # NOTE(Siyuan): update this to expose bmm2 scale
+                workspace_size,
+                window_left,
+                enable_pdl,
+                out=o,
+                sinks=sinks,
+            )
 
-        return tuple(out) if return_lse else out[0]
+        @register_fake_op(f"flashinfer::{uri}_paged_run")
+        def _fake_paged_run(
+            float_workspace_buffer: torch.Tensor,
+            int_workspace_buffer: torch.Tensor,
+            plan_info_vec: List[int],
+            q: torch.Tensor,
+            paged_k_cache: torch.Tensor,
+            paged_v_cache: torch.Tensor,
+            qo_indptr: torch.Tensor,
+            paged_kv_indptr: torch.Tensor,
+            paged_kv_indices: torch.Tensor,
+            paged_kv_last_page_len: torch.Tensor,
+            o: torch.Tensor,
+            maybe_lse: Optional[torch.Tensor],
+            mask_mode: int,
+            layout: int,
+            window_left: int,
+            enable_pdl: bool,
+            maybe_custom_mask: Optional[torch.Tensor],
+            maybe_mask_indptr: Optional[torch.Tensor],
+            maybe_alibi_slopes: Optional[torch.Tensor],
+            maybe_prefix_len_ptr: Optional[torch.Tensor],
+            maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
+            maybe_max_item_len_ptr: Optional[torch.Tensor],
+            logits_soft_cap: float,
+            sm_scale: float,
+            rope_scale: float,
+            rope_theta: float,
+            token_pos_in_items_len: int,
+            paged_kv_cache: Optional[torch.Tensor] = None,
+            num_qo_heads: Optional[int] = None,
+            num_kv_heads: Optional[int] = None,
+            block_tables: Optional[torch.Tensor] = None,
+            kv_lens_buffer: Optional[torch.Tensor] = None,
+            page_size: Optional[int] = None,
+            max_kv_len: Optional[int] = None,
+            sinks: Optional[torch.Tensor] = None,
+        ) -> None:
+            pass
 
-    run_return_lse = functools.partialmethod(run, return_lse=True)
+        # Register the module.
+        #
+        # Note that plan is not part of model logic. It should not be included in
+        # Cuda Graph or torch.compile. So, we don't provide a torch library for plan.
+        return SimpleNamespace(
+            plan=module._plan,
+            paged_run=paged_run,
+        )
 
-
-class TrtllmGenDecodeModule:
-    def __init__(self) -> None:
-        self._sm_count: Optional[int] = None
-        self._mod = trtllm_gen_fmha_module()
-        self._op = self._mod.build_and_load()
-        from flashinfer.jit.cubin_loader import setup_cubin_loader
-
-        setup_cubin_loader(self._mod.get_library_path())
-
-    def _paged_run(
-        self,
+    def trtllm_batch_decode_with_kv_cache(
         query: torch.Tensor,
-        k_cache: torch.Tensor,
-        v_cache: torch.Tensor,
+        kv_cache: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
         workspace_buffer: torch.Tensor,
         block_tables: torch.Tensor,
         seq_lens: torch.Tensor,
         max_seq_len: int,
-        bmm1_scale: float,  # todo(Yingyi): add dynamic scale tensor later
-        bmm2_scale: float,
-        workspace_size: int,
+        bmm1_scale: float,
+        bmm2_scale: float,  # todo(Yingyi): add dynamic scale tensor later
         window_left: int = -1,
+        out: Optional[Union[torch.Tensor, FP4Tensor]] = None,
+        out_dtype: Optional[Union[torch.dtype, str]] = None,
+        o_sf_scale: Optional[float] = None,
+        o_sf_vec_size: Optional[int] = None,
+        sinks: Optional[List[torch.Tensor]] = None,
         enable_pdl: bool = None,
-        out: Optional[torch.Tensor] = None,
-        sinks: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        if out is None:
-            out = torch.empty_like(query)
-        if self._sm_count is None:
-            self._sm_count = get_device_sm_count(query.device)
+        q_len_per_req: Optional[int] = 1,
+    ) -> Union[torch.Tensor, FP4Tensor]:
+        """
+        Parameters
+        ----------
+        query : torch.Tensor
+            query tensor with shape [num_tokens, num_heads, head_dim], num_tokens = batch_size * q_len_per_request
 
-        self._op.trtllm_paged_attention_decode(
+        kv_cache : Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+            If kv_cache is a single tensor, it should be a tensor with shape [num_pages, 1 or 2, num_kv_heads, page_size, head_dim]
+            If kv_cache is a tuple of two tensors, it should be a tuple of two tensors with shape [num_pages, num_kv_heads, page_size, head_dim]
+
+        workspace_buffer : torch.Tensor. Must be initialized to 0 for its first use.
+            workspace
+
+        block_tables : torch.Tensor
+            page_table of kv cache, [batch_size, num_pages]
+
+        seq_lens : torch.Tensor
+            A uint32 1D tensor indicating the kv sequence length of each prompt. shape: ``[batch_size]``
+
+        max_seq_len : int
+            max sequence length for kv_cache
+
+        bmm1_scale : float
+            fused scale for bmm1 input.
+
+        bmm2_scale : float
+            fused scale for bmm2 input.
+
+        window_left : int = -1
+            The left (inclusive) window size for the attention window, when set to ``-1``, the window
+            size will be set to the full length of the sequence. Defaults to ``-1``.
+
+        out :  Optional[Union[torch.Tensor, FP4Tensor]] = None
+            output tensor, if not provided, will be allocated with ``out_dtype``, if ``out_dtype`` is not provided, will use the type of ``query``.
+
+        out_dtype : Optional[Union[torch.dtype, str]] = None
+            output dtype, if not provided, will use the type of ``out``. For nvfp4, use string ``nvfp4``.
+
+        o_sf_scale : Optional[float] = None
+            scale for nvfp4 output tensor scale factor.
+
+        o_sf_vec_size : Optional[int] = None
+            vector size for nvfp4 output tensor scale factor.
+
+        sinks : Optional[List[torch.Tensor]] = None
+            additional value per head in the denominator of the softmax.
+
+        enable_pdl : bool
+            Whether to enable Programmatic Dependent Launch (PDL). See https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
+            Only supported for >= sm90, and currently only for FA2, CUDA core, and trtllm-gen decode.
+
+        Returns
+        -------
+        out : Union[torch.Tensor, FP4Tensor]
+            output torch.Tensor or FP4Tensor.
+        """
+        enable_pdl = (
+            device_support_pdl(query.device) if enable_pdl is None else enable_pdl
+        )
+
+        if isinstance(kv_cache, tuple):
+            k_cache, v_cache = kv_cache
+        else:
+            if kv_cache.shape[1] == 1:
+                k_cache, v_cache = kv_cache, kv_cache
+            else:
+                assert kv_cache.shape[1] == 2, (
+                    "When kv_cache is a single tensor, the second dimension must be 1 or 2"
+                )
+                # NOTE(Zihao): unbind transforms [num_pages, 2, ...] to ([num_pages, ...], [num_pages, ...])
+                # it doesn't change underlying storage
+                k_cache, v_cache = kv_cache.unbind(dim=1)
+
+        run_func = get_trtllm_gen_fmha_module().trtllm_paged_attention_decode
+        sm_count = get_device_sm_count(query.device)
+
+        if out_dtype == "nvfp4" or (out_dtype is None and isinstance(out, FP4Tensor)):
+            assert query.dtype == torch.float8_e4m3fn, (
+                "query must be fp8 when out_dtype is nvfp4."
+            )
+            assert o_sf_scale is not None
+            assert o_sf_vec_size in [None, 16], "only o_sf_vec_size = 16 is supported"
+            o_sf_vec_size = o_sf_vec_size or 16
+
+            fp4_out_shape = query.shape[:-1] + (ceil_div(query.shape[-1], 2),)
+
+            if isinstance(out, FP4Tensor):
+                fp4_out_scale_shape = (
+                    out.scale.shape[0],
+                    round_up(query.shape[1] * query.shape[2] // o_sf_vec_size, 4),
+                )
+                out_scale_factor = out.scale
+                o_sf_start_index = out.scale_start_index
+                out = out.data
+                # out_dtype may be None
+                out_dtype = out_dtype or "nvfp4"
+            elif out is None:
+                fp4_out_scale_shape = (
+                    round_up(query.shape[0], 128),
+                    round_up(query.shape[1] * query.shape[2] // o_sf_vec_size, 4),
+                )
+                out_scale_factor = torch.empty(
+                    fp4_out_scale_shape, dtype=torch.float8_e4m3fn, device=query.device
+                )
+                o_sf_start_index = 0
+                out = torch.empty(fp4_out_shape, dtype=torch.uint8, device=query.device)
+            else:
+                raise ValueError(f"Invalid out: {out}")
+
+            assert out_dtype == "nvfp4"
+            assert isinstance(out, torch.Tensor)
+
+            # Use uint8 as the container dtype to compliant with next fp4 gemm.
+            check_shape_dtype_device(
+                out, fp4_out_shape, torch.uint8, query.device, "out"
+            )
+
+            check_shape_dtype_device(
+                out_scale_factor,
+                fp4_out_scale_shape,
+                torch.float8_e4m3fn,
+                query.device,
+                "out_scale_factor",
+            )
+
+            # Check o_sf_start_index is valid
+            if (
+                o_sf_start_index < 0
+                or o_sf_start_index + out.shape[0] > out_scale_factor.shape[0]
+            ):
+                raise ValueError(
+                    f"o_sf_start_index is out of the valid range of out_scale_factor. "
+                    f"o_sf_start_index={o_sf_start_index}, out.shape[0]={out.shape[0]}, "
+                    f"out_scale_factor.shape[0]={out_scale_factor.shape[0]}"
+                )
+
+        elif isinstance(out_dtype, torch.dtype) or out_dtype is None:
+            assert o_sf_scale is None
+            assert o_sf_vec_size is None
+            out_scale_factor = None
+            o_sf_start_index = 0
+            if out_dtype is None:
+                out_dtype = out.dtype if out is not None else query.dtype
+            out = out if out is not None else torch.empty_like(query, dtype=out_dtype)
+            if out_dtype not in (query.dtype, torch.float16, torch.bfloat16):
+                raise ValueError(f"Unsupported out_dtype: {out_dtype}")
+            check_shape_dtype_device(out, query.shape, out_dtype, query.device, "out")
+        else:
+            raise ValueError(f"Invalid out_dtype: {out_dtype}")
+
+        run_func(
             out,
-            None,  # fp4 output not supported in wrapper api yet.
-            query,  # [B, S, H, D], w/ MTP here so second dim is S
+            out_scale_factor,
+            query.view(
+                query.size(0) // q_len_per_req,
+                q_len_per_req,
+                query.size(1),
+                query.size(2),
+            ),
             k_cache,
             v_cache,
+            workspace_buffer,
+            block_tables,
+            seq_lens,
+            max_seq_len,
+            bmm1_scale,
+            bmm2_scale,
+            o_sf_scale or -1.0,
+            o_sf_vec_size or -1,
+            o_sf_start_index,
+            window_left,
+            sm_count,
+            enable_pdl,
+            workspace_buffer.numel() * workspace_buffer.element_size(),
+            sinks,
+        )
+
+        return (
+            out
+            if out_dtype != "nvfp4"
+            else FP4Tensor(out, out_scale_factor, o_sf_start_index, query.shape)
+        )
+
+    def _check_trtllm_gen_mla_shape(
+        query,
+        kv_cache,
+        qk_nope_head_dim,
+        kv_lora_rank,
+        qk_rope_head_dim,
+        page_table,
+        page_size,
+    ):
+        if query.ndim != 4:
+            raise ValueError(f"Expected query.ndim == 4, got {query.ndim}")
+        if kv_cache.ndim != 4:
+            raise ValueError(f"Expected kv_cache.ndim == 4, got {kv_cache.ndim}")
+        if qk_nope_head_dim != 128:
+            raise ValueError(
+                f"Expected qk_nope_head_dim == 128, got {qk_nope_head_dim}"
+            )
+        if kv_lora_rank != 512:
+            raise ValueError(f"Expected kv_lora_rank == 512, got {kv_lora_rank}")
+        if qk_rope_head_dim != 64:
+            raise ValueError(f"Expected qk_rope_head_dim == 64, got {qk_rope_head_dim}")
+
+        B_q, Q_len, H, D_q = query.shape
+        D_ckv = kv_cache.shape[3]
+        # if H != 128:
+        #     raise ValueError(f"Expected 128 heads for query, got {H}")
+        # todo(Yingyi): should we check num_heads == 128? Is this deepseek only?
+        if D_q != D_ckv or D_q != 576:
+            raise ValueError(
+                f"Expected head dim 576 for query and kv_cache, got {D_q} and {D_ckv}"
+            )
+
+        B_block_table, block_num = page_table.shape
+        block_size = page_size
+        if B_q != B_block_table:
+            raise ValueError(
+                f"Expected batch size {B_q} for query and block_table, got {B_q} and {B_block_table}"
+            )
+        if block_num % (128 / block_size) != 0:
+            raise ValueError(
+                f"Expected block_num % (128 / block_size) == 0, got {block_num=} and {block_size=}"
+            )
+
+    def trtllm_batch_decode_with_kv_cache_mla(
+        query: torch.Tensor,
+        kv_cache: torch.Tensor,
+        workspace_buffer: torch.Tensor,
+        qk_nope_head_dim: int,
+        kv_lora_rank: int,
+        qk_rope_head_dim: int,
+        block_tables: torch.Tensor,
+        seq_lens: torch.Tensor,
+        max_seq_len: int,
+        out: Optional[torch.Tensor] = None,
+        bmm1_scale: Optional[float] = 1.0,
+        bmm2_scale: Optional[float] = 1.0,
+        bmm1_scale_log2_tensor: Optional[torch.Tensor] = None,
+        bmm2_scale_tensor: Optional[torch.Tensor] = None,
+        sinks: Optional[List[torch.Tensor]] = None,
+        enable_pdl: bool = None,
+    ) -> torch.Tensor:
+        """
+        Parameters:
+        query: [batch_size, q_len_per_request, num_heads, head_dim_qk], head_dim_qk = qk_nope_head_dim (kv_lora_rank) + qk_rope_head_dim, should be concated q_nope + q_rope; q_len_per_request is the MTP query length.
+        kv_cache: [num_pages, page_size, head_dim_ckv + head_dim_kpe], should be concated ckv_cache + kpe_cache
+        workspace_buffer: [num_semaphores, 4], used for multi_block mode. Must be initialized to 0 for its first use.
+        qk_nope_head_dim: qk_nope_head_dim, must be 128
+        kv_lora_rank: kv_lora_rank, must be 512
+        qk_rope_head_dim: qk_rope_head_dim, must be 64
+        block_tables: page_table of kv cache, [batch_size, num_pages]
+        seq_lens: query_len
+        max_seq_len: max sequence length for kv_cache
+        out: output tensor, if not provided, will be allocated internally
+        bmm1_scale: fused scale for mla bmm1 input.
+        bmm2_scale: fused scale for mla bmm2 input.
+        bmm1_scale_log2_tensor: On-device fused scale tensor for mla bmm1 input. Must be fused with * M_LOG2E before passing in.
+        bmm2_scale_tensor: On-device fused scale tensor for mla bmm2 input.
+        sinks: additional value per head in the denominator of the softmax.
+
+        Note:
+        In MLA, the actual BMM1 and BMM2 scales applied would be fused as:
+        bmm1_scale = q_scale * k_scale * sm_scale / (head_dim_qk ** 0.5)
+        bmm2_scale = v_scale * o_scale
+        or,
+        bmm1_scale_log2_tensor = [q_scale * k_scale * sm_scale / (head_dim_qk ** 0.5) * M_LOG2E]
+        bmm2_scale_tensor = [v_scale * o_scale]
+
+        The two scale factors should be static constant for cuda graph capture.
+        Either (bmm1_scale, bmm2_scale) or (bmm1_scale_log2_tensor, bmm2_scale_tensor) should be provided.
+
+        For static constant scale factors, the scale factors should be provided as float.
+            - (bmm1_scale, bmm2_scale)
+        For on-device fused scale tensors, which could dynamically change, the scale factors should be provided as torch.Tensor.
+            - (bmm1_scale_log2_tensor, bmm2_scale_tensor)
+            - Currently, only fp8 tensor core operation supports this mode.
+        When both are provided, the dynamic scale factor tensors will be used.
+        """
+        enable_pdl = (
+            device_support_pdl(query.device) if enable_pdl is None else enable_pdl
+        )
+        run_func = get_trtllm_gen_fmha_module().trtllm_paged_attention_decode
+        sm_count = get_device_sm_count(query.device)
+
+        block_size = kv_cache.size(-2)
+        if (
+            block_size != 32 and block_size != 64
+        ):  # todo(Yingyi): add support for more block sizes?
+            raise ValueError(f"Supported block_size are 32 and 64, got {block_size}")
+
+        _check_trtllm_gen_mla_shape(
+            query,
+            kv_cache,
+            qk_nope_head_dim,
+            kv_lora_rank,
+            qk_rope_head_dim,
+            block_tables,
+            block_size,
+        )
+
+        if out is None:
+            out_shape = query.shape[:-1] + (kv_lora_rank,)
+            out = torch.empty(out_shape, dtype=torch.bfloat16, device=query.device)
+        else:
+            batch_size, _, num_q_heads, _ = query.shape
+            check_shape_dtype_device(
+                out,
+                [batch_size, num_q_heads, kv_lora_rank],
+                torch.bfloat16,
+                query.device,
+                "out",
+            )
+
+        if bmm1_scale_log2_tensor is not None and bmm2_scale_tensor is not None:
+            # dynamic scale factors
+            if (
+                query.dtype != torch.float8_e4m3fn
+                or kv_cache.dtype != torch.float8_e4m3fn
+            ):
+                raise ValueError(
+                    "Dynamic scale factors bmm1_scale_tensor and bmm2_scale_tensor are only supported for fp8 tensor core operation"
+                )
+
+        run_func(
+            out,
+            None,  # fp4 output not supported in wrapper api yet.
+            query,
+            kv_cache,
+            kv_cache,
             workspace_buffer,
             block_tables,
             seq_lens,
@@ -1865,499 +2376,11 @@ class TrtllmGenDecodeModule:
             -1,  # o_sf_scale
             -1,  # o_sf_vec_size
             0,  # o_sf_start_index
-            window_left,
-            self._sm_count,
+            -1,  # window_left
+            sm_count,
             enable_pdl,
-            workspace_size,
+            workspace_buffer.numel() * workspace_buffer.element_size(),
             sinks,
         )
         return out
-
-    def _plan(self, *args, **kwargs):
-        pass
-
-
-@functools.cache
-def get_trtllm_gen_decode_module(*args):
-    uri = get_batch_prefill_uri("trtllm-gen", *args)
-    module = TrtllmGenDecodeModule()
-
-    @register_custom_op(
-        f"flashinfer::{uri}_ragged_run",
-        mutates_args=(
-            "float_workspace_buffer",
-            "int_workspace_buffer",
-            "o",
-            "maybe_lse",
-        ),
-    )
-    def paged_run(
-        float_workspace_buffer: torch.Tensor,
-        int_workspace_buffer: torch.Tensor,
-        plan_info_vec: List[int],
-        q: torch.Tensor,
-        paged_k_cache: torch.Tensor,
-        paged_v_cache: torch.Tensor,
-        qo_indptr: torch.Tensor,
-        paged_kv_indptr: torch.Tensor,
-        paged_kv_indices: torch.Tensor,
-        paged_kv_last_page_len: torch.Tensor,
-        o: torch.Tensor,
-        maybe_lse: Optional[torch.Tensor],
-        mask_mode: int,
-        layout: int,
-        window_left: int,
-        enable_pdl: bool,
-        maybe_custom_mask: Optional[torch.Tensor],
-        maybe_mask_indptr: Optional[torch.Tensor],
-        maybe_alibi_slopes: Optional[torch.Tensor],
-        maybe_prefix_len_ptr: Optional[torch.Tensor],
-        maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
-        maybe_max_item_len_ptr: Optional[torch.Tensor],
-        logits_soft_cap: float,
-        sm_scale: float,
-        scale_q: Optional[torch.Tensor],
-        scale_k: Optional[torch.Tensor],
-        scale_v: Optional[torch.Tensor],
-        rope_scale: float,
-        rope_theta: float,
-        token_pos_in_items_len: int,
-        workspace_size: int,
-        paged_kv_cache: Optional[torch.Tensor] = None,
-        num_qo_heads: Optional[int] = None,
-        num_kv_heads: Optional[int] = None,
-        block_tables: Optional[torch.Tensor] = None,
-        kv_lens_buffer: Optional[torch.Tensor] = None,
-        page_size: Optional[int] = None,
-        max_kv_len: Optional[int] = None,
-        sinks: Optional[torch.Tensor] = None,
-    ) -> None:
-        assert maybe_lse is None
-        assert paged_kv_cache is not None
-        assert num_qo_heads is not None
-        assert num_kv_heads is not None
-        assert block_tables is not None
-        assert kv_lens_buffer is not None
-        assert page_size is not None
-        assert max_kv_len is not None
-        assert enable_pdl is not None
-        o = module._paged_run(
-            q.contiguous(),  # NOTE(Siyuan): without contiguous, the result is incorrect
-            paged_k_cache,
-            paged_v_cache,
-            int_workspace_buffer,
-            block_tables,
-            kv_lens_buffer,
-            max_kv_len,
-            sm_scale,
-            1.0,  # NOTE(Siyuan): update this to expose bmm2 scale
-            workspace_size,
-            window_left,
-            enable_pdl,
-            out=o,
-            sinks=sinks,
-        )
-
-    @register_fake_op(f"flashinfer::{uri}_paged_run")
-    def _fake_paged_run(
-        float_workspace_buffer: torch.Tensor,
-        int_workspace_buffer: torch.Tensor,
-        plan_info_vec: List[int],
-        q: torch.Tensor,
-        paged_k_cache: torch.Tensor,
-        paged_v_cache: torch.Tensor,
-        qo_indptr: torch.Tensor,
-        paged_kv_indptr: torch.Tensor,
-        paged_kv_indices: torch.Tensor,
-        paged_kv_last_page_len: torch.Tensor,
-        o: torch.Tensor,
-        maybe_lse: Optional[torch.Tensor],
-        mask_mode: int,
-        layout: int,
-        window_left: int,
-        enable_pdl: bool,
-        maybe_custom_mask: Optional[torch.Tensor],
-        maybe_mask_indptr: Optional[torch.Tensor],
-        maybe_alibi_slopes: Optional[torch.Tensor],
-        maybe_prefix_len_ptr: Optional[torch.Tensor],
-        maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
-        maybe_max_item_len_ptr: Optional[torch.Tensor],
-        logits_soft_cap: float,
-        sm_scale: float,
-        rope_scale: float,
-        rope_theta: float,
-        token_pos_in_items_len: int,
-        paged_kv_cache: Optional[torch.Tensor] = None,
-        num_qo_heads: Optional[int] = None,
-        num_kv_heads: Optional[int] = None,
-        block_tables: Optional[torch.Tensor] = None,
-        kv_lens_buffer: Optional[torch.Tensor] = None,
-        page_size: Optional[int] = None,
-        max_kv_len: Optional[int] = None,
-        sinks: Optional[torch.Tensor] = None,
-    ) -> None:
-        pass
-
-    # Register the module.
-    #
-    # Note that plan is not part of model logic. It should not be included in
-    # Cuda Graph or torch.compile. So, we don't provide a torch library for plan.
-    return SimpleNamespace(
-        plan=module._plan,
-        paged_run=paged_run,
-    )
-
-
-def trtllm_batch_decode_with_kv_cache(
-    query: torch.Tensor,
-    kv_cache: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
-    workspace_buffer: torch.Tensor,
-    block_tables: torch.Tensor,
-    seq_lens: torch.Tensor,
-    max_seq_len: int,
-    bmm1_scale: float,
-    bmm2_scale: float,  # todo(Yingyi): add dynamic scale tensor later
-    window_left: int = -1,
-    out: Optional[Union[torch.Tensor, FP4Tensor]] = None,
-    out_dtype: Optional[Union[torch.dtype, str]] = None,
-    o_sf_scale: Optional[float] = None,
-    o_sf_vec_size: Optional[int] = None,
-    sinks: Optional[List[torch.Tensor]] = None,
-    enable_pdl: bool = None,
-    q_len_per_req: Optional[int] = 1,
-) -> Union[torch.Tensor, FP4Tensor]:
-    """
-    Parameters
-    ----------
-    query : torch.Tensor
-        query tensor with shape [num_tokens, num_heads, head_dim], num_tokens = batch_size * q_len_per_request
-
-    kv_cache : Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
-        If kv_cache is a single tensor, it should be a tensor with shape [num_pages, 1 or 2, num_kv_heads, page_size, head_dim]
-        If kv_cache is a tuple of two tensors, it should be a tuple of two tensors with shape [num_pages, num_kv_heads, page_size, head_dim]
-
-    workspace_buffer : torch.Tensor. Must be initialized to 0 for its first use.
-        workspace
-
-    block_tables : torch.Tensor
-        page_table of kv cache, [batch_size, num_pages]
-
-    seq_lens : torch.Tensor
-        A uint32 1D tensor indicating the kv sequence length of each prompt. shape: ``[batch_size]``
-
-    max_seq_len : int
-        max sequence length for kv_cache
-
-    bmm1_scale : float
-        fused scale for bmm1 input.
-
-    bmm2_scale : float
-        fused scale for bmm2 input.
-
-    window_left : int = -1
-        The left (inclusive) window size for the attention window, when set to ``-1``, the window
-        size will be set to the full length of the sequence. Defaults to ``-1``.
-
-    out :  Optional[Union[torch.Tensor, FP4Tensor]] = None
-        output tensor, if not provided, will be allocated with ``out_dtype``, if ``out_dtype`` is not provided, will use the type of ``query``.
-
-    out_dtype : Optional[Union[torch.dtype, str]] = None
-        output dtype, if not provided, will use the type of ``out``. For nvfp4, use string ``nvfp4``.
-
-    o_sf_scale : Optional[float] = None
-        scale for nvfp4 output tensor scale factor.
-
-    o_sf_vec_size : Optional[int] = None
-        vector size for nvfp4 output tensor scale factor.
-
-    sinks : Optional[List[torch.Tensor]] = None
-        additional value per head in the denominator of the softmax.
-
-    enable_pdl : bool
-        Whether to enable Programmatic Dependent Launch (PDL). See https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
-        Only supported for >= sm90, and currently only for FA2, CUDA core, and trtllm-gen decode.
-
-    Returns
-    -------
-    out : Union[torch.Tensor, FP4Tensor]
-        output torch.Tensor or FP4Tensor.
-    """
-    enable_pdl = device_support_pdl(query.device) if enable_pdl is None else enable_pdl
-
-    if isinstance(kv_cache, tuple):
-        k_cache, v_cache = kv_cache
-    else:
-        if kv_cache.shape[1] == 1:
-            k_cache, v_cache = kv_cache, kv_cache
-        else:
-            assert kv_cache.shape[1] == 2, (
-                "When kv_cache is a single tensor, the second dimension must be 1 or 2"
-            )
-            # NOTE(Zihao): unbind transforms [num_pages, 2, ...] to ([num_pages, ...], [num_pages, ...])
-            # it doesn't change underlying storage
-            k_cache, v_cache = kv_cache.unbind(dim=1)
-
-    run_func = get_trtllm_gen_fmha_module().trtllm_paged_attention_decode
-    sm_count = get_device_sm_count(query.device)
-
-    if out_dtype == "nvfp4" or (out_dtype is None and isinstance(out, FP4Tensor)):
-        assert query.dtype == torch.float8_e4m3fn, (
-            "query must be fp8 when out_dtype is nvfp4."
-        )
-        assert o_sf_scale is not None
-        assert o_sf_vec_size in [None, 16], "only o_sf_vec_size = 16 is supported"
-        o_sf_vec_size = o_sf_vec_size or 16
-
-        fp4_out_shape = query.shape[:-1] + (ceil_div(query.shape[-1], 2),)
-
-        if isinstance(out, FP4Tensor):
-            fp4_out_scale_shape = (
-                out.scale.shape[0],
-                round_up(query.shape[1] * query.shape[2] // o_sf_vec_size, 4),
-            )
-            out_scale_factor = out.scale
-            o_sf_start_index = out.scale_start_index
-            out = out.data
-            # out_dtype may be None
-            out_dtype = out_dtype or "nvfp4"
-        elif out is None:
-            fp4_out_scale_shape = (
-                round_up(query.shape[0], 128),
-                round_up(query.shape[1] * query.shape[2] // o_sf_vec_size, 4),
-            )
-            out_scale_factor = torch.empty(
-                fp4_out_scale_shape, dtype=torch.float8_e4m3fn, device=query.device
-            )
-            o_sf_start_index = 0
-            out = torch.empty(fp4_out_shape, dtype=torch.uint8, device=query.device)
-        else:
-            raise ValueError(f"Invalid out: {out}")
-
-        assert out_dtype == "nvfp4"
-        assert isinstance(out, torch.Tensor)
-
-        # Use uint8 as the container dtype to compliant with next fp4 gemm.
-        check_shape_dtype_device(out, fp4_out_shape, torch.uint8, query.device, "out")
-
-        check_shape_dtype_device(
-            out_scale_factor,
-            fp4_out_scale_shape,
-            torch.float8_e4m3fn,
-            query.device,
-            "out_scale_factor",
-        )
-
-        # Check o_sf_start_index is valid
-        if (
-            o_sf_start_index < 0
-            or o_sf_start_index + out.shape[0] > out_scale_factor.shape[0]
-        ):
-            raise ValueError(
-                f"o_sf_start_index is out of the valid range of out_scale_factor. "
-                f"o_sf_start_index={o_sf_start_index}, out.shape[0]={out.shape[0]}, "
-                f"out_scale_factor.shape[0]={out_scale_factor.shape[0]}"
-            )
-
-    elif isinstance(out_dtype, torch.dtype) or out_dtype is None:
-        assert o_sf_scale is None
-        assert o_sf_vec_size is None
-        out_scale_factor = None
-        o_sf_start_index = 0
-        if out_dtype is None:
-            out_dtype = out.dtype if out is not None else query.dtype
-        out = out if out is not None else torch.empty_like(query, dtype=out_dtype)
-        if out_dtype not in (query.dtype, torch.float16, torch.bfloat16):
-            raise ValueError(f"Unsupported out_dtype: {out_dtype}")
-        check_shape_dtype_device(out, query.shape, out_dtype, query.device, "out")
-    else:
-        raise ValueError(f"Invalid out_dtype: {out_dtype}")
-
-    run_func(
-        out,
-        out_scale_factor,
-        query.view(
-            query.size(0) // q_len_per_req, q_len_per_req, query.size(1), query.size(2)
-        ),
-        k_cache,
-        v_cache,
-        workspace_buffer,
-        block_tables,
-        seq_lens,
-        max_seq_len,
-        bmm1_scale,
-        bmm2_scale,
-        o_sf_scale or -1.0,
-        o_sf_vec_size or -1,
-        o_sf_start_index,
-        window_left,
-        sm_count,
-        enable_pdl,
-        workspace_buffer.numel() * workspace_buffer.element_size(),
-        sinks,
-    )
-
-    return (
-        out
-        if out_dtype != "nvfp4"
-        else FP4Tensor(out, out_scale_factor, o_sf_start_index, query.shape)
-    )
-
-
-def _check_trtllm_gen_mla_shape(
-    query,
-    kv_cache,
-    qk_nope_head_dim,
-    kv_lora_rank,
-    qk_rope_head_dim,
-    page_table,
-    page_size,
-):
-    if query.ndim != 4:
-        raise ValueError(f"Expected query.ndim == 4, got {query.ndim}")
-    if kv_cache.ndim != 4:
-        raise ValueError(f"Expected kv_cache.ndim == 4, got {kv_cache.ndim}")
-    if qk_nope_head_dim != 128:
-        raise ValueError(f"Expected qk_nope_head_dim == 128, got {qk_nope_head_dim}")
-    if kv_lora_rank != 512:
-        raise ValueError(f"Expected kv_lora_rank == 512, got {kv_lora_rank}")
-    if qk_rope_head_dim != 64:
-        raise ValueError(f"Expected qk_rope_head_dim == 64, got {qk_rope_head_dim}")
-
-    B_q, Q_len, H, D_q = query.shape
-    D_ckv = kv_cache.shape[3]
-    # if H != 128:
-    #     raise ValueError(f"Expected 128 heads for query, got {H}")
-    # todo(Yingyi): should we check num_heads == 128? Is this deepseek only?
-    if D_q != D_ckv or D_q != 576:
-        raise ValueError(
-            f"Expected head dim 576 for query and kv_cache, got {D_q} and {D_ckv}"
-        )
-
-    B_block_table, block_num = page_table.shape
-    block_size = page_size
-    if B_q != B_block_table:
-        raise ValueError(
-            f"Expected batch size {B_q} for query and block_table, got {B_q} and {B_block_table}"
-        )
-    if block_num % (128 / block_size) != 0:
-        raise ValueError(
-            f"Expected block_num % (128 / block_size) == 0, got {block_num=} and {block_size=}"
-        )
-
-
-def trtllm_batch_decode_with_kv_cache_mla(
-    query: torch.Tensor,
-    kv_cache: torch.Tensor,
-    workspace_buffer: torch.Tensor,
-    qk_nope_head_dim: int,
-    kv_lora_rank: int,
-    qk_rope_head_dim: int,
-    block_tables: torch.Tensor,
-    seq_lens: torch.Tensor,
-    max_seq_len: int,
-    out: Optional[torch.Tensor] = None,
-    bmm1_scale: Optional[float] = 1.0,
-    bmm2_scale: Optional[float] = 1.0,
-    bmm1_scale_log2_tensor: Optional[torch.Tensor] = None,
-    bmm2_scale_tensor: Optional[torch.Tensor] = None,
-    sinks: Optional[List[torch.Tensor]] = None,
-    enable_pdl: bool = None,
-) -> torch.Tensor:
-    """
-    Parameters:
-    query: [batch_size, q_len_per_request, num_heads, head_dim_qk], head_dim_qk = qk_nope_head_dim (kv_lora_rank) + qk_rope_head_dim, should be concated q_nope + q_rope; q_len_per_request is the MTP query length.
-    kv_cache: [num_pages, page_size, head_dim_ckv + head_dim_kpe], should be concated ckv_cache + kpe_cache
-    workspace_buffer: [num_semaphores, 4], used for multi_block mode. Must be initialized to 0 for its first use.
-    qk_nope_head_dim: qk_nope_head_dim, must be 128
-    kv_lora_rank: kv_lora_rank, must be 512
-    qk_rope_head_dim: qk_rope_head_dim, must be 64
-    block_tables: page_table of kv cache, [batch_size, num_pages]
-    seq_lens: query_len
-    max_seq_len: max sequence length for kv_cache
-    out: output tensor, if not provided, will be allocated internally
-    bmm1_scale: fused scale for mla bmm1 input.
-    bmm2_scale: fused scale for mla bmm2 input.
-    bmm1_scale_log2_tensor: On-device fused scale tensor for mla bmm1 input. Must be fused with * M_LOG2E before passing in.
-    bmm2_scale_tensor: On-device fused scale tensor for mla bmm2 input.
-    sinks: additional value per head in the denominator of the softmax.
-
-    Note:
-    In MLA, the actual BMM1 and BMM2 scales applied would be fused as:
-    bmm1_scale = q_scale * k_scale * sm_scale / (head_dim_qk ** 0.5)
-    bmm2_scale = v_scale * o_scale
-    or,
-    bmm1_scale_log2_tensor = [q_scale * k_scale * sm_scale / (head_dim_qk ** 0.5) * M_LOG2E]
-    bmm2_scale_tensor = [v_scale * o_scale]
-
-    The two scale factors should be static constant for cuda graph capture.
-    Either (bmm1_scale, bmm2_scale) or (bmm1_scale_log2_tensor, bmm2_scale_tensor) should be provided.
-
-    For static constant scale factors, the scale factors should be provided as float.
-        - (bmm1_scale, bmm2_scale)
-    For on-device fused scale tensors, which could dynamically change, the scale factors should be provided as torch.Tensor.
-        - (bmm1_scale_log2_tensor, bmm2_scale_tensor)
-        - Currently, only fp8 tensor core operation supports this mode.
-    When both are provided, the dynamic scale factor tensors will be used.
-    """
-    enable_pdl = device_support_pdl(query.device) if enable_pdl is None else enable_pdl
-    run_func = get_trtllm_gen_fmha_module().trtllm_paged_attention_decode
-    sm_count = get_device_sm_count(query.device)
-
-    block_size = kv_cache.size(-2)
-    if (
-        block_size != 32 and block_size != 64
-    ):  # todo(Yingyi): add support for more block sizes?
-        raise ValueError(f"Supported block_size are 32 and 64, got {block_size}")
-
-    _check_trtllm_gen_mla_shape(
-        query,
-        kv_cache,
-        qk_nope_head_dim,
-        kv_lora_rank,
-        qk_rope_head_dim,
-        block_tables,
-        block_size,
-    )
-
-    if out is None:
-        out_shape = query.shape[:-1] + (kv_lora_rank,)
-        out = torch.empty(out_shape, dtype=torch.bfloat16, device=query.device)
-    else:
-        batch_size, _, num_q_heads, _ = query.shape
-        check_shape_dtype_device(
-            out,
-            [batch_size, num_q_heads, kv_lora_rank],
-            torch.bfloat16,
-            query.device,
-            "out",
-        )
-
-    if bmm1_scale_log2_tensor is not None and bmm2_scale_tensor is not None:
-        # dynamic scale factors
-        if query.dtype != torch.float8_e4m3fn or kv_cache.dtype != torch.float8_e4m3fn:
-            raise ValueError(
-                "Dynamic scale factors bmm1_scale_tensor and bmm2_scale_tensor are only supported for fp8 tensor core operation"
-            )
-
-    run_func(
-        out,
-        None,  # fp4 output not supported in wrapper api yet.
-        query,
-        kv_cache,
-        kv_cache,
-        workspace_buffer,
-        block_tables,
-        seq_lens,
-        max_seq_len,
-        bmm1_scale,
-        bmm2_scale,
-        -1,  # o_sf_scale
-        -1,  # o_sf_vec_size
-        0,  # o_sf_start_index
-        -1,  # window_left
-        sm_count,
-        enable_pdl,
-        workspace_buffer.numel() * workspace_buffer.element_size(),
-        sinks,
-    )
-    return out
+# end of if IS_CUDA:

--- a/flashinfer/hip_utils.py
+++ b/flashinfer/hip_utils.py
@@ -259,26 +259,28 @@ def check_torch_rocm_compatibility() -> None:
 
     # ROCm version compatibility warning
     torch_rocm = version.hip
-    torch_rocm_major_minor = ".".join(torch_rocm.split(".")[:3])
+    torch_rocm_major_minor = ".".join(torch_rocm.split(".")[:2])
 
     # Try to detect system ROCm version
     system_rocm = get_system_rocm_version()
 
-    if system_rocm and torch_rocm_major_minor != system_rocm:
-        warnings.warn(
-            f"\n{'=' * 70}\n"
-            f"WARNING: ROCm version mismatch detected!\n\n"
-            f"  System ROCm version: {system_rocm}\n"
-            f"  PyTorch ROCm version: {torch_rocm_major_minor}\n\n"
-            f"This may cause runtime errors or crashes.\n\n"
-            f"To fix, reinstall PyTorch for your ROCm version:\n"
-            f"  pip install torch==2.7.1 --index-url "
-            f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{system_rocm}/\n\n"
-            f"Or if using uv:\n"
-            f"  export FLASHINFER_ROCM_VERSION={system_rocm}\n"
-            f"  uv pip install torch==2.7.1 --index-url "
-            f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{system_rocm}/\n"
-            f"{'=' * 70}",
-            RuntimeWarning,
-            stacklevel=2,
-        )
+    if system_rocm:
+        system_rocm_major_minor = ".".join(system_rocm.split(".")[:2])
+        if torch_rocm_major_minor != system_rocm_major_minor:
+            warnings.warn(
+                f"\n{'=' * 70}\n"
+                f"WARNING: ROCm version mismatch detected!\n\n"
+                f"  System ROCm version: {system_rocm}\n"
+                f"  PyTorch ROCm version: {torch_rocm_major_minor}\n\n"
+                f"This may cause runtime errors or crashes.\n\n"
+                f"To fix, reinstall PyTorch for your ROCm version:\n"
+                f"  pip install torch==2.7.1 --index-url "
+                f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{system_rocm}/\n\n"
+                f"Or if using uv:\n"
+                f"  export FLASHINFER_ROCM_VERSION={system_rocm}\n"
+                f"  uv pip install torch==2.7.1 --index-url "
+                f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{system_rocm}/\n"
+                f"{'=' * 70}",
+                RuntimeWarning,
+                stacklevel=2,
+            )

--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -41,7 +41,9 @@ if IS_CUDA:
     from .attention import (
         gen_customize_single_prefill_module as gen_customize_single_prefill_module,
     )
-    from .attention import gen_fmha_cutlass_sm100a_module as gen_fmha_cutlass_sm100a_module
+    from .attention import (
+        gen_fmha_cutlass_sm100a_module as gen_fmha_cutlass_sm100a_module,
+    )
     from .attention import gen_pod_module as gen_pod_module
     from .attention import gen_sampling_tvm_binding as gen_sampling_tvm_binding
     from .attention import gen_single_decode_module as gen_single_decode_module
@@ -58,6 +60,7 @@ if IS_CUDA:
     from .core import JitSpec as JitSpec
     from .core import build_jit_specs as build_jit_specs
     from .core import clear_cache_dir as clear_cache_dir
+    from .core import load_cuda_ops as load_cuda_ops
     from .core import gen_jit_spec as gen_jit_spec
     from .core import sm90a_nvcc_flags as sm90a_nvcc_flags
     from .core import sm100a_nvcc_flags as sm100a_nvcc_flags
@@ -105,6 +108,7 @@ elif IS_HIP:
     from .core import JitSpec as JitSpec
     from .core import build_jit_specs as build_jit_specs
     from .core import clear_cache_dir as clear_cache_dir
+    from .core import load_cuda_ops as load_cuda_ops
     from .core import gen_jit_spec as gen_jit_spec
 else:
     # CPU-only torch (no CUDA or HIP)

--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -17,17 +17,11 @@ if IS_CUDA:
     from .activation import gen_act_and_mul_module as gen_act_and_mul_module
     from .activation import get_act_and_mul_cu_str as get_act_and_mul_cu_str
     from .attention import cudnn_fmha_gen_module as cudnn_fmha_gen_module
-    from .attention import (
-        gen_batch_attention_module as gen_batch_attention_module,
-    )
-    from .attention import (
-        gen_batch_decode_mla_module as gen_batch_decode_mla_module,
-    )
+    from .attention import gen_batch_attention_module as gen_batch_attention_module
+    from .attention import gen_batch_decode_mla_module as gen_batch_decode_mla_module
     from .attention import gen_batch_decode_module as gen_batch_decode_module
     from .attention import gen_batch_mla_module as gen_batch_mla_module
-    from .attention import (
-        gen_batch_mla_tvm_binding as gen_batch_mla_tvm_binding,
-    )
+    from .attention import gen_batch_mla_tvm_binding as gen_batch_mla_tvm_binding
     from .attention import gen_batch_prefill_module as gen_batch_prefill_module
     from .attention import (
         gen_customize_batch_decode_module as gen_customize_batch_decode_module,
@@ -47,15 +41,11 @@ if IS_CUDA:
     from .attention import (
         gen_customize_single_prefill_module as gen_customize_single_prefill_module,
     )
-    from .attention import (
-        gen_fmha_cutlass_sm100a_module as gen_fmha_cutlass_sm100a_module,
-    )
+    from .attention import gen_fmha_cutlass_sm100a_module as gen_fmha_cutlass_sm100a_module
     from .attention import gen_pod_module as gen_pod_module
     from .attention import gen_sampling_tvm_binding as gen_sampling_tvm_binding
     from .attention import gen_single_decode_module as gen_single_decode_module
-    from .attention import (
-        gen_single_prefill_module as gen_single_prefill_module,
-    )
+    from .attention import gen_single_prefill_module as gen_single_prefill_module
     from .attention import get_batch_attention_uri as get_batch_attention_uri
     from .attention import get_batch_decode_mla_uri as get_batch_decode_mla_uri
     from .attention import get_batch_decode_uri as get_batch_decode_uri

--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -60,7 +60,6 @@ if IS_CUDA:
     from .core import JitSpec as JitSpec
     from .core import build_jit_specs as build_jit_specs
     from .core import clear_cache_dir as clear_cache_dir
-    from .core import load_cuda_ops as load_cuda_ops
     from .core import gen_jit_spec as gen_jit_spec
     from .core import sm90a_nvcc_flags as sm90a_nvcc_flags
     from .core import sm100a_nvcc_flags as sm100a_nvcc_flags

--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -1,132 +1,124 @@
-"""
-Copyright (c) 2024 by FlashInfer team.
+# SPDX-FileCopyrightText: 2024-2026 FlashInfer team.
+# SPDX-FileCopyrightText: 2025-2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
 
 import ctypes
 import functools
-import importlib.util
 import os
-from typing import Optional, Set
 
-# Re-export
-from . import cubin_loader
-from . import env as env
-from .activation import gen_act_and_mul_module as gen_act_and_mul_module
-from .activation import get_act_and_mul_cu_str as get_act_and_mul_cu_str
-from .attention import (
-    gen_batch_decode_mla_module as gen_batch_decode_mla_module,
-)
-from .attention import gen_batch_decode_module as gen_batch_decode_module
-from .attention import gen_batch_mla_module as gen_batch_mla_module
-from .attention import gen_batch_prefill_module as gen_batch_prefill_module
-from .attention import (
-    gen_customize_batch_decode_module as gen_customize_batch_decode_module,
-)
-from .attention import (
-    gen_customize_batch_prefill_module as gen_customize_batch_prefill_module,
-)
-from .attention import (
-    gen_customize_single_decode_module as gen_customize_single_decode_module,
-)
-from .attention import (
-    gen_customize_single_prefill_module as gen_customize_single_prefill_module,
-)
-from .attention import (
-    gen_fmha_cutlass_sm100a_module as gen_fmha_cutlass_sm100a_module,
-)
-from .attention import gen_pod_module as gen_pod_module
-from .attention import gen_single_decode_module as gen_single_decode_module
-from .attention import gen_single_prefill_module as gen_single_prefill_module
-from .attention import get_batch_attention_uri as get_batch_attention_uri
-from .attention import get_batch_decode_mla_uri as get_batch_decode_mla_uri
-from .attention import get_batch_decode_uri as get_batch_decode_uri
-from .attention import get_batch_mla_uri as get_batch_mla_uri
-from .attention import get_batch_prefill_uri as get_batch_prefill_uri
-from .attention import get_pod_uri as get_pod_uri
-from .attention import get_single_decode_uri as get_single_decode_uri
-from .attention import get_single_prefill_uri as get_single_prefill_uri
-from .core import JitSpec as JitSpec
-from .core import build_jit_specs as build_jit_specs
-from .core import clear_cache_dir, load_cuda_ops  # noqa: F401
-from .env import *
-from .utils import parallel_load_modules as parallel_load_modules
+from ..device_utils import IS_CUDA, IS_HIP
 
+if IS_CUDA:
+    # Re-export
+    from . import cubin_loader
+    from . import env as env
+    from .activation import gen_act_and_mul_module as gen_act_and_mul_module
+    from .activation import get_act_and_mul_cu_str as get_act_and_mul_cu_str
+    from .attention import cudnn_fmha_gen_module as cudnn_fmha_gen_module
+    from .attention import (
+        gen_batch_attention_module as gen_batch_attention_module,
+    )
+    from .attention import (
+        gen_batch_decode_mla_module as gen_batch_decode_mla_module,
+    )
+    from .attention import gen_batch_decode_module as gen_batch_decode_module
+    from .attention import gen_batch_mla_module as gen_batch_mla_module
+    from .attention import (
+        gen_batch_mla_tvm_binding as gen_batch_mla_tvm_binding,
+    )
+    from .attention import gen_batch_prefill_module as gen_batch_prefill_module
+    from .attention import (
+        gen_customize_batch_decode_module as gen_customize_batch_decode_module,
+    )
+    from .attention import (
+        gen_customize_batch_decode_tvm_binding as gen_customize_batch_decode_tvm_binding,
+    )
+    from .attention import (
+        gen_customize_batch_prefill_module as gen_customize_batch_prefill_module,
+    )
+    from .attention import (
+        gen_customize_batch_prefill_tvm_binding as gen_customize_batch_prefill_tvm_binding,
+    )
+    from .attention import (
+        gen_customize_single_decode_module as gen_customize_single_decode_module,
+    )
+    from .attention import (
+        gen_customize_single_prefill_module as gen_customize_single_prefill_module,
+    )
+    from .attention import (
+        gen_fmha_cutlass_sm100a_module as gen_fmha_cutlass_sm100a_module,
+    )
+    from .attention import gen_pod_module as gen_pod_module
+    from .attention import gen_sampling_tvm_binding as gen_sampling_tvm_binding
+    from .attention import gen_single_decode_module as gen_single_decode_module
+    from .attention import (
+        gen_single_prefill_module as gen_single_prefill_module,
+    )
+    from .attention import get_batch_attention_uri as get_batch_attention_uri
+    from .attention import get_batch_decode_mla_uri as get_batch_decode_mla_uri
+    from .attention import get_batch_decode_uri as get_batch_decode_uri
+    from .attention import get_batch_mla_uri as get_batch_mla_uri
+    from .attention import get_batch_prefill_uri as get_batch_prefill_uri
+    from .attention import get_pod_uri as get_pod_uri
+    from .attention import get_single_decode_uri as get_single_decode_uri
+    from .attention import get_single_prefill_uri as get_single_prefill_uri
+    from .attention import trtllm_gen_fmha_module as trtllm_gen_fmha_module
+    from .core import JitSpec as JitSpec
+    from .core import build_jit_specs as build_jit_specs
+    from .core import clear_cache_dir as clear_cache_dir
+    from .core import gen_jit_spec as gen_jit_spec
+    from .core import sm90a_nvcc_flags as sm90a_nvcc_flags
+    from .core import sm100a_nvcc_flags as sm100a_nvcc_flags
+    from .cubin_loader import setup_cubin_loader
 
-def _get_extension_path(name: str) -> Optional[str]:
-    """Try to find installed extension module"""
-    try:
-        spec = importlib.util.find_spec(name)
-        if spec and spec.origin:
-            return spec.origin
-        return None
-    except (ImportError, ModuleNotFoundError):
-        return None
+    @functools.cache
+    def get_cudnn_fmha_gen_module():
+        mod = cudnn_fmha_gen_module()
+        op = mod.build_and_load()
+        setup_cubin_loader(mod.get_library_path())
+        return op
 
-
-# noqa: F401
-has_prebuilt_ops = False
-from .core import logger
-
-# Try and Except to break circular dependencies
-try:
-    from ..__aot_prebuilt_uris__ import prebuilt_ops_uri
-except ImportError:
-    prebuilt_ops_uri = None
-
-try:
-    from .. import __config__
-
-    if __config__.get_info("aot_torch_exts_cuda"):
-        try:
-            from .. import flashinfer_kernels
-
-            has_prebuilt_ops = True
-            kernels_path = _get_extension_path("flashinfer.flashinfer_kernels")
-
-        except ImportError:
-            logger.warning(
-                "CUDA kernels were enabled in build but couldn't be imported"
-            )
-
-        # Only try to import SM90 kernels if they were enabled during build
-        if 90 in __config__.get_info("aot_torch_exts_cuda_archs"):
-            try:
-                from .. import flashinfer_kernels_sm90  # noqa: F401
-
-                has_prebuilt_ops = True
-                kernels_sm90_path = _get_extension_path(
-                    "flashinfer.flashinfer_kernels_sm90"
-                )
-
-            except ImportError:
-                logger.warning(
-                    "SM90 kernels were enabled in build but couldn't be imported"
-                )
-
-    if prebuilt_ops_uri is not None and __config__.get_info("aot_torch_exts_hip"):
-        try:
-            from .. import flashinfer_hip_kernels  # noqa: F401
-
-            logger.info("Loading prebuilt HIP kernels")
-            has_prebuilt_ops = True
-
-            kernels_hip_path = _get_extension_path("flashinfer.flashinfer_hip_kernels")
-
-        except ImportError as e:
-            print(e)
-            logger.warning("HIP kernels were enabled in build but couldn't be imported")
-
-except ImportError:
-    pass
+    cuda_lib_path = os.environ.get(
+        "CUDA_LIB_PATH", "/usr/local/cuda/targets/x86_64-linux/lib/"
+    )
+    if os.path.exists(f"{cuda_lib_path}/libcudart.so.12"):
+        ctypes.CDLL(f"{cuda_lib_path}/libcudart.so.12", mode=ctypes.RTLD_GLOBAL)
+elif IS_HIP:
+    # Re-export (HIP/ROCm backend - AMD-ported modules only)
+    from . import env as env
+    from .activation import gen_act_and_mul_module as gen_act_and_mul_module
+    from .activation import get_act_and_mul_cu_str as get_act_and_mul_cu_str
+    from .attention import gen_batch_decode_module as gen_batch_decode_module
+    from .attention import gen_batch_prefill_module as gen_batch_prefill_module
+    from .attention import (
+        gen_customize_batch_decode_module as gen_customize_batch_decode_module,
+    )
+    from .attention import (
+        gen_customize_batch_prefill_module as gen_customize_batch_prefill_module,
+    )
+    from .attention import (
+        gen_customize_single_decode_module as gen_customize_single_decode_module,
+    )
+    from .attention import (
+        gen_customize_single_prefill_module as gen_customize_single_prefill_module,
+    )
+    from .attention import gen_single_decode_module as gen_single_decode_module
+    from .attention import (
+        gen_single_prefill_module as gen_single_prefill_module,
+    )
+    from .attention import get_batch_decode_uri as get_batch_decode_uri
+    from .attention import get_batch_prefill_uri as get_batch_prefill_uri
+    from .attention import get_single_decode_uri as get_single_decode_uri
+    from .attention import get_single_prefill_uri as get_single_prefill_uri
+    from .core import JitSpec as JitSpec
+    from .core import build_jit_specs as build_jit_specs
+    from .core import clear_cache_dir as clear_cache_dir
+    from .core import gen_jit_spec as gen_jit_spec
+else:
+    # CPU-only torch (no CUDA or HIP)
+    raise RuntimeError(
+        "FlashInfer requires either CUDA or ROCm/HIP backend. "
+        "Detected CPU-only PyTorch installation."
+    )

--- a/flashinfer/jit/attention/pytorch.py
+++ b/flashinfer/jit/attention/pytorch.py
@@ -26,7 +26,6 @@ from ..core import JitSpec, gen_jit_spec, logger, sm90a_nvcc_flags, sm100a_nvcc_
 from ...jit.cubin_loader import get_cubin
 from ..utils import (
     dtype_map,
-    dtype_map_hip,
     filename_safe_dtype_map,
     mask_mode_literal,
     pos_encoding_mode_literal,
@@ -1022,15 +1021,9 @@ def gen_customize_single_decode_module(
         "additional_params_setter": additional_params_setter,
         "variant_decl": variant_decl,
         "variant_name": variant_name,
-        "dtype_q": (
-            dtype_map_hip[dtype_q] if check_hip_availability() else dtype_map[dtype_q]
-        ),
-        "dtype_kv": (
-            dtype_map_hip[dtype_kv] if check_hip_availability() else dtype_map[dtype_kv]
-        ),
-        "dtype_o": (
-            dtype_map_hip[dtype_o] if check_hip_availability() else dtype_map[dtype_o]
-        ),
+        "dtype_q": dtype_map[dtype_q],
+        "dtype_kv": dtype_map[dtype_kv],
+        "dtype_o": dtype_map[dtype_o],
         "head_dim_qk": head_dim_qk,
         "head_dim_vo": head_dim_vo,
         "pos_encoding_mode": pos_encoding_mode_literal[pos_encoding_mode],
@@ -1052,13 +1045,10 @@ def gen_customize_single_decode_module(
         **kwargs,
     )
     write_if_different(dest_path, source)
+
     for filename in [
-        "single_decode_hip.cu" if check_hip_availability() else "single_decode.cu",
-        (
-            "single_decode_jit_pybind_hip.cu"
-            if check_hip_availability()
-            else "single_decode_jit_pybind.cu"
-        ),
+        "single_decode.cu",
+        "single_decode_jit_pybind.cu",
     ]:
         src_path = jit_env.FLASHINFER_CSRC_DIR / filename
         dest_path = gen_directory / filename
@@ -1067,11 +1057,7 @@ def gen_customize_single_decode_module(
             source = f.read()
         write_if_different(dest_path, source)
 
-    generated_config_path = (
-        gen_directory / "single_decode_config_hip.inc"
-        if check_hip_availability()
-        else gen_directory / "single_decode_config.inc"
-    )
+    generated_config_path = gen_directory / "single_decode_config.inc"
     write_if_different(generated_config_path, generated_inc_str)
 
     return gen_jit_spec(uri, source_paths)
@@ -1275,18 +1261,10 @@ def gen_customize_batch_decode_module(
         "additional_params_setter": additional_params_setter,
         "variant_decl": variant_decl,
         "variant_name": variant_name,
-        "dtype_q": (
-            dtype_map_hip[dtype_q] if check_hip_availability() else dtype_map[dtype_q]
-        ),
-        "dtype_kv": (
-            dtype_map_hip[dtype_kv] if check_hip_availability() else dtype_map[dtype_kv]
-        ),
-        "dtype_o": (
-            dtype_map_hip[dtype_o] if check_hip_availability() else dtype_map[dtype_o]
-        ),
-        "idtype": (
-            dtype_map_hip[idtype] if check_hip_availability() else dtype_map[idtype]
-        ),
+        "dtype_q": dtype_map[dtype_q],
+        "dtype_kv": dtype_map[dtype_kv],
+        "dtype_o": dtype_map[dtype_o],
+        "idtype": dtype_map[idtype],
         "head_dim_qk": head_dim_qk,
         "head_dim_vo": head_dim_vo,
         "pos_encoding_mode": pos_encoding_mode_literal[pos_encoding_mode],
@@ -1314,12 +1292,8 @@ def gen_customize_batch_decode_module(
     write_if_different(dest_path, source)
 
     for filename in [
-        "batch_decode_hip.cu" if check_hip_availability() else "batch_decode.cu",
-        (
-            "batch_decode_jit_pybind_hip.cu"
-            if check_hip_availability()
-            else "batch_decode_jit_pybind.cu"
-        ),
+        "batch_decode.cu",
+        "batch_decode_jit_pybind.cu",
     ]:
         src_path = jit_env.FLASHINFER_CSRC_DIR / filename
         dest_path = gen_directory / filename

--- a/flashinfer/jit/attention/pytorch_hip.py
+++ b/flashinfer/jit/attention/pytorch_hip.py
@@ -80,7 +80,7 @@ def get_single_prefill_uri(
 ) -> str:
     if backend == "fa3":
         logger.warning(
-            f"FA3 backend not supported on ROCm. The backend argument will be ignored."
+            "FA3 backend not supported on ROCm. The backend argument will be ignored."
         )
     return (
         f"single_prefill_with_kv_cache_dtype_q_{filename_safe_dtype_map[dtype_q]}_"
@@ -110,7 +110,7 @@ def get_batch_prefill_uri(
 ) -> str:
     if backend == "fa3":
         logger.warning(
-            f"FA3 backend not supported on ROCm. The backend argument will be ignored."
+            "FA3 backend not supported on ROCm. The backend argument will be ignored."
         )
     return (
         f"batch_prefill_with_kv_cache_dtype_q_{filename_safe_dtype_map[dtype_q]}_"

--- a/flashinfer/jit/attention/pytorch_hip.py
+++ b/flashinfer/jit/attention/pytorch_hip.py
@@ -163,7 +163,7 @@ def gen_single_decode_module(
         ],  # additional_scalar_names
         ["double", "double", "double", "double"],  # additional_scalar_dtypes
         f"DefaultAttention<false, {str(use_sliding_window).lower()}, {str(use_logits_soft_cap).lower()}, {str(pos_encoding_mode == 2).lower()}>",  # variant_name
-        ("#include<flashinfer/attention/generic/variants.cuh>"),  # variant_decl
+        "#include<flashinfer/attention/generic/variants.cuh>",  # variant_decl
         pos_encoding_mode=pos_encoding_mode,
         use_sliding_window=use_sliding_window,
         use_logits_soft_cap=use_logits_soft_cap,
@@ -275,7 +275,7 @@ def gen_batch_decode_module(
         ],  # additional_scalar_names
         ["double", "double", "double", "double"],  # additional_scalar_dtypes
         f"DefaultAttention<false, {str(use_sliding_window).lower()}, {str(use_logits_soft_cap).lower()}, {str(pos_encoding_mode == 2).lower()}>",  # variant_name
-        ("#include<flashinfer/attention/generic/variants.cuh>"),  # variant_decl
+        "#include<flashinfer/attention/generic/variants.cuh>",  # variant_decl
         pos_encoding_mode=pos_encoding_mode,
         use_sliding_window=use_sliding_window,
         use_logits_soft_cap=use_logits_soft_cap,
@@ -426,7 +426,7 @@ def gen_customize_single_decode_module(
     write_if_different(dest_path, source)
     for filename in [
         "single_decode.cu",
-        ("single_decode_jit_pybind.cu"),
+        "single_decode_jit_pybind.cu",
     ]:
         src_path = FLASHINFER_CSRC_DIR / filename
         dest_path = gen_directory / filename
@@ -515,8 +515,8 @@ def gen_customize_single_prefill_module(
             write_if_different(dest_path, source)
 
         for filename in [
-            ("single_prefill.cu"),
-            ("single_prefill_jit_pybind.cu"),
+            "single_prefill.cu",
+            "single_prefill_jit_pybind.cu",
         ]:
             src_path = FLASHINFER_CSRC_DIR / filename
             dest_path = gen_directory / filename

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -191,13 +191,22 @@ def gen_jit_spec(
     cuda_cflags = [
         "-O3",
         "-std=c++17",
-        f"--threads={os.environ.get('FLASHINFER_NVCC_THREADS', '1')}",
-        "-use_fast_math",
         "-DFLASHINFER_ENABLE_F16",
         "-DFLASHINFER_ENABLE_BF16",
         "-DFLASHINFER_ENABLE_FP8_E4M3",
         "-DFLASHINFER_ENABLE_FP8_E5M2",
     ]
+    # Add CUDA-specific nvcc flags
+    if IS_CUDA:
+        cuda_cflags += [
+            f"--threads={os.environ.get('FLASHINFER_NVCC_THREADS', '1')}",
+            "-use_fast_math",
+        ]
+    elif IS_HIP:
+        cuda_cflags += [
+            "-ffast-math",  # HIP equivalent of -use_fast_math
+        ]
+
     if verbose:
         if not IS_HIP:
             cuda_cflags += [

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -26,7 +26,7 @@ from torch.utils.cpp_extension import (
 if IS_CUDA:
     from torch.utils.cpp_extension import CUDA_HOME, _get_cuda_arch_flags
 elif IS_HIP:
-    from torch.utils.cpp_extension import ROCM_HOME, _get_rocm_arch_flags
+    from torch.utils.cpp_extension import ROCM_HOME
 
 from . import env as jit_env
 
@@ -127,7 +127,6 @@ def generate_ninja_build_for_op(
             "$common_cflags",
             "-fPIC",
         ]
-        cuda_cflags += _get_rocm_arch_flags(extra_cuda_cflags)
         if extra_cuda_cflags is not None:
             cuda_cflags += extra_cuda_cflags
 
@@ -238,9 +237,6 @@ def generate_ninja_build_for_op(
             "  depfile = $out.d",
             "  deps = gcc",
             "",
-            "rule link",
-            "  command = $cxx $in $ldflags -o $out",
-            "",
         ]
 
     # Add nvcc linking rule for device code
@@ -270,7 +266,7 @@ def generate_ninja_build_for_op(
         cmd = ""
         if is_cuda and IS_CUDA:
             cmd = "cuda_compile"
-        elif is_cuda and not IS_HIP:
+        elif is_cuda and IS_HIP:
             cmd = "hip_compile"
         else:
             cmd = "compile"
@@ -282,7 +278,6 @@ def generate_ninja_build_for_op(
     lines.append("")
     link_rule = "nvcc_link" if needs_device_linking else "link"
     lines.append(f"build $name/$name.so: {link_rule} " + " ".join(objects))
-    lines.append("build $name/$name.so: link " + " ".join(objects))
     lines.append("default $name/$name.so")
     lines.append("")
 

--- a/flashinfer/jit/utils.py
+++ b/flashinfer/jit/utils.py
@@ -48,8 +48,8 @@ dtype_cutlass_map = {
 dtype_map_hip = {
     torch.float16: "__half",
     torch.bfloat16: "__hip_bfloat16",
-    torch.float8_e4m3fnuz: "__hip_fp8_e4m3_fnuz",
-    torch.float8_e5m2fnuz: "__hip_fp8_e5m2_fnuz",
+    torch.float8_e4m3fn: "__nv_fp8_e4m3",
+    torch.float8_e5m2: "__nv_fp8_e5m2",
     torch.int8: "int8_t",
     torch.uint8: "uint8_t",
     torch.int32: "int32_t",

--- a/flashinfer/jit/utils.py
+++ b/flashinfer/jit/utils.py
@@ -48,8 +48,8 @@ dtype_cutlass_map = {
 dtype_map_hip = {
     torch.float16: "__half",
     torch.bfloat16: "__hip_bfloat16",
-    torch.float8_e4m3fn: "__nv_fp8_e4m3",
-    torch.float8_e5m2: "__nv_fp8_e5m2",
+    torch.float8_e4m3fn: "__hip_fp8_e4m3_fnuz",
+    torch.float8_e5m2: "__hip_fp8_e5m2_fnuz",
     torch.int8: "int8_t",
     torch.uint8: "uint8_t",
     torch.int32: "int32_t",

--- a/flashinfer/jit/utils.py
+++ b/flashinfer/jit/utils.py
@@ -1,18 +1,7 @@
-"""
-Copyright (c) 2024 by FlashInfer team.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# SPDX-FileCopyrightText: 2024-2026 FlashInfer team.
+# SPDX-FileCopyrightText: 2025-2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 import pathlib
 
@@ -30,32 +19,6 @@ def write_if_different(path: pathlib.Path, content: str) -> None:
         f.write(content)
 
 
-def parallel_load_modules(
-    load_module_func_args: List[Tuple[Callable, List[Any]]],
-):
-    threads = []
-    exceptions = []
-
-    def wrapper(func, args):
-        try:
-            func(*args)
-        except Exception as e:
-            exceptions.append((func, e))
-
-    for func, args in load_module_func_args:
-        thread = threading.Thread(target=wrapper, args=(func, args))
-        thread.start()
-        threads.append(thread)
-
-    for thread in threads:
-        thread.join()
-
-    if exceptions:
-        for func, e in exceptions:
-            print(f"Exception occurred in {func.__name__}: {e}")
-        raise RuntimeError("One or more exceptions occurred during module loading")
-
-
 dtype_map = {
     torch.float16: "half",
     torch.bfloat16: "nv_bfloat16",
@@ -67,6 +30,19 @@ dtype_map = {
     torch.uint32: "uint32_t",
     torch.int64: "int64_t",
     torch.uint64: "uint64_t",
+}
+
+dtype_cutlass_map = {
+    torch.float16: "cutlass::half_t",
+    torch.bfloat16: "cutlass::bfloat16_t",
+    torch.float8_e4m3fn: "cutlass::float_e4m3_t",
+    torch.float8_e5m2: "cutlass::float_e5m2_t",
+    torch.int8: "cutlass::int8_t",
+    torch.uint8: "cutlass::uint8_t",
+    torch.int32: "cutlass::int32_t",
+    torch.uint32: "cutlass::uint32_t",
+    torch.int64: "cutlass::int64_t",
+    torch.uint64: "cutlass::uint64_t",
 }
 
 dtype_map_hip = {
@@ -85,8 +61,8 @@ dtype_map_hip = {
 filename_safe_dtype_map = {
     torch.float16: "f16",
     torch.bfloat16: "bf16",
-    torch.float8_e4m3fnuz: "e4m3fnuz",
-    torch.float8_e5m2fnuz: "e5m2fnuz",
+    torch.float8_e4m3fn: "e4m3",
+    torch.float8_e5m2: "e5m2",
     torch.int8: "i8",
     torch.uint8: "u8",
     torch.int32: "i32",

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -37,29 +37,7 @@ def gen_norm_module() -> JitSpec:
 
 @functools.cache
 def get_norm_module():
-    global _norm_module
-    if _norm_module is None:
-        if has_prebuilt_ops:
-            _kernels = torch.ops.flashinfer_hip_kernels
-
-            _norm_module = _kernels
-        else:
-            _norm_module = load_cuda_ops(
-                "norm",
-                [
-                    FLASHINFER_CSRC_DIR / "norm.cu",
-                    FLASHINFER_CSRC_DIR / "flashinfer_norm_ops.cu",
-                ],
-            )
-    return _norm_module
-
-
-@cache
-def get_module_attr(attr: str) -> Any:
-    global _norm_module
-    if _norm_module is None:
-        get_norm_module()
-    return getattr(_norm_module, attr).default
+    return gen_norm_module().build_and_load()
 
 
 def rmsnorm(

--- a/flashinfer/page.py
+++ b/flashinfer/page.py
@@ -43,29 +43,7 @@ def gen_page_module() -> JitSpec:
 
 @functools.cache
 def get_page_module():
-    global _page_module
-    if _page_module is None:
-        if has_prebuilt_ops:
-            _kernels = torch.ops.flashinfer_hip_kernels
-
-            _page_module = _kernels
-        else:
-            _page_module = load_cuda_ops(
-                "page",
-                [
-                    FLASHINFER_CSRC_DIR / "page.cu",
-                    FLASHINFER_CSRC_DIR / "flashinfer_page_ops.cu",
-                ],
-            )
-    return _page_module
-
-
-@cache
-def get_module_attr(attr: str) -> Any:
-    global _page_module
-    if _page_module is None:
-        get_page_module()
-    return getattr(_page_module, attr).default
+    return gen_page_module().build_and_load()
 
 
 def block_sparse_indices_to_vector_sparse_offsets(

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -18,419 +18,698 @@ import functools
 import logging
 import math
 from types import SimpleNamespace
-from typing import Any, List, Literal, Optional, Tuple, Union, overload
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union, overload
 
 import torch
 
 from .jit import (
     gen_batch_prefill_module,
     gen_customize_batch_prefill_module,
+    gen_fmha_cutlass_sm100a_module,
     gen_single_prefill_module,
     get_batch_prefill_uri,
     get_single_prefill_uri,
-    has_prebuilt_ops,
-    prebuilt_ops_uri,
+    setup_cubin_loader,
+    trtllm_gen_fmha_module,
 )
+from .cudnn import cudnn_batch_prefill_with_kv_cache
 from .page import block_sparse_indices_to_vector_sparse_offsets, get_seq_lens
 from .quantization import packbits, segment_packbits
 from .utils import (
+    FP4Tensor,
     MaskMode,
     PosEncodingMode,
     TensorLayout,
     _check_cached_qkv_data_type,
     _check_kv_layout,
     _check_pos_encoding_mode,
-    _check_shape_dtype_device,
+    check_shape_dtype_device,
     _get_cache_alibi_slopes_buf,
     _get_cache_buf,
     _unpack_paged_kv_cache,
     canonicalize_torch_dtype,
     determine_attention_backend,
+    device_support_pdl,
+    get_device_sm_count,
     is_float8,
+    is_sm100a_supported,
     register_custom_op,
     register_fake_op,
+    ceil_div,
+    round_up,
 )
 
-_single_prefill_modules = {}
-_single_prefill_sm90_modules = {}
-_batch_prefill_modules = {}
-_batch_prefill_sm90_modules = {}
-_batch_prefill_jit_modules = {}
+
+@functools.cache
+def get_fmha_module(
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+    dtype_o: torch.dtype,
+    dtype_idx: torch.dtype,
+    head_dim_qk: int,
+    head_dim_vo: int,
+    pos_encoding_mode: int,
+    use_sliding_window: bool,
+    use_logits_soft_cap: bool,
+    use_fp16_qk_reduction: bool = False,
+):
+    if is_sm100a_supported(torch.device("cuda")):
+        return gen_fmha_cutlass_sm100a_module(
+            dtype_q,
+            dtype_kv,
+            dtype_o,
+            dtype_idx,
+            head_dim_qk,
+            head_dim_vo,
+            pos_encoding_mode,
+            use_sliding_window,
+            use_logits_soft_cap,
+        ).build_and_load()
+    else:
+        raise ValueError("SM100A is not supported on this device")
 
 
-def get_single_prefill_module(backend):
-    def backend_module(*args):
-        global _single_prefill_modules, _single_prefill_sm90_modules
-        modules_dict = (
-            _single_prefill_modules
-            if backend == "fa2"
-            else _single_prefill_sm90_modules
-        )
-        if args not in modules_dict:
-            uri = get_single_prefill_uri(backend, *args)
-            if has_prebuilt_ops and uri in prebuilt_ops_uri:
-                if backend == "fa2":
-                    _kernels = torch.ops.flashinfer_hip_kernels
+def make_hashable_cache(func):
+    """
+    Decorator that converts unhashable arguments (like lists) to hashable ones (tuples)
+    before applying functools.cache.
+    """
 
-                    run_func = _kernels.single_prefill_with_kv_cache.default
-                else:
-                    _kernels_sm90 = torch.ops.flashinfer_kernels_sm90
+    @functools.cache
+    def cached_wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
 
-                    run_func = _kernels_sm90.single_prefill_with_kv_cache_sm90.default
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        # Convert unhashable arguments to hashable ones
+        hashable_args = []
+        for arg in args:
+            if isinstance(arg, list):
+                hashable_args.append(tuple(arg))
             else:
-                module = gen_single_prefill_module(backend, *args).build_and_load()
-                run_func = module.run.default
+                hashable_args.append(arg)
 
-            # torch library for single_prefill_with_kv_cache
-            @register_custom_op(
-                f"flashinfer::{uri}_run", mutates_args=("tmp", "o", "maybe_lse")
-            )
-            def run_single_prefill(
-                q: torch.Tensor,
-                k: torch.Tensor,
-                v: torch.Tensor,
-                tmp: torch.Tensor,
-                o: torch.Tensor,
-                maybe_lse: Optional[torch.Tensor],
-                mask_mode: int,
-                layout: int,
-                window_left: int,
-                maybe_packed_custom_mask: Optional[torch.Tensor],
-                maybe_alibi_slopes: Optional[torch.Tensor],
-                logits_soft_cap: float,
-                sm_scale: float,
-                rope_scale: float,
-                rope_theta: float,
-            ) -> None:
-                if backend == "fa3":
-                    run_func(
-                        q,
-                        k,
-                        v,
-                        tmp,
-                        o,
-                        maybe_lse,
-                        mask_mode,
-                        layout,
-                        window_left,
-                        logits_soft_cap,
-                        sm_scale,
-                    )
-                else:
-                    run_func(
-                        q,
-                        k,
-                        v,
-                        tmp,
-                        o,
-                        maybe_lse,
-                        mask_mode,
-                        layout,
-                        window_left,
-                        maybe_packed_custom_mask,
-                        maybe_alibi_slopes,
-                        logits_soft_cap,
-                        sm_scale,
-                        1.0 / rope_scale,  # rope_rcp_scale
-                        1.0 / rope_theta,  # rope_rcp_theta
-                    )
-                return o
-
-            @register_fake_op(f"flashinfer::{uri}_run")
-            def _fake_run_single_prefill(
-                q: torch.Tensor,
-                k: torch.Tensor,
-                v: torch.Tensor,
-                tmp: torch.Tensor,
-                o: torch.Tensor,
-                maybe_lse: Optional[torch.Tensor],
-                mask_mode: int,
-                layout: int,
-                window_left: int,
-                maybe_packed_custom_mask: Optional[torch.Tensor],
-                maybe_alibi_slopes: Optional[torch.Tensor],
-                logits_soft_cap: float,
-                sm_scale: float,
-                rope_scale: float,
-                rope_theta: float,
-            ) -> None:
-                pass
-
-            # Register the module
-            modules_dict[args] = SimpleNamespace(run=run_single_prefill)
-
-        return modules_dict[args]
-
-    return backend_module
-
-
-def get_batch_prefill_module(backend):
-    def backend_module(*args):
-        global _batch_prefill_modules, _batch_prefill_sm90_modules
-        modules_dict = (
-            _batch_prefill_modules if backend == "fa2" else _batch_prefill_sm90_modules
-        )
-        if args not in modules_dict:
-            uri = get_batch_prefill_uri(backend, *args)
-            if has_prebuilt_ops and uri in prebuilt_ops_uri:
-                if backend == "fa2":
-                    _kernels = torch.ops.flashinfer_hip_kernels
-
-                    plan_func = _kernels.batch_prefill_with_kv_cache_plan.default
-                    ragged_run_func = (
-                        _kernels.batch_prefill_with_ragged_kv_cache_run.default
-                    )
-                    paged_run_func = (
-                        _kernels.batch_prefill_with_paged_kv_cache_run.default
-                    )
-                else:
-                    _kernels_sm90 = torch.ops.flashinfer_kernels_sm90
-
-                    plan_func = (
-                        _kernels_sm90.batch_prefill_with_kv_cache_sm90_plan.default
-                    )
-                    ragged_run_func = _kernels_sm90.batch_prefill_with_ragged_kv_cache_sm90_run.default
-                    paged_run_func = (
-                        _kernels_sm90.batch_prefill_with_paged_kv_cache_sm90_run.default
-                    )
+        hashable_kwargs = {}
+        for key, value in kwargs.items():
+            if isinstance(value, list):
+                hashable_kwargs[key] = tuple(value)
             else:
-                module = gen_batch_prefill_module(backend, *args).build_and_load()
-                plan_func = module.plan.default
-                ragged_run_func = module.ragged_run.default
-                paged_run_func = module.paged_run.default
+                hashable_kwargs[key] = value
 
-            # torch library for ragged_run
+        return cached_wrapper(*hashable_args, **hashable_kwargs)
 
-            @register_custom_op(
-                f"flashinfer::{uri}_ragged_run",
-                mutates_args=(
-                    "float_workspace_buffer",
-                    "int_workspace_buffer",
-                    "o",
-                    "maybe_lse",
-                ),
+    return wrapper
+
+
+@make_hashable_cache
+def get_customize_batch_prefill_module(
+    backend: str,
+    uri: str,
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+    dtype_o: torch.dtype,
+    idtype: torch.dtype,
+    head_dim_qk: int,
+    head_dim_vo: int,
+    additional_tensor_names: List[str],
+    additional_tensor_dtypes: List[str],
+    additional_scalar_names: List[str],
+    additional_scalar_dtypes: List[str],
+    variant_name: str,
+    variant_decl: str,
+    pos_encoding_mode: int = 0,
+    use_sliding_window: bool = False,
+    use_logits_soft_cap: bool = False,
+    use_fp16_qk_reduction: bool = False,
+    fp8_enabled: bool = False,
+):
+    return gen_customize_batch_prefill_module(
+        backend,
+        uri,
+        dtype_q,
+        dtype_kv,
+        dtype_o,
+        idtype,
+        head_dim_qk,
+        head_dim_vo,
+        additional_tensor_names,
+        additional_tensor_dtypes,
+        additional_scalar_names,
+        additional_scalar_dtypes,
+        variant_name,
+        variant_decl,
+        pos_encoding_mode,
+        use_sliding_window,
+        use_logits_soft_cap,
+        use_fp16_qk_reduction,
+        fp8_enabled,
+    ).build_and_load()
+
+
+@functools.cache
+def get_trtllm_gen_prefill_module():
+    mod = trtllm_gen_fmha_module()
+    op = mod.build_and_load()
+    setup_cubin_loader(mod.get_library_path())
+
+    def _paged_run(
+        query: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        workspace_buffer: torch.Tensor,
+        block_tables: torch.Tensor,
+        seq_lens: torch.Tensor,
+        max_q_len: int,
+        max_kv_len: int,
+        bmm1_scale: float,
+        bmm2_scale: float,
+        batch_size: int,
+        cum_seq_lens_q: torch.Tensor,
+        cum_seq_lens_kv: torch.Tensor,
+        enable_pdl: bool,
+        workspace_size: int,
+        window_left: int = -1,
+        out: Optional[torch.Tensor] = None,
+        sinks: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        sm_count = get_device_sm_count(query.device)
+        if out is None:
+            out = torch.empty_like(query)
+        op.trtllm_paged_attention_context(
+            out,
+            None,  # fp4 output not supported in wrapper api yet.
+            query,
+            k_cache,
+            v_cache,
+            workspace_buffer,
+            block_tables,
+            seq_lens,
+            max_q_len,
+            max_kv_len,
+            bmm1_scale,
+            bmm2_scale,
+            -1,  # o_sf_scale
+            -1,  # o_sf_vec_size
+            0,  # o_sf_start_index
+            batch_size,
+            window_left,
+            cum_seq_lens_q,
+            cum_seq_lens_kv,
+            sm_count,
+            enable_pdl,
+            workspace_size,
+            sinks,
+        )
+        return out
+
+    def _ragged_run(*args, **kwargs):
+        # TODO(Zihao): trtllm-gen backend already supports variable length attention,
+        # but not integrated into flashinfer yet.
+        raise NotImplementedError(
+            "Variable length is not implemented for trtllm-gen backend yet."
+        )
+
+    def _plan(*args, **kwargs):
+        pass
+
+    return SimpleNamespace(
+        paged_run=_paged_run,
+        ragged_run=_ragged_run,
+        plan=_plan,
+    )
+
+
+@functools.cache
+def get_single_prefill_module(backend, *args):
+    uri = get_single_prefill_uri(backend, *args)
+    module = gen_single_prefill_module(backend, *args).build_and_load()
+    run_func = module.run.default
+
+    # torch library for single_prefill_with_kv_cache
+
+    @register_custom_op(
+        f"flashinfer::{uri}_run", mutates_args=("tmp", "o", "maybe_lse")
+    )
+    def run_single_prefill(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        tmp: torch.Tensor,
+        o: torch.Tensor,
+        maybe_lse: Optional[torch.Tensor],
+        mask_mode: int,
+        layout: int,
+        window_left: int,
+        maybe_packed_custom_mask: Optional[torch.Tensor],
+        maybe_alibi_slopes: Optional[torch.Tensor],
+        logits_soft_cap: float,
+        sm_scale: float,
+        scale_q: Optional[torch.Tensor],
+        scale_k: Optional[torch.Tensor],
+        scale_v: Optional[torch.Tensor],
+        rope_scale: float,
+        rope_theta: float,
+    ) -> None:
+        if backend == "fa3":
+            if not is_float8(q):
+                run_func(
+                    q,
+                    k,
+                    v,
+                    tmp,
+                    o,
+                    maybe_lse,
+                    mask_mode,
+                    layout,
+                    window_left,
+                    logits_soft_cap,
+                    sm_scale,
+                )
+            else:
+                # FP8 enabled
+                run_func(
+                    q,
+                    k,
+                    v,
+                    tmp,
+                    o,
+                    maybe_lse,
+                    mask_mode,
+                    layout,
+                    window_left,
+                    scale_q,
+                    scale_k,
+                    scale_v,
+                    sm_scale,
+                )
+        else:
+            run_func(
+                q,
+                k,
+                v,
+                tmp,
+                o,
+                maybe_lse,
+                mask_mode,
+                layout,
+                window_left,
+                maybe_packed_custom_mask,
+                maybe_alibi_slopes,
+                logits_soft_cap,
+                sm_scale,
+                1.0 / rope_scale,  # rope_rcp_scale
+                1.0 / rope_theta,  # rope_rcp_theta
             )
-            def ragged_run(
-                float_workspace_buffer: torch.Tensor,
-                int_workspace_buffer: torch.Tensor,
-                plan_info_vec: List[int],
-                q: torch.Tensor,
-                k: torch.Tensor,
-                v: torch.Tensor,
-                qo_indptr: torch.Tensor,
-                kv_indptr: torch.Tensor,
-                o: torch.Tensor,
-                maybe_lse: Optional[torch.Tensor],
-                mask_mode: int,
-                layout: int,
-                window_left: int,
-                maybe_custom_mask: Optional[torch.Tensor],
-                maybe_mask_indptr: Optional[torch.Tensor],
-                maybe_alibi_slopes: Optional[torch.Tensor],
-                logits_soft_cap: float,
-                sm_scale: float,
-                rope_scale: float,
-                rope_theta: float,
-            ) -> None:
-                if backend == "fa2":
-                    ragged_run_func(
-                        float_workspace_buffer,
-                        int_workspace_buffer,
-                        plan_info_vec,
-                        q,
-                        k,
-                        v,
-                        qo_indptr,
-                        kv_indptr,
-                        o,
-                        maybe_lse,
-                        mask_mode,
-                        layout,
-                        window_left,
-                        maybe_custom_mask,
-                        maybe_mask_indptr,
-                        maybe_alibi_slopes,
-                        logits_soft_cap,
-                        sm_scale,
-                        1.0 / rope_scale,  # rope_rcp_scale
-                        1.0 / rope_theta,  # rope_rcp_theta
-                    )
-                else:
-                    ragged_run_func(
-                        float_workspace_buffer,
-                        int_workspace_buffer,
-                        plan_info_vec,
-                        q,
-                        k,
-                        v,
-                        qo_indptr,
-                        kv_indptr,
-                        o,
-                        maybe_lse,
-                        mask_mode,
-                        layout,
-                        window_left,
-                        logits_soft_cap,
-                        sm_scale,
-                    )
+        return o
 
-                return o
+    @register_fake_op(f"flashinfer::{uri}_run")
+    def _fake_run_single_prefill(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        tmp: torch.Tensor,
+        o: torch.Tensor,
+        maybe_lse: Optional[torch.Tensor],
+        mask_mode: int,
+        layout: int,
+        window_left: int,
+        maybe_packed_custom_mask: Optional[torch.Tensor],
+        maybe_alibi_slopes: Optional[torch.Tensor],
+        logits_soft_cap: float,
+        sm_scale: float,
+        rope_scale: float,
+        rope_theta: float,
+    ) -> None:
+        pass
 
-            @register_fake_op(f"flashinfer::{uri}_ragged_run")
-            def _fake_ragged_run(
-                float_workspace_buffer: torch.Tensor,
-                int_workspace_buffer: torch.Tensor,
-                plan_info_vec: List[int],
-                q: torch.Tensor,
-                k: torch.Tensor,
-                v: torch.Tensor,
-                qo_indptr: torch.Tensor,
-                kv_indptr: torch.Tensor,
-                o: torch.Tensor,
-                maybe_lse: Optional[torch.Tensor],
-                mask_mode: int,
-                layout: int,
-                window_left: int,
-                maybe_custom_mask: Optional[torch.Tensor],
-                maybe_mask_indptr: Optional[torch.Tensor],
-                maybe_alibi_slopes: Optional[torch.Tensor],
-                logits_soft_cap: float,
-                sm_scale: float,
-                rope_scale: float,
-                rope_theta: float,
-            ) -> None:
-                pass
+    # Register the module
+    return SimpleNamespace(run=run_single_prefill)
 
-            # torch library for paged_run
 
-            @register_custom_op(
-                f"flashinfer::{uri}_paged_run",
-                mutates_args=(
-                    "float_workspace_buffer",
-                    "int_workspace_buffer",
-                    "paged_k_cache",
-                    "paged_v_cache",
-                    "o",
-                    "maybe_lse",
-                ),
+@functools.cache
+def get_batch_prefill_module(backend, *args):
+    if backend == "trtllm-gen":
+        uri = "trtllm_gen_context"
+        module = get_trtllm_gen_prefill_module()
+        plan_func = module.plan
+        ragged_run_func = module.ragged_run
+        paged_run_func = module.paged_run
+    else:
+        uri = get_batch_prefill_uri(backend, *args)
+        module = gen_batch_prefill_module(backend, *args).build_and_load()
+        plan_func = module.plan.default
+        ragged_run_func = module.ragged_run.default
+        paged_run_func = module.paged_run.default
+
+    # torch library for ragged_run
+
+    @register_custom_op(
+        f"flashinfer::{uri}_ragged_run",
+        mutates_args=(
+            "float_workspace_buffer",
+            "int_workspace_buffer",
+            "o",
+            "maybe_lse",
+        ),
+    )
+    def ragged_run(
+        float_workspace_buffer: torch.Tensor,
+        int_workspace_buffer: torch.Tensor,
+        plan_info_vec: List[int],
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        qo_indptr: torch.Tensor,
+        kv_indptr: torch.Tensor,
+        o: torch.Tensor,
+        maybe_lse: Optional[torch.Tensor],
+        mask_mode: int,
+        layout: int,
+        window_left: int,
+        enable_pdl: bool,
+        maybe_custom_mask: Optional[torch.Tensor],
+        maybe_mask_indptr: Optional[torch.Tensor],
+        maybe_alibi_slopes: Optional[torch.Tensor],
+        maybe_prefix_len_ptr: Optional[torch.Tensor],
+        maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
+        maybe_max_item_len_ptr: Optional[torch.Tensor],
+        logits_soft_cap: float,
+        sm_scale: float,
+        rope_scale: float,
+        rope_theta: float,
+        token_pos_in_items_len: int,
+    ) -> None:
+        if backend == "fa2":
+            ragged_run_func(
+                float_workspace_buffer,
+                int_workspace_buffer,
+                plan_info_vec,
+                q,
+                k,
+                v,
+                qo_indptr,
+                kv_indptr,
+                o,
+                maybe_lse,
+                mask_mode,
+                layout,
+                window_left,
+                enable_pdl,
+                maybe_custom_mask,
+                maybe_mask_indptr,
+                maybe_alibi_slopes,
+                maybe_prefix_len_ptr,
+                maybe_token_pos_in_items_ptr,
+                maybe_max_item_len_ptr,
+                logits_soft_cap,
+                sm_scale,
+                1.0 / rope_scale,  # rope_rcp_scale
+                1.0 / rope_theta,  # rope_rcp_theta
+                token_pos_in_items_len,
             )
-            def paged_run(
-                float_workspace_buffer: torch.Tensor,
-                int_workspace_buffer: torch.Tensor,
-                plan_info_vec: List[int],
-                q: torch.Tensor,
-                paged_k_cache: torch.Tensor,
-                paged_v_cache: torch.Tensor,
-                qo_indptr: torch.Tensor,
-                paged_kv_indptr: torch.Tensor,
-                paged_kv_indices: torch.Tensor,
-                paged_kv_last_page_len: torch.Tensor,
-                o: torch.Tensor,
-                maybe_lse: Optional[torch.Tensor],
-                mask_mode: int,
-                layout: int,
-                window_left: int,
-                maybe_custom_mask: Optional[torch.Tensor],
-                maybe_mask_indptr: Optional[torch.Tensor],
-                maybe_alibi_slopes: Optional[torch.Tensor],
-                logits_soft_cap: float,
-                sm_scale: float,
-                rope_scale: float,
-                rope_theta: float,
-            ) -> None:
-                if backend == "fa2":
-                    paged_run_func(
-                        float_workspace_buffer,
-                        int_workspace_buffer,
-                        plan_info_vec,
-                        q,
-                        paged_k_cache,
-                        paged_v_cache,
-                        qo_indptr,
-                        paged_kv_indptr,
-                        paged_kv_indices,
-                        paged_kv_last_page_len,
-                        o,
-                        maybe_lse,
-                        mask_mode,
-                        layout,
-                        window_left,
-                        maybe_custom_mask,
-                        maybe_mask_indptr,
-                        maybe_alibi_slopes,
-                        logits_soft_cap,
-                        sm_scale,
-                        1.0 / rope_scale,  # rope_rcp_scale
-                        1.0 / rope_theta,  # rope_rcp_theta
-                    )
-                else:
-                    paged_run_func(
-                        float_workspace_buffer,
-                        int_workspace_buffer,
-                        plan_info_vec,
-                        q,
-                        paged_k_cache,
-                        paged_v_cache,
-                        qo_indptr,
-                        paged_kv_indptr,
-                        paged_kv_indices,
-                        paged_kv_last_page_len,
-                        o,
-                        maybe_lse,
-                        mask_mode,
-                        layout,
-                        window_left,
-                        logits_soft_cap,
-                        sm_scale,
-                    )
-                return o
-
-            @register_fake_op(f"flashinfer::{uri}_paged_run")
-            def _fake_paged_run(
-                float_workspace_buffer: torch.Tensor,
-                int_workspace_buffer: torch.Tensor,
-                plan_info_vec: List[int],
-                q: torch.Tensor,
-                paged_k_cache: torch.Tensor,
-                paged_v_cache: torch.Tensor,
-                qo_indptr: torch.Tensor,
-                paged_kv_indptr: torch.Tensor,
-                paged_kv_indices: torch.Tensor,
-                paged_kv_last_page_len: torch.Tensor,
-                o: torch.Tensor,
-                maybe_lse: Optional[torch.Tensor],
-                mask_mode: int,
-                layout: int,
-                window_left: int,
-                maybe_custom_mask: Optional[torch.Tensor],
-                maybe_mask_indptr: Optional[torch.Tensor],
-                maybe_alibi_slopes: Optional[torch.Tensor],
-                logits_soft_cap: float,
-                sm_scale: float,
-                rope_scale: float,
-                rope_theta: float,
-            ) -> None:
-                pass
-
-            # Register the module.
-            #
-            # Note that plan is not part of model logic. It should not be included in
-            # Cuda Graph or torch.compile. So, we don't provide a torch library for plan.
-            modules_dict[args] = SimpleNamespace(
-                plan=plan_func,
-                ragged_run=ragged_run,
-                paged_run=paged_run,
+        else:
+            ragged_run_func(
+                float_workspace_buffer,
+                int_workspace_buffer,
+                plan_info_vec,
+                q,
+                k,
+                v,
+                qo_indptr,
+                kv_indptr,
+                o,
+                maybe_lse,
+                mask_mode,
+                layout,
+                window_left,
+                enable_pdl,
+                maybe_prefix_len_ptr,
+                maybe_token_pos_in_items_ptr,
+                maybe_max_item_len_ptr,
+                logits_soft_cap,
+                sm_scale,
+                token_pos_in_items_len,
             )
-        return modules_dict[args]
 
-    return backend_module
+        return o
+
+    @register_fake_op(f"flashinfer::{uri}_ragged_run")
+    def _fake_ragged_run(
+        float_workspace_buffer: torch.Tensor,
+        int_workspace_buffer: torch.Tensor,
+        plan_info_vec: List[int],
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        qo_indptr: torch.Tensor,
+        kv_indptr: torch.Tensor,
+        o: torch.Tensor,
+        maybe_lse: Optional[torch.Tensor],
+        mask_mode: int,
+        layout: int,
+        window_left: int,
+        enable_pdl: bool,
+        maybe_custom_mask: Optional[torch.Tensor],
+        maybe_mask_indptr: Optional[torch.Tensor],
+        maybe_alibi_slopes: Optional[torch.Tensor],
+        maybe_prefix_len_ptr: Optional[torch.Tensor],
+        maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
+        maybe_max_item_len_ptr: Optional[torch.Tensor],
+        logits_soft_cap: float,
+        sm_scale: float,
+        rope_scale: float,
+        rope_theta: float,
+        token_pos_in_items_len: int,
+    ) -> None:
+        pass
+
+    # torch library for paged_run
+
+    @register_custom_op(
+        f"flashinfer::{uri}_paged_run",
+        mutates_args=(
+            "float_workspace_buffer",
+            "int_workspace_buffer",
+            "paged_k_cache",
+            "paged_v_cache",
+            "o",
+            "maybe_lse",
+        ),
+    )
+    def paged_run(
+        float_workspace_buffer: torch.Tensor,
+        int_workspace_buffer: torch.Tensor,
+        plan_info_vec: List[int],
+        q: torch.Tensor,
+        paged_k_cache: torch.Tensor,
+        paged_v_cache: torch.Tensor,
+        qo_indptr: torch.Tensor,
+        paged_kv_indptr: torch.Tensor,
+        paged_kv_indices: torch.Tensor,
+        paged_kv_last_page_len: torch.Tensor,
+        o: torch.Tensor,
+        maybe_lse: Optional[torch.Tensor],
+        mask_mode: int,
+        layout: int,
+        window_left: int,
+        enable_pdl: bool,
+        maybe_custom_mask: Optional[torch.Tensor],
+        maybe_mask_indptr: Optional[torch.Tensor],
+        maybe_alibi_slopes: Optional[torch.Tensor],
+        maybe_prefix_len_ptr: Optional[torch.Tensor],
+        maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
+        maybe_max_item_len_ptr: Optional[torch.Tensor],
+        logits_soft_cap: float,
+        sm_scale: float,
+        scale_q: Optional[torch.Tensor],
+        scale_k: Optional[torch.Tensor],
+        scale_v: Optional[torch.Tensor],
+        rope_scale: float,
+        rope_theta: float,
+        token_pos_in_items_len: int,
+        workspace_size: int,
+        num_qo_heads: Optional[int] = None,
+        num_kv_heads: Optional[int] = None,
+        block_tables: Optional[torch.Tensor] = None,
+        kv_lens_buffer: Optional[torch.Tensor] = None,
+        page_size: Optional[int] = None,
+        max_q_len: Optional[int] = None,
+        max_kv_len: Optional[int] = None,
+        batch_size: Optional[int] = None,
+        cum_seq_lens_q: Optional[torch.Tensor] = None,
+        cum_seq_lens_kv: Optional[torch.Tensor] = None,
+        sinks: Optional[torch.Tensor] = None,
+    ) -> None:
+        if backend == "trtllm-gen":
+            assert maybe_lse is None
+            assert num_qo_heads is not None
+            assert num_kv_heads is not None
+            assert block_tables is not None
+            assert kv_lens_buffer is not None
+            assert page_size is not None
+            assert max_kv_len is not None
+            assert batch_size is not None
+            assert cum_seq_lens_q is not None
+            assert cum_seq_lens_kv is not None
+            assert enable_pdl is not None
+            o = paged_run_func(
+                q.contiguous(),  # NOTE(Siyuan): without contiguous, the result is incorrect
+                paged_k_cache,
+                paged_v_cache,
+                int_workspace_buffer,
+                block_tables,
+                kv_lens_buffer,
+                max_q_len,
+                max_kv_len,
+                sm_scale,
+                1.0,  # NOTE(Siyuan): update this to expose bmm2 scale
+                batch_size,
+                cum_seq_lens_q,
+                cum_seq_lens_kv,
+                enable_pdl,
+                workspace_size,
+                window_left,
+                out=o,
+                sinks=sinks,
+            )
+        elif backend == "fa2":
+            assert not is_float8(q)
+            paged_run_func(
+                float_workspace_buffer,
+                int_workspace_buffer,
+                plan_info_vec,
+                q,
+                paged_k_cache,
+                paged_v_cache,
+                qo_indptr,
+                paged_kv_indptr,
+                paged_kv_indices,
+                paged_kv_last_page_len,
+                o,
+                maybe_lse,
+                mask_mode,
+                layout,
+                window_left,
+                enable_pdl,
+                maybe_custom_mask,
+                maybe_mask_indptr,
+                maybe_alibi_slopes,
+                maybe_prefix_len_ptr,
+                maybe_token_pos_in_items_ptr,
+                maybe_max_item_len_ptr,
+                logits_soft_cap,
+                sm_scale,
+                1.0 / rope_scale,  # rope_rcp_scale
+                1.0 / rope_theta,  # rope_rcp_theta
+                token_pos_in_items_len,
+            )
+        else:
+            if not is_float8(q):
+                paged_run_func(
+                    float_workspace_buffer,
+                    int_workspace_buffer,
+                    plan_info_vec,
+                    q,
+                    paged_k_cache,
+                    paged_v_cache,
+                    qo_indptr,
+                    paged_kv_indptr,
+                    paged_kv_indices,
+                    paged_kv_last_page_len,
+                    o,
+                    maybe_lse,
+                    mask_mode,
+                    layout,
+                    window_left,
+                    enable_pdl,
+                    maybe_prefix_len_ptr,
+                    maybe_token_pos_in_items_ptr,
+                    maybe_max_item_len_ptr,
+                    logits_soft_cap,
+                    sm_scale,
+                    token_pos_in_items_len,
+                )
+            else:
+                paged_run_func(
+                    float_workspace_buffer,
+                    int_workspace_buffer,
+                    plan_info_vec,
+                    q,
+                    paged_k_cache,
+                    paged_v_cache,
+                    qo_indptr,
+                    paged_kv_indptr,
+                    paged_kv_indices,
+                    paged_kv_last_page_len,
+                    o,
+                    maybe_lse,
+                    mask_mode,
+                    layout,
+                    window_left,
+                    enable_pdl,
+                    scale_q,
+                    scale_k,
+                    scale_v,
+                    sm_scale,
+                )
+        return o
+
+    @register_fake_op(f"flashinfer::{uri}_paged_run")
+    def _fake_paged_run(
+        float_workspace_buffer: torch.Tensor,
+        int_workspace_buffer: torch.Tensor,
+        plan_info_vec: List[int],
+        q: torch.Tensor,
+        paged_k_cache: torch.Tensor,
+        paged_v_cache: torch.Tensor,
+        qo_indptr: torch.Tensor,
+        paged_kv_indptr: torch.Tensor,
+        paged_kv_indices: torch.Tensor,
+        paged_kv_last_page_len: torch.Tensor,
+        o: torch.Tensor,
+        maybe_lse: Optional[torch.Tensor],
+        mask_mode: int,
+        layout: int,
+        window_left: int,
+        enable_pdl: bool,
+        maybe_custom_mask: Optional[torch.Tensor],
+        maybe_mask_indptr: Optional[torch.Tensor],
+        maybe_alibi_slopes: Optional[torch.Tensor],
+        maybe_prefix_len_ptr: Optional[torch.Tensor],
+        maybe_token_pos_in_items_ptr: Optional[torch.Tensor],
+        maybe_max_item_len_ptr: Optional[torch.Tensor],
+        logits_soft_cap: float,
+        sm_scale: float,
+        rope_scale: float,
+        rope_theta: float,
+        token_pos_in_items_len: int,
+        workspace_size: int,
+        num_qo_heads: Optional[int] = None,
+        num_kv_heads: Optional[int] = None,
+        block_tables: Optional[torch.Tensor] = None,
+        kv_lens_buffer: Optional[torch.Tensor] = None,
+        page_size: Optional[int] = None,
+        max_q_len: Optional[int] = None,
+        max_kv_len: Optional[int] = None,
+        batch_size: Optional[int] = None,
+        cum_seq_lens_q: Optional[torch.Tensor] = None,
+        cum_seq_lens_kv: Optional[torch.Tensor] = None,
+    ) -> None:
+        pass
+
+    # Register the module.
+    #
+    # Note that plan is not part of model logic. It should not be included in
+    # Cuda Graph or torch.compile. So, we don't provide a torch library for plan.
+    return SimpleNamespace(
+        plan=plan_func,
+        ragged_run=ragged_run,
+        paged_run=paged_run,
+    )
 
 
+@functools.cache
 def get_batch_prefill_jit_module(module_name: str, jit_module: Any):
-    global _batch_prefill_jit_modules
-    if module_name in _batch_prefill_jit_modules:
-        return _batch_prefill_jit_modules[module_name]
-
     plan_func = jit_module.plan.default
     ragged_run_func = jit_module.ragged_run.default
     paged_run_func = jit_module.paged_run.default
@@ -571,13 +850,11 @@ def get_batch_prefill_jit_module(module_name: str, jit_module: Any):
     #
     # Note that plan is not part of model logic. It should not be included in
     # Cuda Graph or torch.compile. So, we don't provide a torch library for plan.
-    _batch_prefill_jit_modules[module_name] = SimpleNamespace(
+    return SimpleNamespace(
         plan=plan_func,
         ragged_run=ragged_run,
         paged_run=paged_run,
     )
-
-    return _batch_prefill_jit_modules[module_name]
 
 
 def single_prefill_with_kv_cache_with_jit_module(
@@ -619,6 +896,10 @@ def single_prefill_with_kv_cache(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
+    scale_q: Optional[torch.Tensor] = None,
+    scale_k: Optional[torch.Tensor] = None,
+    scale_v: Optional[torch.Tensor] = None,
+    o_dtype: Optional[torch.dtype] = None,
     custom_mask: Optional[torch.Tensor] = None,
     packed_custom_mask: Optional[torch.Tensor] = None,
     causal: bool = False,
@@ -640,6 +921,10 @@ def single_prefill_with_kv_cache(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
+    scale_q: Optional[torch.Tensor] = None,
+    scale_k: Optional[torch.Tensor] = None,
+    scale_v: Optional[torch.Tensor] = None,
+    o_dtype: Optional[torch.dtype] = None,
     custom_mask: Optional[torch.Tensor] = None,
     packed_custom_mask: Optional[torch.Tensor] = None,
     causal: bool = False,
@@ -660,6 +945,10 @@ def single_prefill_with_kv_cache(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
+    scale_q: Optional[torch.Tensor] = None,
+    scale_k: Optional[torch.Tensor] = None,
+    scale_v: Optional[torch.Tensor] = None,
+    o_dtype: Optional[torch.dtype] = None,
     custom_mask: Optional[torch.Tensor] = None,
     packed_custom_mask: Optional[torch.Tensor] = None,
     causal: bool = False,
@@ -689,6 +978,18 @@ def single_prefill_with_kv_cache(
         The key tensor, shape: ``[kv_len, num_kv_heads, head_dim_vo]`` if :attr:`kv_layout`
         is ``NHD``, ``[num_kv_heads, kv_len, head_dim_vo]`` if :attr:`kv_layout` is
         ``HND``.
+    scale_q : Optional[torch.Tensor]
+        The scale tensor for query, per-head quantization with shape: ``[num_qo_heads]``.
+        Used with FP8 Quantization. If not provided, will be set to ``1.0``.
+    scale_k : Optional[torch.Tensor]
+        The scale tensor for key, per-head quantization with shape: ``[num_kv_heads]``.
+        Used with FP8 Quantization. If not provided, will be set to ``1.0``.
+    scale_v : Optional[torch.Tensor]
+        The scale tensor for value, per-head quantization with shape: ``[num_kv_heads]``.
+        Used with FP8 Quantization. If not provided, will be set to ``1.0``.
+    o_dtype : Optional[torch.dtype]
+        The output tensor data type, if not provided, will be set to the same as the q.
+        This is necessary as output dtype cannot be automatically inferred in quant.
     custom_mask : Optional[torch.Tensor]
         The custom boolean mask tensor, shape: ``[qo_len, kv_len]``.
         The elements in the mask tensor should be either ``True`` or ``False``,
@@ -812,6 +1113,20 @@ def single_prefill_with_kv_cache(
     if return_lse:
         lse = torch.empty((q.size(0), q.size(1)), dtype=torch.float32, device=q.device)
 
+    if is_float8(q):
+        # FP8 quant enabled, do sanity check:
+        #   1. unsupported feature
+        #   2. dtype check
+        assert window_left == -1
+        assert q.dtype == k.dtype == v.dtype
+        assert q.shape[-1] == k.shape[-1] == v.shape[-1]
+        if scale_q is None:
+            scale_q = torch.ones(q.shape[1], dtype=torch.float32, device=q.device)
+        if scale_k is None:
+            scale_k = torch.ones(k.shape[1], dtype=torch.float32, device=q.device)
+        if scale_v is None:
+            scale_v = torch.ones(v.shape[1], dtype=torch.float32, device=q.device)
+
     if backend == "auto":
         backend = determine_attention_backend(
             q.device,
@@ -821,20 +1136,26 @@ def single_prefill_with_kv_cache(
             q.dtype,
             k.dtype,
         )
-    module_getter = get_single_prefill_module(backend)
 
-    out = torch.empty(q.shape[:-1] + v.shape[-1:], dtype=q.dtype, device=q.device)
-    module_getter(
+    # o_dtype should be provided for FP8 attention
+    if o_dtype is None:
+        o_dtype = q.dtype
+    out = torch.empty(q.shape[:-1] + v.shape[-1:], dtype=o_dtype, device=q.device)
+
+    module = get_single_prefill_module(
+        backend,
         q.dtype,
         k.dtype,
-        q.dtype,
+        out.dtype,
         q.shape[-1],  # head_dim_qk
         v.shape[-1],  # head_dim_vo
         PosEncodingMode[pos_encoding_mode].value,
         window_left >= 0,  # use_sliding_window
         logits_soft_cap > 0,  # use_logits_soft_cap
         use_fp16_qk_reduction,
-    ).run(
+    )
+
+    module.run(
         q,
         k,
         v,
@@ -848,6 +1169,9 @@ def single_prefill_with_kv_cache(
         _get_cache_alibi_slopes_buf(q.shape[1], q.device),
         logits_soft_cap,
         sm_scale,
+        scale_q,
+        scale_k,
+        scale_v,
         rope_scale,
         rope_theta,
     )
@@ -900,7 +1224,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
     >>> max_num_pages = 128
     >>> page_size = 16
     >>> # allocate 128MB workspace buffer
-    >>> workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    >>> workspace_buffer = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
     >>> prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
     ...     workspace_buffer, "NHD"
     ... )
@@ -998,6 +1322,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         mask_indptr_buf: Optional[torch.Tensor] = None,
         backend: str = "auto",
         jit_args: Optional[List[Any]] = None,
+        jit_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         r"""Constructor of :class:`BatchPrefillWithPagedKVCacheWrapper`.
 
@@ -1050,28 +1375,41 @@ class BatchPrefillWithPagedKVCacheWrapper:
             mask will be used in attention computation.
 
         backend : str
-            The implementation backend, could be ``auto``/``fa2`` or ``fa3``. Defaults to ``auto``.
+            The implementation backend, could be ``auto``/``fa2``,``fa3`` or ``cudnn``. Defaults to ``auto``.
             If set to ``auto``, the wrapper will automatically choose the backend based on the
             device architecture and kernel availability.
 
         jit_args : Optional[List[Any]]
             If provided, the wrapper will use the provided arguments to create the JIT module,
             otherwise, the wrapper will use default attention implementation.
+
+        jit_kwargs : Optional[Dict[str, Any]]
+            The keyword arguments to create the JIT module, defaults to None.
         """
         _check_kv_layout(kv_layout)
 
         if jit_args is not None:
+            if jit_kwargs is None:
+                jit_kwargs = {}
             self._jit_module = get_batch_prefill_jit_module(
                 jit_args[0],
-                gen_customize_batch_prefill_module(backend, *jit_args),
+                get_customize_batch_prefill_module(backend, *jit_args, **jit_kwargs),
             )
         else:
             self._jit_module = None
 
         self._kv_layout = kv_layout
+        if backend == "cudnn":
+            assert kv_layout == "NHD", "CUDNN backend only supports NHD layout"
+
         self._float_workspace_buffer = float_workspace_buffer
+        self._workspace_size = (
+            self._float_workspace_buffer.numel()
+            * self._float_workspace_buffer.element_size()
+        )
         self.device = float_workspace_buffer.device
-        if backend in ["fa3", "auto"]:
+        self._vector_sparse_indptr_buffer: Optional[torch.Tensor] = None
+        if backend in ["fa3", "auto", "trtllm-gen"]:
             # NOTE(Zihao): assume maximum accumulate kv length is 16M
             self._vector_sparse_indices_buffer = torch.empty(
                 (16 * 1024 * 1024,), dtype=torch.int32, device=self.device
@@ -1132,6 +1470,11 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._mask_indptr_buf = mask_indptr_buf
         self._max_total_num_rows = None
         self._backend = backend
+        self._plan_info = None
+        self._cached_module = None
+        self._seq_lens_kv = None
+        self._seq_lens_q = None
+        self._block_tables = None
 
     @property
     def is_cuda_graph_enabled(self) -> bool:
@@ -1185,6 +1528,15 @@ class BatchPrefillWithPagedKVCacheWrapper:
         q_data_type: Union[str, torch.dtype] = "float16",
         kv_data_type: Optional[Union[str, torch.dtype]] = None,
         non_blocking: bool = True,
+        prefix_len_ptr: Optional[torch.Tensor] = None,
+        token_pos_in_items_ptr: Optional[torch.Tensor] = None,
+        token_pos_in_items_len: int = 0,
+        max_item_len_ptr: Optional[torch.Tensor] = None,
+        seq_lens: Optional[torch.Tensor] = None,
+        seq_lens_q: Optional[torch.Tensor] = None,
+        block_tables: Optional[torch.Tensor] = None,
+        max_token_per_sequence: Optional[int] = None,
+        max_sequence_kv: Optional[int] = None,
     ) -> None:
         r"""Plan batch prefill/append attention on Paged KV-Cache for given problem specification.
 
@@ -1259,7 +1611,31 @@ class BatchPrefillWithPagedKVCacheWrapper:
             The data type of the key/value tensor. If None, will be set to :attr:`q_data_type`.
         non_blocking : bool
             Whether to copy the input tensors to the device asynchronously, defaults to ``True``.
-
+        prefix_len_ptr :Optional[torch.Tensor]
+            prefix length. A uint32 1D tensor indicating the prefix length of each prompt. The tensor size is equal to the batch size.
+        token_pos_in_items_ptr : Optional[float]
+            A uint16 1D tensor (it will be converted to uint16 in flashinfer) indicating the token position of each item and started from 0 (delimiter)
+            for each item. E.g., if we have 3 items of length 3, 2, 4 respectively for this member. This vector will be looking like
+            `[0, 1, 2, 3, 0, 1, 2, 0, 1, 2, 3, 4, 0]` with 4 delimiters indexed as 0. For batch size > 1,
+            we will concat them as 1D with zero paddings to make sure each has the same length, the padding length is defined by
+            `token_pos_in_items_len` - length of the raw `token_pos_in_items_ptr` for each prompt.
+        token_pos_in_items_len : int
+            zero padding length for `token_pos_in_items_ptr` to better handle the bsz > 1 case. Still using the above 3,2,4 example.
+            If we set `token_pos_in_items_len` to be 20, it will be  `[0, 1, 2, 3, 0, 1, 2, 0, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0]`
+            with 7 padded zeros. (note there're 8 zeros in the end where the first one is the delimiter token 0 in the end of the prompt)
+        max_item_len_ptr : Optional[float]
+            a uint16 vector contains the max token length of all items for each prompt
+        seq_lens: Optional[torch.Tensor]
+            A uint32 1D tensor indicating the kv sequence length of each prompt. shape: ``[batch_size]``.
+        seq_lens_q: Optional[torch.Tensor]
+            A uint32 1D tensor indicating the q sequence length of each prompt. shape: ``[batch_size]``.
+            If not provided, will be set to the same value as ``seq_lens``.
+        block_tables: Optional[torch.Tensor]
+            A uint32 2D tensor indicating the block table of each prompt. shape: ``[batch_size, max_num_blocks_per_seq]``.
+        max_token_per_sequence: Optional[int],
+            Required for cudnn backend. This is the scalar max token length of each sequence.
+        max_sequence_kv: Optional[int],
+            Required for cudnn backend. This is the scalar max sequence length of each sequence in kv cache.
         Note
         ----
         The :meth:`plan` method should be called before any :meth:`run` or
@@ -1283,6 +1659,9 @@ class BatchPrefillWithPagedKVCacheWrapper:
             head_dim_vo = head_dim_qk
 
         batch_size = len(qo_indptr) - 1
+        self._batch_size = batch_size
+        self._num_qo_heads = num_qo_heads
+        self._num_kv_heads = num_kv_heads
         if custom_mask is not None or packed_custom_mask is not None:
             mask_indptr = _compute_page_mask_indptr(
                 qo_indptr,
@@ -1298,18 +1677,34 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 bitorder="little",
             )
 
-        # NOTE(Zihao): only required if qo_indptr/paged_kv_indptr are device tensors
-        qo_indptr_host = qo_indptr.to("cpu")
-        paged_kv_indptr_host = paged_kv_indptr.to("cpu")
-        paged_kv_last_page_len_host = paged_kv_last_page_len.to("cpu")
-        kv_lens_arr_host = get_seq_lens(
-            paged_kv_indptr_host, paged_kv_last_page_len_host, page_size
-        )
-        self._kv_lens_buffer[: len(kv_lens_arr_host)].copy_(
-            kv_lens_arr_host, non_blocking=non_blocking
-        )
+        self._prefix_len_ptr = prefix_len_ptr
+        self._token_pos_in_items_ptr = token_pos_in_items_ptr
+        self._token_pos_in_items_len = token_pos_in_items_len
+        self._max_item_len_ptr = max_item_len_ptr
 
-        total_num_rows = qo_indptr_host[-1]
+        # NOTE(Zihao): only required if qo_indptr/paged_kv_indptr are device tensors
+        if max_token_per_sequence is not None:
+            self._max_q_len = max_token_per_sequence
+        else:
+            qo_indptr_host = qo_indptr.to("cpu")
+            self._max_q_len = max(qo_indptr_host).item()
+            total_num_rows = qo_indptr_host[-1]
+
+        if max_sequence_kv is not None:
+            self._max_kv_len = max_sequence_kv
+        else:
+            paged_kv_indptr_host = paged_kv_indptr.to("cpu")
+            paged_kv_last_page_len_host = paged_kv_last_page_len.to("cpu")
+            if seq_lens is None:
+                kv_lens_arr_host = get_seq_lens(
+                    paged_kv_indptr_host, paged_kv_last_page_len_host, page_size
+                )
+            else:
+                kv_lens_arr_host = seq_lens.cpu().flatten()
+            self._kv_lens_buffer[: len(kv_lens_arr_host)].copy_(
+                kv_lens_arr_host, non_blocking=non_blocking
+            )
+            self._max_kv_len = max(kv_lens_arr_host).item()
 
         if self.is_cuda_graph_enabled:
             if self._max_total_num_rows is None:
@@ -1379,6 +1774,9 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 self._mask_indptr_buf = mask_indptr.to(
                     self.device, non_blocking=non_blocking
                 )
+            else:
+                self._custom_mask_buf = None
+                self._mask_indptr_buf = None
 
         self._cached_q_data_type = q_data_type
         self._cached_kv_data_type = kv_data_type
@@ -1395,25 +1793,25 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     q_data_type,
                     kv_data_type,
                 )
+            if self._backend != "cudnn":
+                get_module_args = (
+                    q_data_type,
+                    kv_data_type,
+                    q_data_type,
+                    paged_kv_indptr.dtype,
+                    head_dim_qk,
+                    head_dim_vo,
+                    PosEncodingMode[pos_encoding_mode].value,
+                    window_left >= 0,  # use_sliding_window
+                    logits_soft_cap > 0,  # use_logits_soft_cap
+                    use_fp16_qk_reduction,
+                )
 
-            get_module_args = (
-                q_data_type,
-                kv_data_type,
-                q_data_type,
-                paged_kv_indptr.dtype,
-                head_dim_qk,
-                head_dim_vo,
-                PosEncodingMode[pos_encoding_mode].value,
-                window_left >= 0,  # use_sliding_window
-                logits_soft_cap > 0,  # use_logits_soft_cap
-                use_fp16_qk_reduction,
-            )
+                self._cached_module = get_batch_prefill_module(
+                    self._backend, *get_module_args
+                )
 
-            self._cached_module = get_batch_prefill_module(self._backend)(
-                *get_module_args
-            )
-
-        if self._backend == "fa3":
+        if self._backend == "fa3" or self._backend == "trtllm-gen":
             if page_size != 1:
                 vector_sparse_indptr_host = torch.cat(
                     [
@@ -1429,23 +1827,50 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 ].copy_(vector_sparse_indptr_host, non_blocking=non_blocking)
                 paged_kv_indptr_host = vector_sparse_indptr_host
 
-        self._plan_info = self._cached_module.plan(
-            self._float_workspace_buffer,
-            self._int_workspace_buffer,
-            self._pin_memory_int_workspace_buffer,
-            qo_indptr_host,
-            paged_kv_indptr_host,
-            kv_lens_arr_host,
-            self._max_total_num_rows or total_num_rows,
-            batch_size,
-            num_qo_heads,
-            num_kv_heads,
-            page_size,
-            self.is_cuda_graph_enabled,
-            head_dim_qk,
-            head_dim_vo,
-            causal,
-        )
+        self._block_tables = block_tables
+        if self._backend == "trtllm-gen":
+            assert self._kv_layout == "HND"
+            assert logits_soft_cap == 0.0
+            if self._block_tables is None:
+                blocks_per_seq = [
+                    (seq_len + page_size - 1) // page_size
+                    for seq_len in kv_lens_arr_host
+                ]
+                max_num_blocks_per_seq = max(blocks_per_seq)
+                self._block_tables = torch.zeros(
+                    (batch_size, max_num_blocks_per_seq),
+                    dtype=torch.int,
+                    device=self.device,
+                )
+                block_id = paged_kv_indptr_host[0]
+                for i in range(batch_size):
+                    num_blocks_needed = blocks_per_seq[i]
+                    assert self._block_tables is not None, (
+                        "block_tables is not initialized"
+                    )
+                    self._block_tables[i, :num_blocks_needed] = paged_kv_indices[
+                        block_id : block_id + num_blocks_needed
+                    ]
+                    block_id += num_blocks_needed
+
+        if self._cached_module is not None:
+            self._plan_info = self._cached_module.plan(
+                self._float_workspace_buffer,
+                self._int_workspace_buffer,
+                self._pin_memory_int_workspace_buffer,
+                qo_indptr_host,
+                paged_kv_indptr_host,
+                kv_lens_arr_host,
+                self._max_total_num_rows or total_num_rows,
+                batch_size,
+                num_qo_heads,
+                num_kv_heads,
+                page_size,
+                self.is_cuda_graph_enabled,
+                head_dim_qk,
+                head_dim_vo,
+                causal,
+            )
 
         self._causal = causal
         self._pos_encoding_mode = pos_encoding_mode
@@ -1455,6 +1880,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._sm_scale = sm_scale
         self._rope_scale = rope_scale
         self._rope_theta = rope_theta
+        self._seq_lens_kv = seq_lens
+        self._seq_lens_q = seq_lens_q if seq_lens_q is not None else seq_lens
 
     begin_forward = plan
 
@@ -1495,6 +1922,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
         return_lse: Literal[False] = False,
+        enable_pdl: Optional[bool] = None,
+        window_left: Optional[int] = None,
     ) -> torch.Tensor: ...
 
     @overload
@@ -1508,6 +1937,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
         return_lse: Literal[True] = True,
+        enable_pdl: Optional[bool] = None,
+        window_left: Optional[int] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]: ...
 
     def run(
@@ -1515,11 +1946,15 @@ class BatchPrefillWithPagedKVCacheWrapper:
         q: torch.Tensor,
         paged_kv_cache: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
         *args,
+        q_scale: Optional[float] = None,
         k_scale: Optional[float] = None,
         v_scale: Optional[float] = None,
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
         return_lse: bool = False,
+        enable_pdl: Optional[bool] = None,
+        window_left: Optional[int] = None,
+        sinks: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         r"""Compute batch prefill/append attention between query and paged kv-cache.
 
@@ -1553,7 +1988,9 @@ class BatchPrefillWithPagedKVCacheWrapper:
             The log-sum-exp of attention logits, if not provided, will be allocated internally.
         return_lse : bool
             Whether to return the logsumexp of attention output
-
+        enable_pdl : bool
+            Whether to enable Programmatic Dependent Launch (PDL). See https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
+            Only supported for >= sm90, and currently only for FA2 and CUDA core decode.
         Returns
         -------
         Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
@@ -1563,6 +2000,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
             * The attention output, shape: ``[qo_indptr[-1], num_qo_heads, head_dim]``.
             * The logsumexp of attention output, shape: ``[qo_indptr[-1], num_qo_heads]``.
         """
+        if enable_pdl is None:
+            enable_pdl = device_support_pdl(q.device)
         k_cache, v_cache = _unpack_paged_kv_cache(paged_kv_cache, self._kv_layout)
         _check_cached_qkv_data_type(
             q, k_cache, self._cached_q_data_type, self._cached_kv_data_type
@@ -1574,7 +2013,11 @@ class BatchPrefillWithPagedKVCacheWrapper:
         else:
             page_size = k_cache.shape[2]
             stride_n = k_cache.stride(2)
-        window_left = self._window_left
+        window_left = self._window_left if window_left is None else window_left
+        if self._backend != "trtllm-gen":
+            # NOTE(Siyuan): since window_left is appeared in the plan function, we need to make sure it is the same as the one in the plan function.
+            # Remove this check if the backend supports dynamic window_left.
+            assert window_left == self._window_left
         logits_soft_cap = self._logits_soft_cap
         sm_scale = self._sm_scale
         rope_scale = self._rope_scale
@@ -1583,6 +2026,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
             logits_soft_cap = 0.0
         if sm_scale is None:
             sm_scale = 1.0 / math.sqrt(q.size(-1))
+        if q_scale is not None:
+            sm_scale *= q_scale
         if k_scale is not None:
             sm_scale *= k_scale
         if rope_scale is None:
@@ -1595,7 +2040,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     (q.size(0), q.size(1)), dtype=torch.float32, device=q.device
                 )
             else:
-                _check_shape_dtype_device(
+                check_shape_dtype_device(
                     lse, (q.size(0), q.size(1)), torch.float32, q.device, "lse"
                 )
 
@@ -1604,7 +2049,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 q.shape[:-1] + v_cache.shape[-1:], dtype=q.dtype, device=q.device
             )
         else:
-            _check_shape_dtype_device(
+            check_shape_dtype_device(
                 out, q.shape[:-1] + v_cache.shape[-1:], q.dtype, q.device, "out"
             )
 
@@ -1615,6 +2060,9 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 mask_mode = MaskMode.CAUSAL.value
             else:
                 mask_mode = MaskMode.NON_CAUSAL.value
+
+        if self._prefix_len_ptr is not None:
+            mask_mode = MaskMode.MULTIITEMSCORING.value
 
         if self._backend == "fa3":
             # NOTE(Zihao): we divide both stride_block and stride_n by stride_n
@@ -1634,41 +2082,92 @@ class BatchPrefillWithPagedKVCacheWrapper:
             sparse_indices = self._paged_kv_indices_buf
             sparse_indptr = self._paged_kv_indptr_buf
 
-        run_args = [
-            self._float_workspace_buffer,
-            self._int_workspace_buffer,
-            self._plan_info,
-            q,
-            k_cache,
-            v_cache,
-            self._qo_indptr_buf,
-            sparse_indptr,
-            sparse_indices,
-            self._paged_kv_last_page_len_buf,
-            out,
-            lse,
-            mask_mode,
-            TensorLayout[self._kv_layout].value,
-            window_left,
-        ]
+        if self._backend == "cudnn":
+            if self._seq_lens_q is not None and self._seq_lens_q.dim() == 1:
+                self._seq_lens_q = self._seq_lens_q.reshape(self._batch_size, 1, 1, 1)
 
-        if self._jit_module is not None:
-            run_args.extend(list(args))
+            if self._seq_lens_kv is not None and self._seq_lens_kv.dim() == 1:
+                self._seq_lens_kv = self._seq_lens_kv.reshape(self._batch_size, 1, 1, 1)
+
+            cudnn_batch_prefill_with_kv_cache(
+                q,
+                k_cache,  # Need to be changed
+                v_cache,  # Need to be changed
+                self._sm_scale,
+                self._float_workspace_buffer,
+                actual_seq_lens_q=self._seq_lens_q,
+                actual_seq_lens_kv=self._seq_lens_kv,
+                max_token_per_sequence=self._max_q_len,
+                max_sequence_kv=self._max_kv_len,
+                block_tables=self._block_tables,
+                causal=self._causal,
+                return_lse=return_lse,
+                batch_offsets_q=self._qo_indptr_buf,
+                batch_offsets_o=self._qo_indptr_buf,
+                out=out,
+                lse=lse,
+            )
         else:
-            run_args += [
-                self._custom_mask_buf,
-                self._mask_indptr_buf,
-                _get_cache_alibi_slopes_buf(q.shape[1], q.device),
-                logits_soft_cap,
-                sm_scale,
-                rope_scale,
-                rope_theta,
+            if self._backend != "trtllm-gen":
+                assert self._plan_info is not None, "plan info is not initialized"
+            run_args = [
+                self._float_workspace_buffer,
+                self._int_workspace_buffer,
+                self._plan_info,
+                q,
+                k_cache,
+                v_cache,
+                self._qo_indptr_buf,
+                sparse_indptr,
+                sparse_indices,
+                self._paged_kv_last_page_len_buf,
+                out,
+                lse,
+                mask_mode,
+                TensorLayout[self._kv_layout].value,
+                window_left,
+                enable_pdl,
             ]
+            if self._jit_module is not None:
+                run_args.extend(list(args))
+            else:
+                run_args += [
+                    self._custom_mask_buf,
+                    self._mask_indptr_buf,
+                    _get_cache_alibi_slopes_buf(q.shape[1], q.device),
+                    self._prefix_len_ptr,
+                    self._token_pos_in_items_ptr,
+                    self._max_item_len_ptr,
+                    logits_soft_cap,
+                    sm_scale,
+                    None,  # scale_q, not supported yet
+                    None,  # scale_k
+                    None,  # scale_v
+                    rope_scale,
+                    rope_theta,
+                    self._workspace_size,
+                    self._token_pos_in_items_len,
+                    self._num_qo_heads,
+                    self._num_kv_heads,
+                    self._block_tables,
+                    self._kv_lens_buffer,
+                    page_size,
+                    self._max_q_len,
+                    self._max_kv_len,
+                    self._batch_size,
+                    self._qo_indptr_buf,
+                    self._vector_sparse_indptr_buffer,
+                    sinks,
+                ]
 
-        self._cached_module.paged_run(*run_args)
-        if v_scale is not None:
-            out *= v_scale
-
+            assert self._cached_module is not None, "cached module is not initialized"
+            self._cached_module.paged_run(*run_args)
+            if v_scale is not None:
+                # TODO(Zihao): fused into kernel
+                if is_float8(out):
+                    out = (out.to(torch.float32) * v_scale).to(out.dtype)
+                else:
+                    out *= v_scale
         return (out, lse) if return_lse else out
 
     run_return_lse = functools.partialmethod(run, return_lse=True)
@@ -1697,7 +2196,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._sm_scale = sm_scale
         self._rope_scale = rope_scale
         self._rope_theta = rope_theta
-        return self.run_return_lse(q, paged_kv_cache, k_scale, v_scale)
+        return self.run_return_lse(q, paged_kv_cache, k_scale=k_scale, v_scale=v_scale)
 
     def end_forward(self) -> None:
         r"""Warning: this function is deprecated and has no effect."""
@@ -1820,6 +2319,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         mask_indptr_buf: Optional[torch.Tensor] = None,
         backend: str = "auto",
         jit_args: Optional[List[Any]] = None,
+        jit_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         r"""Constructor of :class:`BatchPrefillWithRaggedKVCacheWrapper`.
 
@@ -1860,19 +2360,25 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             will be used in attention computation.
 
         backend : str
-            The implementation backend, could be ``auto``/``fa2`` or ``fa3``. Defaults to ``auto``.
+            The implementation backend, could be ``auto``/``fa2``/``fa3`` or ``trtllm-gen``.
+            Defaults to ``auto``.
             If set to ``auto``, the wrapper will automatically choose the backend based on the
             device architecture and kernel availability.
 
         jit_args : Optional[List[Any]]
             If provided, the wrapper will use the provided arguments to create the JIT module,
             otherwise, the wrapper will use default attention implementation.
+
+        jit_kwargs : Optional[Dict[str, Any]]
+            The keyword arguments to create the JIT module, defaults to None.
         """
         _check_kv_layout(kv_layout)
         if jit_args is not None:
+            if jit_kwargs is None:
+                jit_kwargs = {}
             self._jit_module = get_batch_prefill_jit_module(
                 jit_args[0],
-                gen_customize_batch_prefill_module(backend, *jit_args),
+                get_customize_batch_prefill_module(backend, *jit_args, **jit_kwargs),
             )
         else:
             self._jit_module = None
@@ -1915,6 +2421,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._mask_indptr_buf = mask_indptr_buf
         self._max_total_num_rows = None
         self._backend = backend
+        self._cached_module = None
 
     @property
     def is_cuda_graph_enabled(self) -> bool:
@@ -1964,6 +2471,11 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         rope_theta: Optional[float] = None,
         q_data_type: Union[str, torch.dtype] = "float16",
         kv_data_type: Optional[Union[str, torch.dtype]] = None,
+        non_blocking: bool = True,
+        prefix_len_ptr: Optional[torch.Tensor] = None,
+        token_pos_in_items_ptr: Optional[torch.Tensor] = None,
+        token_pos_in_items_len: int = 0,
+        max_item_len_ptr: Optional[torch.Tensor] = None,
     ) -> None:
         r"""Plan batch prefill/append attention on Ragged KV-Cache for given problem specification.
 
@@ -2031,6 +2543,22 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             The data type of the query tensor, defaults to torch.float16.
         kv_data_type : Optional[Union[str, torch.dtype]]
             The data type of the key/value tensor. If None, will be set to :attr:`q_data_type`.
+        non_blocking : bool
+            Whether to copy the input tensors to the device asynchronously, defaults to ``True``.
+        prefix_len_ptr :Optional[torch.Tensor]
+            prefix length. A uint32 1D tensor indicating the prefix length of each prompt. The tensor size is equal to the batch size.
+        token_pos_in_items_ptr : Optional[float]
+            A uint16 1D tensor (it will be converted to uint16 in flashinfer) indicating the token position of each item and started from 0 (delimiter)
+            for each item. E.g., if we have 3 items of length 3, 2, 4 respectively for this member. This vector will be looking like
+            `[0, 1, 2, 3, 0, 1, 2, 0, 1, 2, 3, 4, 0]` with 4 delimiters indexed as 0. For batch size > 1,
+            we will concat them as 1D with zero paddings to make sure each has the same length, the padding length is defined by
+            `token_pos_in_items_len` - length of the raw `token_pos_in_items_ptr` for each prompt.
+        token_pos_in_items_len : int
+            zero padding length for `token_pos_in_items_ptr` to better handle the bsz > 1 case. Still using the above 3,2,4 example.
+            If we set `token_pos_in_items_len` to be 20, it will be  `[0, 1, 2, 3, 0, 1, 2, 0, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0]`
+            with 7 padded zeros. (note there're 8 zeros in the end where the first one is the delimiter token 0 in the end of the prompt)
+        max_item_len_ptr : Optional[float]
+            a uint16 vector contains the max token length of all items for each prompt
 
         Note
         ----
@@ -2093,8 +2621,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                         batch_size, self._fixed_batch_size
                     )
                 )
-            self._qo_indptr_buf.copy_(qo_indptr)
-            self._kv_indptr_buf.copy_(kv_indptr)
+            self._qo_indptr_buf.copy_(qo_indptr, non_blocking=non_blocking)
+            self._kv_indptr_buf.copy_(kv_indptr, non_blocking=non_blocking)
             if packed_custom_mask is not None:
                 if not torch.is_tensor(self._custom_mask_buf):
                     raise ValueError(
@@ -2105,17 +2633,26 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                         "mask_indptr_buf must be initialized with a torch.Tensor in cuda graph mode if we use custom mask in the attention computation."
                     )
                 self._custom_mask_buf[: len(packed_custom_mask)] = packed_custom_mask
-                self._mask_indptr_buf.copy_(mask_indptr)
+                self._mask_indptr_buf.copy_(mask_indptr, non_blocking=non_blocking)
         else:
-            self._qo_indptr_buf = qo_indptr.to(self.device)
-            self._kv_indptr_buf = kv_indptr.to(self.device)
+            self._qo_indptr_buf = qo_indptr.to(self.device, non_blocking=non_blocking)
+            self._kv_indptr_buf = kv_indptr.to(self.device, non_blocking=non_blocking)
             if packed_custom_mask is not None:
-                self._custom_mask_buf = packed_custom_mask.to(self.device)
-                self._mask_indptr_buf = mask_indptr.to(self.device)
+                self._custom_mask_buf = packed_custom_mask.to(
+                    self.device, non_blocking=non_blocking
+                )
+                self._mask_indptr_buf = mask_indptr.to(
+                    self.device, non_blocking=non_blocking
+                )
 
         self._cached_q_data_type = q_data_type
         self._cached_kv_data_type = kv_data_type
         kv_len_arr = kv_indptr_host[1:] - kv_indptr_host[:-1]
+
+        self._prefix_len_ptr = prefix_len_ptr
+        self._token_pos_in_items_ptr = token_pos_in_items_ptr
+        self._token_pos_in_items_len = token_pos_in_items_len
+        self._max_item_len_ptr = max_item_len_ptr
 
         if self._jit_module is not None:
             self._cached_module = self._jit_module
@@ -2142,27 +2679,37 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 logits_soft_cap > 0,  # use_logits_soft_cap
                 use_fp16_qk_reduction,
             )
-            self._cached_module = get_batch_prefill_module(self._backend)(
-                *get_module_args
-            )
+            if self._backend == "cutlass":
+                self._cached_module = get_fmha_module(*get_module_args)
+            else:
+                self._cached_module = get_batch_prefill_module(
+                    self._backend, *get_module_args
+                )
 
-        self._plan_info = self._cached_module.plan(
-            self._float_workspace_buffer,
-            self._int_workspace_buffer,
-            self._pin_memory_int_workspace_buffer,
-            qo_indptr_host,
-            kv_indptr_host,
-            kv_len_arr,
-            self._max_total_num_rows or total_num_rows,
-            batch_size,
-            num_qo_heads,
-            num_kv_heads,
-            1,  # page_size
-            self.is_cuda_graph_enabled,
-            head_dim_qk,
-            head_dim_vo,
-            causal,
-        )
+        if self._backend == "cutlass":
+            self._plan_info = fmha_varlen_plan(
+                self._cached_module, qo_indptr, kv_indptr, num_qo_heads, causal
+            )
+            self._max_qo_len = torch.max(qo_indptr[1:] - qo_indptr[:-1]).item()
+        else:
+            assert self._cached_module is not None, "cached module is not initialized"
+            self._plan_info = self._cached_module.plan(
+                self._float_workspace_buffer,
+                self._int_workspace_buffer,
+                self._pin_memory_int_workspace_buffer,
+                qo_indptr_host,
+                kv_indptr_host,
+                kv_len_arr,
+                self._max_total_num_rows or total_num_rows,
+                batch_size,
+                num_qo_heads,
+                num_kv_heads,
+                1,  # page_size
+                self.is_cuda_graph_enabled,
+                head_dim_qk,
+                head_dim_vo,
+                causal,
+            )
 
         self._causal = causal
         self._pos_encoding_mode = pos_encoding_mode
@@ -2210,6 +2757,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
         return_lse: Literal[False] = False,
+        enable_pdl: Optional[bool] = None,
     ) -> torch.Tensor: ...
 
     @overload
@@ -2222,6 +2770,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
         return_lse: Literal[True] = True,
+        enable_pdl: Optional[bool] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]: ...
 
     def run(
@@ -2233,6 +2782,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         out: Optional[torch.Tensor] = None,
         lse: Optional[torch.Tensor] = None,
         return_lse: bool = False,
+        enable_pdl: Optional[bool] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         r"""Compute batch prefill/append attention between query and kv-cache stored as
         ragged tensor.
@@ -2253,7 +2803,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             The log-sum-exp of attention logits, if not provided, will be allocated internally.
         return_lse : bool
             Whether to return the logsumexp of attention output
-
+        enable_pdl : bool
+            Whether to enable Programmatic Dependent Launch (PDL). See https://docs.nvidia.com/cuda/cuda-c-programming-guide/#programmatic-dependent-launch-and-synchronization
+            Only supported for >= sm90, and currently only for FA2 and CUDA core decode.
         Returns
         -------
         Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
@@ -2263,6 +2815,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             * The attention output, shape: ``[qo_indptr[-1], num_qo_heads, head_dim_vo]``.
             * The logsumexp of attention output, shape: ``[qo_indptr[-1], num_qo_heads]``.
         """
+        if enable_pdl is None:
+            enable_pdl = device_support_pdl(q.device)
         _check_cached_qkv_data_type(
             q, k, self._cached_q_data_type, self._cached_kv_data_type
         )
@@ -2286,7 +2840,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     (q.size(0), q.size(1)), dtype=torch.float32, device=q.device
                 )
             else:
-                _check_shape_dtype_device(
+                check_shape_dtype_device(
                     lse, (q.size(0), q.size(1)), torch.float32, q.device, "lse"
                 )
         if out is None:
@@ -2294,9 +2848,24 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 q.shape[:-1] + v.shape[-1:], dtype=q.dtype, device=q.device
             )
         else:
-            _check_shape_dtype_device(
+            check_shape_dtype_device(
                 out, q.shape[:-1] + v.shape[-1:], q.dtype, q.device, "out"
             )
+        if self._backend == "cutlass":
+            out, lse = fmha_varlen(
+                q,
+                k,
+                v,
+                self._qo_indptr_buf,
+                self._kv_indptr_buf,
+                plan_info=self._plan_info,
+                causal=self._causal,
+                sm_scale=sm_scale,
+                max_qo_len=self._max_qo_len,
+                out=out,
+                lse=lse,
+            )
+            return (out, lse) if return_lse else out
 
         if is_float8(q):
             logging.warning(
@@ -2329,6 +2898,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             mask_mode,
             TensorLayout[self._kv_layout].value,
             window_left,
+            enable_pdl,
         ]
         if self._jit_module is not None:
             run_args.extend(list(args))
@@ -2337,12 +2907,17 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 self._custom_mask_buf,
                 self._mask_indptr_buf,
                 _get_cache_alibi_slopes_buf(q.shape[1], self.device),
+                self._prefix_len_ptr,
+                self._token_pos_in_items_ptr,
+                self._max_item_len_ptr,
                 logits_soft_cap,
                 sm_scale,
                 rope_scale,
                 rope_theta,
+                self._token_pos_in_items_len,
             ]
 
+        assert self._cached_module is not None, "cached module is not initialized"
         self._cached_module.ragged_run(*run_args)
         return (out, lse) if return_lse else out
 
@@ -2376,3 +2951,497 @@ class BatchPrefillWithRaggedKVCacheWrapper:
     def end_forward(self) -> None:
         r"""Warning: this function is deprecated and has no effect."""
         pass
+
+
+def fmha_varlen_plan(
+    module,
+    qo_segment_offsets: torch.Tensor,
+    kv_segment_offsets: torch.Tensor,
+    num_qo_heads: int,
+    causal: bool,
+):
+    num_ctas = torch.cuda.get_device_properties(
+        qo_segment_offsets.device
+    ).multi_processor_count
+    work_indptr = torch.empty(
+        num_ctas + 1, device=qo_segment_offsets.device, dtype=torch.int32
+    )
+    qo_tile_indices = torch.empty(
+        131072, device=qo_segment_offsets.device, dtype=torch.int32
+    )
+    head_indices = torch.empty(
+        131072, device=qo_segment_offsets.device, dtype=torch.int32
+    )
+    batch_indices = torch.empty(
+        131072, device=qo_segment_offsets.device, dtype=torch.int32
+    )
+    module.plan(
+        qo_segment_offsets,
+        kv_segment_offsets,
+        work_indptr,
+        qo_tile_indices,
+        head_indices,
+        batch_indices,
+        256,  # qo_tile_size
+        num_qo_heads,
+        num_ctas,
+        causal,
+    )
+    return (
+        work_indptr,
+        qo_tile_indices,
+        head_indices,
+        batch_indices,
+    )
+
+
+@overload
+def fmha_varlen(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    qo_segment_offsets: torch.Tensor,
+    kv_segment_offsets: torch.Tensor,
+    plan_info: Optional[List[torch.Tensor]] = None,
+    max_qo_len: Optional[int] = None,
+    out: Optional[torch.Tensor] = None,
+    lse: Optional[torch.Tensor] = None,
+    causal: bool = False,
+    sm_scale: Optional[float] = None,
+    return_lse: Literal[False] = False,
+) -> torch.Tensor: ...
+
+
+@overload
+def fmha_varlen(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    qo_segment_offsets: torch.Tensor,
+    kv_segment_offsets: torch.Tensor,
+    plan_info: Optional[List[torch.Tensor]] = None,
+    max_qo_len: Optional[int] = None,
+    out: Optional[torch.Tensor] = None,
+    lse: Optional[torch.Tensor] = None,
+    causal: bool = False,
+    sm_scale: Optional[float] = None,
+    return_lse: Literal[True] = True,
+) -> Tuple[torch.Tensor, torch.Tensor]: ...
+
+
+def fmha_varlen(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    qo_segment_offsets: torch.Tensor,
+    kv_segment_offsets: torch.Tensor,
+    plan_info: Optional[List[torch.Tensor]] = None,
+    max_qo_len: Optional[int] = None,
+    out: Optional[torch.Tensor] = None,
+    lse: Optional[torch.Tensor] = None,
+    causal: bool = False,
+    sm_scale: Optional[float] = None,
+    return_lse: bool = False,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    workspace_buffer = _get_cache_buf(
+        "fmha_varlen_cutlass_workspace", 32 * 1024 * 1024, q.device
+    )
+    module = get_fmha_module(
+        q.dtype,
+        k.dtype,
+        v.dtype,
+        torch.int32,
+        q.shape[2],
+        v.shape[2],
+        PosEncodingMode.NONE.value,
+        False,  # use_sliding_window
+        False,  # use_logits_soft_cap
+    )
+
+    nnz_qo, num_qo_heads, head_dim_qk = q.shape
+    nnz_kv, num_kv_heads, head_dim_vo = v.shape
+
+    mask_mode_code = 1 if causal else 0
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(head_dim_qk)
+
+    qo_total_len = nnz_qo
+    if max_qo_len is None:
+        max_qo_len = torch.max(qo_segment_offsets[1:] - qo_segment_offsets[:-1]).item()
+
+    if plan_info is None:
+        plan_info = fmha_varlen_plan(
+            module, qo_segment_offsets, kv_segment_offsets, num_qo_heads, causal
+        )
+
+    (
+        work_indptr,
+        qo_tile_indices,
+        head_indices,
+        batch_indices,
+    ) = plan_info
+
+    if out is None:
+        out = torch.empty(
+            qo_total_len + max(max_qo_len, 128),
+            num_qo_heads,
+            head_dim_vo,
+            device=q.device,
+            dtype=q.dtype,
+        )[max(max_qo_len, 128) :]
+
+    if lse is None and return_lse:
+        lse = torch.empty(
+            qo_total_len, num_qo_heads, device=q.device, dtype=torch.float32
+        )
+
+    module.run(
+        workspace_buffer,
+        q,
+        k,
+        v,
+        qo_segment_offsets,
+        kv_segment_offsets,
+        work_indptr,
+        qo_tile_indices,
+        head_indices,
+        batch_indices,
+        out,
+        lse,
+        mask_mode_code,
+        sm_scale,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim_qk,
+        head_dim_vo,
+        max_qo_len,
+    )
+
+    return out, lse
+
+
+@functools.cache
+def get_trtllm_gen_fmha_module():
+    mod = trtllm_gen_fmha_module()
+    op = mod.build_and_load()
+    setup_cubin_loader(mod.get_library_path())
+    return op
+
+
+def trtllm_ragged_attention_deepseek(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    workspace_buffer: torch.Tensor,
+    seq_lens: torch.Tensor,
+    max_q_len: int,
+    max_kv_len: int,
+    bmm1_scale: float,
+    bmm2_scale: float,
+    o_sf_scale: float,
+    batch_size: int,
+    window_left: int,
+    cum_seq_lens_q: torch.Tensor,
+    cum_seq_lens_kv: torch.Tensor,
+    enable_pdl: bool,
+    is_causal: bool,
+    return_lse: bool,
+    attention_sinks: Optional[torch.Tensor] = None,
+    out: Optional[torch.Tensor] = None,
+    lse: Optional[torch.Tensor] = None,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    """
+    Parameters
+    ----------
+    query : torch.Tensor
+        query tensor with shape [num_tokens, num_heads, head_dim]
+    key : torch.Tensor
+        key tensor with shape [num_tokens, num_heads, head_dim]
+    value : torch.Tensor
+        value tensor with shape [num_tokens, num_heads, head_dim]
+    workspace_buffer : torch.Tensor
+        workspace buffer
+    seq_lens : torch.Tensor
+        sequence lengths
+    max_q_len : int
+        max query length
+    max_kv_len : int
+        max key/value length
+    bmm1_scale : float
+        scale for bmm1, scale_q * scale_k * 1.0 / (head_dim_qk ** 0.5)
+    bmm2_scale : float
+        scale for bmm2, scale_v
+    o_sf_scale : float
+        scale for output
+    batch_size : int
+        batch size
+    window_left : int
+        window left
+    cum_seq_lens_q : torch.Tensor
+        cumulative sequence lengths for query
+    cum_seq_lens_kv : torch.Tensor
+        cumulative sequence lengths for key/value
+    enable_pdl : bool
+        enable pdl
+    is_causal : bool
+        is causal
+    attention_sinks : Optional[torch.Tensor]
+        attention sinks
+    out : Optional[torch.Tensor]
+        output tensor, if not provided, will be allocated with shape [query.shape[0], query.shape[1], value.shape[2]]
+    lse : Optional[torch.Tensor]
+        lse tensor, if not provided, will be allocated with shape [query.shape[0], query.shape[1]]
+
+    Returns
+    -------
+    out: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+        output torch.Tensor or Tuple[torch.Tensor, torch.Tensor].
+        If return_lse is True, the output will be a tuple of two tensors, the first is the output tensor, the second is the lse tensor.
+        If return_lse is False, the output will be a single tensor.
+    """
+    assert query.shape[2] == 192 and key.shape[2] == 192 and value.shape[2] == 128, (
+        "currently only support deepseek r1 192 query and 128 value"
+    )
+
+    if enable_pdl is None:
+        enable_pdl = device_support_pdl(query.device)
+
+    run_func = get_trtllm_gen_fmha_module().trtllm_ragged_attention
+    sm_count = get_device_sm_count(query.device)
+    if out is None:
+        out = torch.empty(
+            query.shape[0],
+            query.shape[1],
+            value.shape[2],
+            device=query.device,
+            dtype=query.dtype,
+        )
+    if return_lse and lse is None:
+        lse = torch.empty(
+            query.shape[0],
+            query.shape[1],
+            device=query.device,
+            dtype=torch.float32,
+        )
+
+    workspace_size = workspace_buffer.numel() * workspace_buffer.element_size()
+    run_func(
+        out,
+        query,
+        key,
+        value,
+        workspace_buffer,
+        seq_lens,
+        max_q_len,
+        max_kv_len,
+        bmm1_scale,
+        bmm2_scale,
+        o_sf_scale,
+        batch_size,
+        window_left,
+        cum_seq_lens_q,
+        cum_seq_lens_kv,
+        sm_count,
+        enable_pdl,
+        is_causal,
+        workspace_size,
+        attention_sinks,
+        lse,
+    )
+    if return_lse:
+        return out, lse
+    else:
+        return out
+
+
+def trtllm_batch_context_with_kv_cache(
+    query: torch.Tensor,
+    kv_cache: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
+    workspace_buffer: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    max_q_len: int,
+    max_kv_len: int,
+    bmm1_scale: float,
+    bmm2_scale: float,
+    batch_size: int,
+    cum_seq_lens_q: torch.Tensor,
+    cum_seq_lens_kv: torch.Tensor,
+    window_left: int = -1,
+    out: Optional[Union[torch.Tensor, FP4Tensor]] = None,
+    out_dtype: Optional[Union[torch.dtype, str]] = None,
+    o_sf_scale: Optional[float] = None,
+    o_sf_vec_size: Optional[int] = None,
+    enable_pdl: Optional[bool] = None,
+    sinks: Optional[List[torch.Tensor]] = None,
+) -> Union[torch.Tensor, FP4Tensor]:
+    """
+    Parameters
+    ----------
+    query : torch.Tensor
+        query tensor with shape [num_tokens, num_heads, head_dim]
+    kv_cache : Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+        If kv_cache is a single tensor, it should be a tensor with shape [num_pages, 1 or 2, num_kv_heads, page_size, head_dim]
+        If kv_cache is a tuple of two tensors, it should be a tuple of two tensors with shape [num_pages, num_kv_heads, page_size, head_dim]
+    workspace_buffer : torch.Tensor. Must be initialized to 0 for its first use.
+        workspace
+    block_tables : torch.Tensor
+        page_table of kv cache, [batch_size, num_pages]
+    seq_lens : torch.Tensor
+        A uint32 1D tensor indicating the kv sequence length of each prompt. shape: ``[batch_size]``
+    max_q_len : int
+        max sequence length for query
+    max_kv_len : int
+        max sequence length for kv_cache
+    bmm1_scale : float
+        fused scale for bmm1 input.
+    bmm2_scale : float
+        fused scale for bmm2 input.
+    batch_size : int
+        batch size
+    cum_seq_lens_q : torch.Tensor
+        cumulative sequence length for query. shape: ``[batch_size + 1]``
+    cum_seq_lens_kv : torch.Tensor
+        cumulative sequence length for kv_cache. shape: ``[batch_size + 1]``
+    window_left : int = -1
+        The left (inclusive) window size for the attention window, when set to ``-1``, the window
+        size will be set to the full length of the sequence. Defaults to ``-1``.
+    out : Optional[Union[torch.Tensor, FP4Tensor]] = None
+        output tensor, if not provided, will be allocated with ``out_dtype``, if ``out_dtype`` is not provided, will use the type of ``query``.
+    out_dtype : Optional[Union[torch.dtype, str]] = None
+        output dtype, if not provided, will use the type of ``out``. For nvfp4, use string ``nvfp4``.
+    o_sf_scale : Optional[float] = None
+        scale for nvfp4 output tensor scale factor.
+    o_sf_vec_size : Optional[int] = None
+        vector size for nvfp4 output tensor scale factor.
+    sinks : Optional[List[torch.Tensor]] = None
+        additional value per head in the denominator of the softmax.
+
+    Returns
+    -------
+    out: Union[torch.Tensor, FP4Tensor]
+        output torch.Tensor or FP4Tensor.
+    """
+
+    if enable_pdl is None:
+        enable_pdl = device_support_pdl(query.device)
+
+    if isinstance(kv_cache, tuple):
+        k_cache, v_cache = kv_cache
+    else:
+        if kv_cache.shape[1] == 1:
+            k_cache, v_cache = kv_cache, kv_cache
+        else:
+            assert kv_cache.shape[1] == 2, (
+                "When kv_cache is a single tensor, the second dimension must be 1 or 2"
+            )
+            # NOTE(Zihao): unbind transforms [num_pages, 2, ...] to ([num_pages, ...], [num_pages, ...])
+            # it doesn't change underlying storage
+            k_cache, v_cache = kv_cache.unbind(dim=1)
+
+    run_func = get_trtllm_gen_fmha_module().trtllm_paged_attention_context
+    sm_count = get_device_sm_count(query.device)
+
+    if out_dtype == "nvfp4" or (out_dtype is None and isinstance(out, FP4Tensor)):
+        assert query.dtype == torch.float8_e4m3fn, (
+            "query must be fp8 when out_dtype is nvfp4."
+        )
+        assert o_sf_scale is not None
+        assert o_sf_vec_size in [None, 16], "only o_sf_vec_size = 16 is supported"
+        o_sf_vec_size = o_sf_vec_size or 16
+
+        fp4_out_shape = query.shape[:-1] + (ceil_div(query.shape[-1], 2),)
+
+        if isinstance(out, FP4Tensor):
+            fp4_out_scale_shape = (
+                out.scale.shape[0],
+                round_up(query.shape[1] * query.shape[2] // o_sf_vec_size, 4),
+            )
+            out_scale_factor = out.scale
+            o_sf_start_index = out.scale_start_index
+            out = out.data
+            # out_dtype may be None
+            out_dtype = out_dtype or "nvfp4"
+        elif out is None:
+            fp4_out_scale_shape = (
+                round_up(query.shape[0], 128),
+                round_up(query.shape[1] * query.shape[2] // o_sf_vec_size, 4),
+            )
+            out_scale_factor = torch.empty(
+                fp4_out_scale_shape, dtype=torch.float8_e4m3fn, device=query.device
+            )
+            o_sf_start_index = 0
+            out = torch.empty(fp4_out_shape, dtype=torch.uint8, device=query.device)
+        else:
+            raise ValueError(f"Invalid out: {out}")
+
+        assert out_dtype == "nvfp4"
+        assert isinstance(out, torch.Tensor)
+
+        # Use uint8 as the container dtype to compliant with next fp4 gemm.
+        check_shape_dtype_device(out, fp4_out_shape, torch.uint8, query.device, "out")
+
+        check_shape_dtype_device(
+            out_scale_factor,
+            fp4_out_scale_shape,
+            torch.float8_e4m3fn,
+            query.device,
+            "out_scale_factor",
+        )
+
+        # Check o_sf_start_index is valid
+        if (
+            o_sf_start_index < 0
+            or o_sf_start_index + out.shape[0] > out_scale_factor.shape[0]
+        ):
+            raise ValueError(
+                f"o_sf_start_index is out of the valid range of out_scale_factor. "
+                f"o_sf_start_index={o_sf_start_index}, out.shape[0]={out.shape[0]}, "
+                f"out_scale_factor.shape[0]={out_scale_factor.shape[0]}"
+            )
+
+    elif isinstance(out_dtype, torch.dtype) or out_dtype is None:
+        assert o_sf_scale is None
+        assert o_sf_vec_size is None
+        out_scale_factor = None
+        o_sf_start_index = 0
+        if out_dtype is None:
+            out_dtype = out.dtype if out is not None else query.dtype
+        out = out if out is not None else torch.empty_like(query, dtype=out_dtype)
+        if out_dtype not in (query.dtype, torch.float16, torch.bfloat16):
+            raise ValueError(f"Unsupported out_dtype: {out_dtype}")
+        check_shape_dtype_device(out, query.shape, out_dtype, query.device, "out")
+    else:
+        raise ValueError(f"Invalid out_dtype: {out_dtype}")
+
+    workspace_size = workspace_buffer.numel() * workspace_buffer.element_size()
+    run_func(
+        out,
+        out_scale_factor,
+        query,
+        k_cache,
+        v_cache,
+        workspace_buffer,
+        block_tables,
+        seq_lens,
+        max_q_len,
+        max_kv_len,
+        bmm1_scale,
+        bmm2_scale,
+        o_sf_scale or -1.0,
+        o_sf_vec_size or -1,
+        o_sf_start_index,
+        batch_size,
+        window_left,
+        cum_seq_lens_q,
+        cum_seq_lens_kv,
+        sm_count,
+        enable_pdl,
+        workspace_size,
+        sinks,
+    )
+    return (
+        out
+        if out_dtype != "nvfp4"
+        else FP4Tensor(out, out_scale_factor, o_sf_start_index, query.shape)
+    )

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -29,11 +29,14 @@ from .jit import (
     gen_single_prefill_module,
     get_batch_prefill_uri,
     get_single_prefill_uri,
-    setup_cubin_loader,
 )
 
 if IS_CUDA:
-    from .jit import gen_fmha_cutlass_sm100a_module, trtllm_gen_fmha_module
+    from .jit import (
+        setup_cubin_loader,
+        gen_fmha_cutlass_sm100a_module,
+        trtllm_gen_fmha_module,
+    )
     from .cudnn import cudnn_batch_prefill_with_kv_cache
 
 from .quantization import packbits, segment_packbits

--- a/flashinfer/rope.py
+++ b/flashinfer/rope.py
@@ -37,29 +37,7 @@ def gen_rope_module() -> JitSpec:
 
 @functools.cache
 def get_rope_module():
-    global _rope_module
-    if _rope_module is None:
-        if has_prebuilt_ops:
-            _kernels = torch.ops.flashinfer_hip_kernels
-
-            _rope_module = _kernels
-        else:
-            _rope_module = load_cuda_ops(
-                "rope",
-                [
-                    FLASHINFER_CSRC_DIR / "rope.cu",
-                    FLASHINFER_CSRC_DIR / "flashinfer_rope_ops.cu",
-                ],
-            )
-    return _rope_module
-
-
-@cache
-def get_module_attr(attr: str) -> Any:
-    global _rope_module
-    if _rope_module is None:
-        get_rope_module()
-    return getattr(_rope_module, attr).default
+    return gen_rope_module().build_and_load()
 
 
 @register_custom_op("flashinfer::apply_rope", mutates_args=("q_rope", "k_rope"))

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -14,385 +14,446 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import functools
 from types import SimpleNamespace
 from typing import Optional, Union
 
 import torch
 
-from .jit import FLASHINFER_CSRC_DIR, has_prebuilt_ops, load_cuda_ops
-from .utils import register_custom_op, register_fake_op
+from .jit import JitSpec
+from .jit import env as jit_env
+from .jit import gen_jit_spec
+from .utils import (
+    _get_cache_buf,
+    device_support_pdl,
+    register_custom_op,
+    register_fake_op,
+)
 
-_sampling_module = None
+
+def gen_sampling_module() -> JitSpec:
+    return gen_jit_spec(
+        "sampling",
+        [
+            jit_env.FLASHINFER_CSRC_DIR / "sampling.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "renorm.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "flashinfer_sampling_ops.cu",
+        ],
+    )
 
 
+@functools.cache
 def get_sampling_module():
-    global _sampling_module
-    if _sampling_module is None:
-        if has_prebuilt_ops:
-            _kernels = torch.ops.flashinfer_kernels
+    module = gen_sampling_module().build_and_load()
 
-            module = _kernels
-        else:
-            sources = [
-                FLASHINFER_CSRC_DIR / "sampling.cu",
-                FLASHINFER_CSRC_DIR / "renorm.cu",
-                FLASHINFER_CSRC_DIR / "flashinfer_sampling_ops.cu",
-            ]
-            module = load_cuda_ops("sampling", sources)
-
-        # torch library for sampling_from_probs
-
-        @register_custom_op("flashinfer::sampling_from_probs", mutates_args=())
-        def sampling_from_probs(
-            probs: torch.Tensor,
-            indices: Optional[torch.Tensor],
-            deterministic: bool,
-            generator: Optional[torch.Generator],
-        ) -> torch.Tensor:
-            device = probs.device
-            probs = probs.float()
-            batch_size = indices.size(0) if indices is not None else probs.size(0)
-            samples = torch.empty(batch_size, dtype=torch.int32, device=device)
-            module.sampling_from_probs.default(
-                probs,
-                samples,
-                indices,
-                deterministic,
-                generator,
-            )
-            return samples
-
-        @register_fake_op("flashinfer::sampling_from_probs")
-        def _fake_sampling_from_probs(
-            probs: torch.Tensor,
-            indices: Optional[torch.Tensor],
-            deterministic: bool,
-            generator: Optional[torch.Generator],
-        ) -> torch.Tensor:
-            batch_size = indices.size(0) if indices is not None else probs.size(0)
-            return torch.empty(batch_size, dtype=torch.int32, device=probs.device)
-
-        # torch library for top_p_sampling_from_probs
-
-        @register_custom_op("flashinfer::top_p_sampling_from_probs", mutates_args=())
-        def top_p_sampling_from_probs(
-            probs: torch.Tensor,
-            indices: Optional[torch.Tensor],
-            maybe_top_p_arr: Optional[torch.Tensor],
-            top_p_val: float,
-            deterministic: bool,
-            generator: Optional[torch.Generator],
-        ) -> torch.Tensor:
-            device = probs.device
-            probs = probs.float()
-            maybe_top_p_arr = (
-                maybe_top_p_arr.float() if maybe_top_p_arr is not None else None
-            )
-            batch_size = indices.size(0) if indices is not None else probs.size(0)
-            samples = torch.empty(batch_size, dtype=torch.int32, device=device)
-            module.top_p_sampling_from_probs.default(
-                probs,
-                samples,
-                indices,
-                maybe_top_p_arr,
-                top_p_val,
-                deterministic,
-                generator,
-            )
-            return samples
-
-        @register_fake_op("flashinfer::top_p_sampling_from_probs")
-        def _fake_top_p_sampling_from_probs(
-            probs: torch.Tensor,
-            indices: Optional[torch.Tensor],
-            maybe_top_p_arr: Optional[torch.Tensor],
-            top_p_val: float,
-            deterministic: bool,
-            generator: Optional[torch.Generator],
-        ) -> torch.Tensor:
-            sample = torch.empty(probs.size(0), dtype=torch.int32, device=probs.device)
-            return sample
-
-        # torch library for top_k_sampling_from_probs
-
-        @register_custom_op("flashinfer::top_k_sampling_from_probs", mutates_args=())
-        def top_k_sampling_from_probs(
-            probs: torch.Tensor,
-            indices: Optional[torch.Tensor],
-            maybe_top_k_arr: Optional[torch.Tensor],
-            top_k_val: int,
-            deterministic: bool,
-            generator: Optional[torch.Generator],
-        ) -> torch.Tensor:
-            device = probs.device
-            probs = probs.float()
-            batch_size = indices.size(0) if indices is not None else probs.size(0)
-            maybe_top_k_arr = (
-                maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
-            )
-            samples = torch.empty(batch_size, dtype=torch.int32, device=device)
-            module.top_k_sampling_from_probs.default(
-                probs,
-                samples,
-                indices,
-                maybe_top_k_arr,
-                top_k_val,
-                deterministic,
-                generator,
-            )
-            return samples
-
-        @register_fake_op("flashinfer::top_k_sampling_from_probs")
-        def _fake_top_k_sampling_from_probs(
-            probs: torch.Tensor,
-            indices: Optional[torch.Tensor],
-            maybe_top_k_arr: Optional[torch.Tensor],
-            top_k_val: int,
-            deterministic: bool,
-            generator: Optional[torch.Generator],
-        ) -> torch.Tensor:
-            batch_size = indices.size(0) if indices is not None else probs.size(0)
-            sample = torch.empty(batch_size, dtype=torch.int32, device=probs.device)
-            return sample
-
-        # torch library for min_p_sampling_from_probs
-
-        @register_custom_op("flashinfer::min_p_sampling_from_probs", mutates_args=())
-        def min_p_sampling_from_probs(
-            probs: torch.Tensor,
-            indices: Optional[torch.Tensor],
-            maybe_min_p_arr: Optional[torch.Tensor],
-            min_p_val: float,
-            deterministic: bool,
-            generator: Optional[torch.Generator],
-        ) -> torch.Tensor:
-            device = probs.device
-            probs = probs.float()
-            maybe_min_p_arr = (
-                maybe_min_p_arr.float() if maybe_min_p_arr is not None else None
-            )
-            batch_size = indices.size(0) if indices is not None else probs.size(0)
-            samples = torch.empty(batch_size, dtype=torch.int32, device=device)
-            module.min_p_sampling_from_probs.default(
-                probs,
-                samples,
-                indices,
-                maybe_min_p_arr,
-                min_p_val,
-                deterministic,
-                generator,
-            )
-            return samples
-
-        # torch library for top_k_top_p_sampling_from_probs
-
-        @register_custom_op(
-            "flashinfer::top_k_top_p_sampling_from_probs", mutates_args=()
+    @register_custom_op("flashinfer::softmax", mutates_args=("workspace_buffer",))
+    def softmax(
+        workspace_buffer: torch.Tensor,
+        logits: torch.Tensor,
+        maybe_temperature_arr: Optional[torch.Tensor],
+        temperature_val: float,
+        enable_pdl: bool,
+    ) -> torch.Tensor:
+        logits = logits.float()
+        probs = torch.empty_like(logits, device=logits.device)
+        maybe_temperature_arr = (
+            maybe_temperature_arr.float() if maybe_temperature_arr is not None else None
         )
-        def top_k_top_p_sampling_from_probs(
-            probs: torch.Tensor,
-            indices: Optional[torch.Tensor],
-            maybe_top_k_arr: Optional[torch.Tensor],
-            top_k_val: int,
-            maybe_top_p_arr: Optional[torch.Tensor],
-            top_p_val: float,
-            deterministic: bool,
-            generator: Optional[torch.Generator],
-        ) -> torch.Tensor:
-            device = probs.device
-            probs = probs.float()
-            maybe_top_k_arr = (
-                maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
-            )
-            maybe_top_p_arr = (
-                maybe_top_p_arr.float() if maybe_top_p_arr is not None else None
-            )
-            batch_size = indices.size(0) if indices is not None else probs.size(0)
-            samples = torch.empty(batch_size, dtype=torch.int32, device=device)
-            module.top_k_top_p_sampling_from_probs.default(
-                probs,
-                samples,
-                indices,
-                maybe_top_k_arr,
-                top_k_val,
-                maybe_top_p_arr,
-                top_p_val,
-                deterministic,
-                generator,
-            )
-            return samples
-
-        @register_fake_op("flashinfer::top_k_top_p_sampling_from_probs")
-        def _fake_top_k_top_p_sampling_from_probs(
-            probs: torch.Tensor,
-            indices: Optional[torch.Tensor],
-            maybe_top_k_arr: Optional[torch.Tensor],
-            top_k_val: int,
-            maybe_top_p_arr: Optional[torch.Tensor],
-            top_p_val: float,
-            deterministic: bool,
-            generator: Optional[torch.Generator],
-        ) -> torch.Tensor:
-            batch_size = indices.size(0) if indices is not None else probs.size(0)
-            sample = torch.empty(batch_size, dtype=torch.int32, device=probs.device)
-            return sample
-
-        # torch library for top_p_renorm_probs
-
-        @register_custom_op("flashinfer::top_p_renorm_probs", mutates_args=())
-        def top_p_renorm_probs(
-            probs: torch.Tensor,
-            maybe_top_p_arr: Optional[torch.Tensor],
-            top_p_val: float,
-        ) -> torch.Tensor:
-            device = probs.device
-            probs = probs.float()
-            maybe_top_p_arr = (
-                maybe_top_p_arr.float() if maybe_top_p_arr is not None else None
-            )
-            renorm_probs = torch.empty_like(probs)
-            module.top_p_renorm_probs.default(
-                probs,
-                renorm_probs,
-                maybe_top_p_arr,
-                top_p_val,
-            )
-            return renorm_probs
-
-        @register_fake_op("flashinfer::top_p_renorm_probs")
-        def _fake_top_p_renorm_probs(
-            probs: torch.Tensor,
-            maybe_top_p_arr: Optional[torch.Tensor],
-            top_p_val: float,
-        ) -> torch.Tensor:
-            return torch.empty_like(probs)
-
-        # torch library for top_k_renorm_probs
-
-        @register_custom_op("flashinfer::top_k_renorm_probs", mutates_args=())
-        def top_k_renorm_probs(
-            probs: torch.Tensor,
-            maybe_top_k_arr: Optional[torch.Tensor],
-            top_k_val: int,
-        ) -> torch.Tensor:
-            device = probs.device
-            probs = probs.float()
-            maybe_top_k_arr = (
-                maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
-            )
-            renorm_probs = torch.empty_like(probs)
-            module.top_k_renorm_probs.default(
-                probs,
-                renorm_probs,
-                maybe_top_k_arr,
-                top_k_val,
-            )
-            return renorm_probs
-
-        @register_fake_op("flashinfer::top_k_renorm_probs")
-        def _fake_top_k_renorm_probs(
-            probs: torch.Tensor,
-            maybe_top_k_arr: Optional[torch.Tensor],
-            top_k_val: int,
-        ) -> torch.Tensor:
-            return torch.empty_like(probs)
-
-        # torch library for top_k_mask_logits
-
-        @register_custom_op("flashinfer::top_k_mask_logits", mutates_args=())
-        def top_k_mask_logits(
-            logits: torch.Tensor,
-            maybe_top_k_arr: Optional[torch.Tensor],
-            top_k_val: int,
-        ) -> torch.Tensor:
-            device = logits.device
-            logits = logits.float()
-            maybe_top_k_arr = (
-                maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
-            )
-            mask_logits = torch.empty_like(logits)
-            module.top_k_mask_logits.default(
-                logits,
-                mask_logits,
-                maybe_top_k_arr,
-                top_k_val,
-            )
-            return mask_logits
-
-        @register_fake_op("flashinfer::top_k_mask_logits")
-        def _fake_top_k_mask_logits(
-            logits: torch.Tensor,
-            maybe_top_k_arr: Optional[torch.Tensor],
-            top_k_val: int,
-        ) -> torch.Tensor:
-            return torch.empty_like(logits)
-
-        # torch library for chain_speculative_sampling
-
-        @register_custom_op(
-            "flashinfer::chain_speculative_sampling",
-            mutates_args=(
-                "output_accepted_token_num",
-                "output_emitted_draft_token_num",
-            ),
+        module.softmax.default(
+            workspace_buffer,
+            logits,
+            probs,
+            maybe_temperature_arr,
+            temperature_val,
+            enable_pdl,
         )
-        def chain_speculative_sampling(
-            draft_probs: torch.Tensor,
-            draft_token_ids: torch.Tensor,
-            target_probs: torch.Tensor,
-            output_accepted_token_num: torch.Tensor,
-            output_emitted_draft_token_num: torch.Tensor,
-            deterministic: bool,
-            generator: Optional[torch.Generator],
-        ) -> torch.Tensor:
-            device = draft_probs.device
-            draft_probs = draft_probs.float()
-            draft_token_ids = draft_token_ids.int()
-            target_probs = target_probs.float()
-            output_accepted_token_num = output_accepted_token_num.int()
-            output_emitted_draft_token_num = output_emitted_draft_token_num.int()
-            b, n = draft_token_ids.shape
-            output_token_ids = torch.empty((b, n + 1), dtype=torch.int32, device=device)
-            module.chain_speculative_sampling.default(
-                draft_probs,
-                draft_token_ids,
-                target_probs,
-                output_token_ids,
-                output_accepted_token_num,
-                output_emitted_draft_token_num,
-                deterministic,
-                generator,
-            )
-            return output_token_ids
+        return probs
 
-        @register_fake_op("flashinfer::chain_speculative_sampling")
-        def _fake_chain_speculative_sampling(
-            draft_probs: torch.Tensor,
-            draft_token_ids: torch.Tensor,
-            target_probs: torch.Tensor,
-            output_accepted_token_num: torch.Tensor,
-            output_emitted_draft_token_num: torch.Tensor,
-            deterministic: bool,
-            generator: Optional[torch.Generator],
-        ) -> torch.Tensor:
-            b, n = draft_token_ids.shape
-            device = draft_token_ids.device
-            return torch.empty((b, n + 1), dtype=torch.int32, device=device)
+    @register_fake_op("flashinfer::softmax")
+    def _fake_softmax(
+        workspace_buffer: torch.Tensor,
+        logits: torch.Tensor,
+        maybe_temperature_arr: Optional[torch.Tensor],
+        temperature_val: float,
+        enable_pdl: bool,
+    ) -> torch.Tensor:
+        return torch.empty_like(logits, device=logits.device, dtype=torch.float32)
 
-        # Register the module
-        _sampling_module = SimpleNamespace(
-            sampling_from_probs=sampling_from_probs,
-            top_p_sampling_from_probs=top_p_sampling_from_probs,
-            top_k_sampling_from_probs=top_k_sampling_from_probs,
-            min_p_sampling_from_probs=min_p_sampling_from_probs,
-            top_k_top_p_sampling_from_probs=top_k_top_p_sampling_from_probs,
-            top_p_renorm_probs=top_p_renorm_probs,
-            top_k_renorm_probs=top_k_renorm_probs,
-            top_k_mask_logits=top_k_mask_logits,
-            chain_speculative_sampling=chain_speculative_sampling,
+    # torch library for sampling_from_logits
+    @register_custom_op("flashinfer::sampling_from_logits", mutates_args=())
+    def sampling_from_logits(
+        logits: torch.Tensor,
+        indices: Optional[torch.Tensor],
+        deterministic: bool,
+        generator: Optional[torch.Generator],
+    ) -> torch.Tensor:
+        device = logits.device
+        # TODO: support more data types in logits to avoid conversion
+        # to float32
+        logits = logits.float()
+        batch_size = indices.size(0) if indices is not None else logits.size(0)
+        samples = torch.empty(batch_size, dtype=torch.int32, device=device)
+        module.sampling_from_logits.default(
+            logits,
+            samples,
+            indices,
+            deterministic,
+            generator,
         )
+        return samples
 
-    return _sampling_module
+    @register_fake_op("flashinfer::sampling_from_logits")
+    def _fake_sampling_from_logits(
+        logits: torch.Tensor,
+        indices: Optional[torch.Tensor],
+        deterministic: bool,
+        generator: Optional[torch.Generator],
+    ) -> torch.Tensor:
+        batch_size = indices.size(0) if indices is not None else logits.size(0)
+        return torch.empty(batch_size, dtype=torch.int32, device=logits.device)
+
+    # torch library for sampling_from_probs
+
+    @register_custom_op("flashinfer::sampling_from_probs", mutates_args=())
+    def sampling_from_probs(
+        probs: torch.Tensor,
+        indices: Optional[torch.Tensor],
+        deterministic: bool,
+        generator: Optional[torch.Generator],
+    ) -> torch.Tensor:
+        device = probs.device
+        probs = probs.float()
+        batch_size = indices.size(0) if indices is not None else probs.size(0)
+        samples = torch.empty(batch_size, dtype=torch.int32, device=device)
+        module.sampling_from_probs.default(
+            probs,
+            samples,
+            indices,
+            deterministic,
+            generator,
+        )
+        return samples
+
+    # torch library for sampling_from_probs
+
+    @register_fake_op("flashinfer::sampling_from_probs")
+    def _fake_sampling_from_probs(
+        probs: torch.Tensor,
+        indices: Optional[torch.Tensor],
+        deterministic: bool,
+        generator: Optional[torch.Generator],
+    ) -> torch.Tensor:
+        batch_size = indices.size(0) if indices is not None else probs.size(0)
+        return torch.empty(batch_size, dtype=torch.int32, device=probs.device)
+
+    # torch library for top_p_sampling_from_probs
+
+    @register_custom_op("flashinfer::top_p_sampling_from_probs", mutates_args=())
+    def top_p_sampling_from_probs(
+        probs: torch.Tensor,
+        indices: Optional[torch.Tensor],
+        maybe_top_p_arr: Optional[torch.Tensor],
+        top_p_val: float,
+        deterministic: bool,
+        generator: Optional[torch.Generator],
+    ) -> torch.Tensor:
+        device = probs.device
+        probs = probs.float()
+        maybe_top_p_arr = (
+            maybe_top_p_arr.float() if maybe_top_p_arr is not None else None
+        )
+        batch_size = indices.size(0) if indices is not None else probs.size(0)
+        samples = torch.empty(batch_size, dtype=torch.int32, device=device)
+        module.top_p_sampling_from_probs.default(
+            probs,
+            samples,
+            indices,
+            maybe_top_p_arr,
+            top_p_val,
+            deterministic,
+            generator,
+        )
+        return samples
+
+    @register_fake_op("flashinfer::top_p_sampling_from_probs")
+    def _fake_top_p_sampling_from_probs(
+        probs: torch.Tensor,
+        indices: Optional[torch.Tensor],
+        maybe_top_p_arr: Optional[torch.Tensor],
+        top_p_val: float,
+        deterministic: bool,
+        generator: Optional[torch.Generator],
+    ) -> torch.Tensor:
+        sample = torch.empty(probs.size(0), dtype=torch.int32, device=probs.device)
+        return sample
+
+    # torch library for top_k_sampling_from_probs
+
+    @register_custom_op("flashinfer::top_k_sampling_from_probs", mutates_args=())
+    def top_k_sampling_from_probs(
+        probs: torch.Tensor,
+        indices: Optional[torch.Tensor],
+        maybe_top_k_arr: Optional[torch.Tensor],
+        top_k_val: int,
+        deterministic: bool,
+        generator: Optional[torch.Generator],
+    ) -> torch.Tensor:
+        device = probs.device
+        probs = probs.float()
+        batch_size = indices.size(0) if indices is not None else probs.size(0)
+        maybe_top_k_arr = maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
+        samples = torch.empty(batch_size, dtype=torch.int32, device=device)
+        module.top_k_sampling_from_probs.default(
+            probs,
+            samples,
+            indices,
+            maybe_top_k_arr,
+            top_k_val,
+            deterministic,
+            generator,
+        )
+        return samples
+
+    @register_fake_op("flashinfer::top_k_sampling_from_probs")
+    def _fake_top_k_sampling_from_probs(
+        probs: torch.Tensor,
+        indices: Optional[torch.Tensor],
+        maybe_top_k_arr: Optional[torch.Tensor],
+        top_k_val: int,
+        deterministic: bool,
+        generator: Optional[torch.Generator],
+    ) -> torch.Tensor:
+        batch_size = indices.size(0) if indices is not None else probs.size(0)
+        sample = torch.empty(batch_size, dtype=torch.int32, device=probs.device)
+        return sample
+
+    # torch library for min_p_sampling_from_probs
+
+    @register_custom_op("flashinfer::min_p_sampling_from_probs", mutates_args=())
+    def min_p_sampling_from_probs(
+        probs: torch.Tensor,
+        indices: Optional[torch.Tensor],
+        maybe_min_p_arr: Optional[torch.Tensor],
+        min_p_val: float,
+        deterministic: bool,
+        generator: Optional[torch.Generator],
+    ) -> torch.Tensor:
+        device = probs.device
+        probs = probs.float()
+        maybe_min_p_arr = (
+            maybe_min_p_arr.float() if maybe_min_p_arr is not None else None
+        )
+        batch_size = indices.size(0) if indices is not None else probs.size(0)
+        samples = torch.empty(batch_size, dtype=torch.int32, device=device)
+        module.min_p_sampling_from_probs.default(
+            probs,
+            samples,
+            indices,
+            maybe_min_p_arr,
+            min_p_val,
+            deterministic,
+            generator,
+        )
+        return samples
+
+    # torch library for top_k_top_p_sampling_from_probs
+
+    @register_custom_op("flashinfer::top_k_top_p_sampling_from_probs", mutates_args=())
+    def top_k_top_p_sampling_from_probs(
+        probs: torch.Tensor,
+        indices: Optional[torch.Tensor],
+        maybe_top_k_arr: Optional[torch.Tensor],
+        top_k_val: int,
+        maybe_top_p_arr: Optional[torch.Tensor],
+        top_p_val: float,
+        deterministic: bool,
+        generator: Optional[torch.Generator],
+    ) -> torch.Tensor:
+        device = probs.device
+        probs = probs.float()
+        maybe_top_k_arr = maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
+        maybe_top_p_arr = (
+            maybe_top_p_arr.float() if maybe_top_p_arr is not None else None
+        )
+        batch_size = indices.size(0) if indices is not None else probs.size(0)
+        samples = torch.empty(batch_size, dtype=torch.int32, device=device)
+        module.top_k_top_p_sampling_from_probs.default(
+            probs,
+            samples,
+            indices,
+            maybe_top_k_arr,
+            top_k_val,
+            maybe_top_p_arr,
+            top_p_val,
+            deterministic,
+            generator,
+        )
+        return samples
+
+    @register_fake_op("flashinfer::top_k_top_p_sampling_from_probs")
+    def _fake_top_k_top_p_sampling_from_probs(
+        probs: torch.Tensor,
+        indices: Optional[torch.Tensor],
+        maybe_top_k_arr: Optional[torch.Tensor],
+        top_k_val: int,
+        maybe_top_p_arr: Optional[torch.Tensor],
+        top_p_val: float,
+        deterministic: bool,
+        generator: Optional[torch.Generator],
+    ) -> torch.Tensor:
+        batch_size = indices.size(0) if indices is not None else probs.size(0)
+        sample = torch.empty(batch_size, dtype=torch.int32, device=probs.device)
+        return sample
+
+    # torch library for top_p_renorm_probs
+
+    @register_custom_op("flashinfer::top_p_renorm_probs", mutates_args=())
+    def top_p_renorm_probs(
+        probs: torch.Tensor,
+        maybe_top_p_arr: Optional[torch.Tensor],
+        top_p_val: float,
+    ) -> torch.Tensor:
+        probs = probs.float()
+        maybe_top_p_arr = (
+            maybe_top_p_arr.float() if maybe_top_p_arr is not None else None
+        )
+        renorm_probs = torch.empty_like(probs)
+        module.top_p_renorm_probs.default(
+            probs,
+            renorm_probs,
+            maybe_top_p_arr,
+            top_p_val,
+        )
+        return renorm_probs
+
+    @register_fake_op("flashinfer::top_p_renorm_probs")
+    def _fake_top_p_renorm_probs(
+        probs: torch.Tensor,
+        maybe_top_p_arr: Optional[torch.Tensor],
+        top_p_val: float,
+    ) -> torch.Tensor:
+        return torch.empty_like(probs)
+
+    # torch library for top_k_renorm_probs
+
+    @register_custom_op("flashinfer::top_k_renorm_probs", mutates_args=())
+    def top_k_renorm_probs(
+        probs: torch.Tensor,
+        maybe_top_k_arr: Optional[torch.Tensor],
+        top_k_val: int,
+    ) -> torch.Tensor:
+        probs = probs.float()
+        maybe_top_k_arr = maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
+        renorm_probs = torch.empty_like(probs)
+        module.top_k_renorm_probs.default(
+            probs,
+            renorm_probs,
+            maybe_top_k_arr,
+            top_k_val,
+        )
+        return renorm_probs
+
+    @register_fake_op("flashinfer::top_k_renorm_probs")
+    def _fake_top_k_renorm_probs(
+        probs: torch.Tensor,
+        maybe_top_k_arr: Optional[torch.Tensor],
+        top_k_val: int,
+    ) -> torch.Tensor:
+        return torch.empty_like(probs)
+
+    # torch library for top_k_mask_logits
+
+    @register_custom_op("flashinfer::top_k_mask_logits", mutates_args=())
+    def top_k_mask_logits(
+        logits: torch.Tensor,
+        maybe_top_k_arr: Optional[torch.Tensor],
+        top_k_val: int,
+    ) -> torch.Tensor:
+        logits = logits.float()
+        maybe_top_k_arr = maybe_top_k_arr.int() if maybe_top_k_arr is not None else None
+        mask_logits = torch.empty_like(logits)
+        module.top_k_mask_logits.default(
+            logits,
+            mask_logits,
+            maybe_top_k_arr,
+            top_k_val,
+        )
+        return mask_logits
+
+    @register_fake_op("flashinfer::top_k_mask_logits")
+    def _fake_top_k_mask_logits(
+        logits: torch.Tensor,
+        maybe_top_k_arr: Optional[torch.Tensor],
+        top_k_val: int,
+    ) -> torch.Tensor:
+        return torch.empty_like(logits)
+
+    # torch library for chain_speculative_sampling
+
+    @register_custom_op(
+        "flashinfer::chain_speculative_sampling",
+        mutates_args=(
+            "output_accepted_token_num",
+            "output_emitted_draft_token_num",
+        ),
+    )
+    def chain_speculative_sampling(
+        draft_probs: torch.Tensor,
+        draft_token_ids: torch.Tensor,
+        target_probs: torch.Tensor,
+        output_accepted_token_num: torch.Tensor,
+        output_emitted_draft_token_num: torch.Tensor,
+        deterministic: bool,
+        generator: Optional[torch.Generator],
+    ) -> torch.Tensor:
+        device = draft_probs.device
+        draft_probs = draft_probs.float()
+        draft_token_ids = draft_token_ids.int()
+        target_probs = target_probs.float()
+        output_accepted_token_num = output_accepted_token_num.int()
+        output_emitted_draft_token_num = output_emitted_draft_token_num.int()
+        b, n = draft_token_ids.shape
+        output_token_ids = torch.empty((b, n + 1), dtype=torch.int32, device=device)
+        module.chain_speculative_sampling.default(
+            draft_probs,
+            draft_token_ids,
+            target_probs,
+            output_token_ids,
+            output_accepted_token_num,
+            output_emitted_draft_token_num,
+            deterministic,
+            generator,
+        )
+        return output_token_ids
+
+    @register_fake_op("flashinfer::chain_speculative_sampling")
+    def _fake_chain_speculative_sampling(
+        draft_probs: torch.Tensor,
+        draft_token_ids: torch.Tensor,
+        target_probs: torch.Tensor,
+        output_accepted_token_num: torch.Tensor,
+        output_emitted_draft_token_num: torch.Tensor,
+        deterministic: bool,
+        generator: Optional[torch.Generator],
+    ) -> torch.Tensor:
+        b, n = draft_token_ids.shape
+        device = draft_token_ids.device
+        return torch.empty((b, n + 1), dtype=torch.int32, device=device)
+
+    # Register the module
+    return SimpleNamespace(
+        softmax=softmax,
+        sampling_from_probs=sampling_from_probs,
+        sampling_from_logits=sampling_from_logits,
+        top_p_sampling_from_probs=top_p_sampling_from_probs,
+        top_k_sampling_from_probs=top_k_sampling_from_probs,
+        min_p_sampling_from_probs=min_p_sampling_from_probs,
+        top_k_top_p_sampling_from_probs=top_k_top_p_sampling_from_probs,
+        top_p_renorm_probs=top_p_renorm_probs,
+        top_k_renorm_probs=top_k_renorm_probs,
+        top_k_mask_logits=top_k_mask_logits,
+        chain_speculative_sampling=chain_speculative_sampling,
+    )
 
 
 def _to_tensor_scalar_tuple(x):
@@ -400,6 +461,121 @@ def _to_tensor_scalar_tuple(x):
         return (x, 0)
     else:
         return (None, x)
+
+
+def softmax(
+    logits: torch.Tensor,
+    temperature: Optional[Union[torch.Tensor, float]] = None,
+    enable_pdl: Optional[bool] = None,
+) -> torch.Tensor:
+    r"""Fused GPU kernel for `online safe softmax <https://arxiv.org/abs/1805.02867>`_ with temperature scaling.
+
+
+    Parameters
+    ----------
+    logits : torch.Tensor
+        Input tensor of logits.
+    temperature: Optional[Union[torch.Tensor, float]]
+        Either a scalar or a tensor of shape ``(batch_size,)``, representing the temperature for temperature scaling.
+        If a scalar, the same temperature is used for all requests.
+        If a tensor, each request has its own temperature.
+    enable_pdl : Optional[bool]
+        Whether to enable Programmatic Dependent Launch (PDL) for improved performance on supported hardware.
+        If None (default), PDL will be automatically enabled on devices with compute capability >= 9.0.
+    Returns
+    -------
+    probs : torch.Tensor
+        Tensor of the same shape as input containing the softmax probabilities.
+
+    Examples
+    --------
+    >>> import torch
+    >>> import flashinfer
+    >>> torch.manual_seed(42)
+    >>> batch_size = 4
+    >>> vocab_size = 5
+    >>> logits = torch.rand(batch_size, vocab_size).to(0)
+    >>> logits
+    tensor([[0.8823, 0.9150, 0.3829, 0.9593, 0.3904],
+            [0.6009, 0.2566, 0.7936, 0.9408, 0.1332],
+            [0.9346, 0.5936, 0.8694, 0.5677, 0.7411],
+            [0.4294, 0.8854, 0.5739, 0.2666, 0.6274]], device='cuda:0')
+    >>> probs = flashinfer.sampling.softmax(logits, temperature=1.0)
+    >>> probs
+    tensor([[0.2309, 0.2385, 0.1401, 0.2493, 0.1412],
+            [0.2019, 0.1431, 0.2448, 0.2837, 0.1265],
+            [0.2401, 0.1707, 0.2249, 0.1664, 0.1979],
+            [0.1724, 0.2719, 0.1991, 0.1465, 0.2101]], device='cuda:0')
+    """
+    workspace_buffer = _get_cache_buf("softmax_workspace", 1024 * 1024, logits.device)
+    if temperature is None:
+        temperature = 1.0
+
+    # Auto-detect PDL support if not specified
+    if enable_pdl is None:
+        enable_pdl = device_support_pdl(logits.device)
+
+    return get_sampling_module().softmax(
+        workspace_buffer, logits, *_to_tensor_scalar_tuple(temperature), enable_pdl
+    )
+
+
+def sampling_from_logits(
+    logits: torch.Tensor,
+    indices: Optional[torch.Tensor] = None,
+    deterministic: bool = True,
+    generator: Optional[torch.Generator] = None,
+    check_nan: bool = False,
+) -> torch.Tensor:
+    r"""Fused GPU kernel for category sampling from logits. It's equivalent to sampling
+    from :attr:`logits` after applying softmax.
+    Parameters
+    ----------
+    logits: torch.Tensor
+        Logits for sampling. When indices is not provided, shape should be ``(batch_size, num_classes)``
+        and the i-th output will be sampled from the i-th row of logits. When indices is provided,
+        shape should be ``(unique_batch_size, num_classes)`` where unique_batch_size is the number of unique
+        probability distributions.
+    indices: Optional[torch.Tensor]
+        Optional indices tensor of shape ``(batch_size,)`` that maps each output to a row in logits.
+        For example, if indices[i] = j, then the i-th output will be sampled from logits[j].
+        This allows reusing the same probability distribution for multiple outputs.
+        If indices is not provided, the i-th output will be sampled from the i-th row of logits.
+    deterministic: bool
+        Since the sampling doesn't use cub's BlockScan, the sampling is deterministic. We keep this
+        argument for compatibility with other sampling functions.
+    generator: Optional[torch.Generator]
+        A random number generator for the operation.
+    check_nan: bool
+        Whether to check nan in :attr:`logits`, default is ``False``.
+    Returns
+    -------
+    samples: torch.Tensor
+        Sampled categories, shape (batch_size,). It's equivalent to sampling from
+        :attr:`logits` after applying softmax.
+    Examples
+    --------
+    >>> import torch
+    >>> import flashinfer
+    >>> torch.manual_seed(42)
+    >>> batch_size = 4
+    >>> vocab_size = 5
+    >>> logits = torch.rand(batch_size, vocab_size).to(0)
+    >>> logits
+    tensor([[0.8823, 0.9150, 0.3829, 0.9593, 0.3904],
+            [0.6009, 0.2566, 0.7936, 0.9408, 0.1332],
+            [0.9346, 0.5936, 0.8694, 0.5677, 0.7411],
+            [0.4294, 0.8854, 0.5739, 0.2666, 0.6274]], device='cuda:0')
+    >>> samples = flashinfer.sampling.sampling_from_logits(logits)
+    >>> samples
+    tensor([0, 1, 1, 1], device='cuda:0', dtype=torch.int32)
+    """
+    if check_nan:
+        if torch.any(torch.isnan(logits)):
+            raise ValueError("Input logits contains NaN.")
+    return get_sampling_module().sampling_from_logits(
+        logits, indices, deterministic, generator
+    )
 
 
 def sampling_from_probs(


### PR DESCRIPTION
## Summary
Refactors Python imports and JIT infrastructure to support clean CUDA/HIP device separation for v0.3.0 rebase.

## Changes
- Properly fixes `pytorch_hip.py` (HIP) to have only HIP-specific changes
- Updated core modules with IS_CUDA/IS_HIP guards: prefill, norm, rope, sampling
- Fixed JIT compilation framework: architecture detection, compiler selection, flag separation
- Removed CUDA-only features from HIP path (FA3, etc.)

## Testing
- ✅ Single prefill validated: 9 configurations passing on gfx942
- ✅ JIT compilation working: kernels load and execute correctly
- ✅ Architecture detection: correct gfx942 detection and compilation

## Known Limitations (Next PR)
- Batch operations need signature alignment (enable_pdl parameter)
- Test suite updates pending
- Full validation suite to follow

## Related Issues
- Part of: v0.2.5 → v0.3.0 migration

## Review Notes
Focus areas:
- Device guard patterns in prefill.py
- JIT module import logic in jit/__init__.py
- Compilation flag separation in jit/core.py