### PR TITLE
Adds a device_utils for HIP/CUDA device identification.

### DIFF
--- a/flashinfer/device_utils.py
+++ b/flashinfer/device_utils.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Device detection and capability utilities for CUDA/ROCm backends.
+
+This module provides a central location for device detection and backend
+selection, avoiding scattered checks throughout the codebase.
+"""
+
+from typing import Optional
+
+from torch import version
+
+
+def is_hip_available() -> bool:
+    """
+    Check if ROCm/HIP backend is available.
+
+    Returns:
+        bool: True if PyTorch was built with ROCm/HIP support
+    """
+    return hasattr(version, "hip") and version.hip is not None
+
+
+def is_cuda_available() -> bool:
+    """
+    Check if CUDA backend is available (and not HIP).
+
+    Returns:
+        bool: True if PyTorch was built with CUDA (not ROCm) support
+    """
+    return hasattr(version, "cuda") and version.cuda is not None
+
+
+# Global constants - evaluated once at module import
+# Use these throughout the codebase for device-specific logic
+IS_HIP = is_hip_available()
+IS_CUDA = is_cuda_available()
+
+
+def get_device_backend() -> str:
+    """
+    Get the current device backend.
+
+    Returns:
+        str: One of 'hip', 'cuda', or 'cpu'
+    """
+    if IS_HIP:
+        return "hip"
+    elif IS_CUDA:
+        return "cuda"
+    return "cpu"
+
+
+def get_backend_version() -> Optional[str]:
+    """
+    Get the version string of the current backend (CUDA or HIP).
+
+    Returns:
+        Optional[str]: Version string (e.g., "12.4" for CUDA or "6.4.0" for ROCm)
+                      Returns None if neither backend is available
+    """
+    if IS_HIP:
+        return version.hip
+    elif IS_CUDA:
+        return version.cuda
+    return None
+
+
+def get_backend_name() -> str:
+    """
+    Get a human-readable name for the current backend.
+
+    Returns:
+        str: "ROCm/HIP", "CUDA", or "CPU"
+    """
+    if IS_HIP:
+        return "ROCm/HIP"
+    elif IS_CUDA:
+        return "CUDA"
+    return "CPU"

--- a/flashinfer/hip_utils.py
+++ b/flashinfer/hip_utils.py
@@ -156,9 +156,6 @@ def validate_rocm_arch(arch_list: str = None, verbose: bool = False) -> str:
     return arch_list
 
 
-# New consolidated validation function to add to hip_utils.py
-
-
 def validate_flashinfer_rocm_arch(
     arch_list: str = None, torch_cpp_ext_module=None, verbose: bool = False
 ) -> tuple:
@@ -222,3 +219,67 @@ def validate_flashinfer_rocm_arch(
     # Return both the flags list and the set
     arch_set = set(requested_archs)
     return arch_flags, arch_set
+
+
+def check_torch_rocm_compatibility() -> None:
+    """
+    Verify that PyTorch is installed with compatible ROCm support.
+
+    This function checks:
+    1. PyTorch is installed
+    2. PyTorch has ROCm/HIP support (not CPU-only)
+    3. PyTorch ROCm version matches system ROCm version (if detectable)
+
+    Provides helpful error messages to guide users to correct installation.
+
+    Raises:
+        ImportError: If PyTorch is not installed
+        RuntimeError: If PyTorch doesn't have ROCm support
+    """
+    import warnings
+
+    from torch import version
+
+    # Check for torch package with rocm support
+    if not hasattr(version, "hip") or version.hip is None:
+        raise RuntimeError(
+            "\n" + "=" * 70 + "\n"
+            "ERROR: PyTorch does NOT have ROCm support.\n\n"
+            "You installed the CPU-only version from PyPI.\n"
+            "amd-flashinfer requires PyTorch compiled with ROCm support.\n\n"
+            "Fix this by:\n"
+            "  1. Uninstall current PyTorch:\n"
+            "     pip uninstall torch\n\n"
+            "  2. Install PyTorch for ROCm:\n"
+            "     pip install torch==2.7.1 --index-url https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4/\n\n"
+            "See https://github.com/rocm/flashinfer for detailed installation instructions.\n"
+            + "=" * 70
+        )
+
+    # ROCm version compatibility warning
+    torch_rocm = version.hip
+    torch_rocm_major_minor = ".".join(torch_rocm.split(".")[:2])
+
+    # Try to detect system ROCm version
+    system_rocm = get_system_rocm_version()
+
+    if system_rocm:
+        system_rocm_major_minor = ".".join(system_rocm.split(".")[:2])
+        if torch_rocm_major_minor != system_rocm_major_minor:
+            warnings.warn(
+                f"\n{'=' * 70}\n"
+                f"WARNING: ROCm version mismatch detected!\n\n"
+                f"  System ROCm version: {system_rocm}\n"
+                f"  PyTorch ROCm version: {torch_rocm_major_minor}\n\n"
+                f"This may cause runtime errors or crashes.\n\n"
+                f"To fix, reinstall PyTorch for your ROCm version:\n"
+                f"  pip install torch==2.7.1 --index-url "
+                f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{system_rocm}/\n\n"
+                f"Or if using uv:\n"
+                f"  export FLASHINFER_ROCM_VERSION={system_rocm}\n"
+                f"  uv pip install torch==2.7.1 --index-url "
+                f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{system_rocm}/\n"
+                f"{'=' * 70}",
+                RuntimeWarning,
+                stacklevel=2,
+            )


### PR DESCRIPTION
Adds a `device_utils` module that provides to globals `IS_HIP` and `IS_CUDA` to enable device identification. The globals are meant to be used elsewhere in the code for easy separation of HIP-only and CUDA-only functionalities.