### PR TITLE
Port OnlineSoftmax / SamplingFromLogits to HIP

### DIFF
--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -204,9 +204,7 @@ elif IS_HIP:
     from .rope import (
         apply_rope_with_cos_sin_cache_inplace as apply_rope_with_cos_sin_cache_inplace,
     )
-    from .sampling import (
-        chain_speculative_sampling as chain_speculative_sampling,
-    )
+    from .sampling import chain_speculative_sampling as chain_speculative_sampling
     from .sampling import min_p_sampling_from_probs as min_p_sampling_from_probs
     from .sampling import sampling_from_logits as sampling_from_logits
     from .sampling import sampling_from_probs as sampling_from_probs
@@ -236,4 +234,3 @@ else:
         "FlashInfer requires either CUDA or ROCm/HIP backend. "
         "Detected CPU-only PyTorch installation."
     )
-    

--- a/flashinfer/csrc_rocm/flashinfer_sampling_ops.cu
+++ b/flashinfer/csrc_rocm/flashinfer_sampling_ops.cu
@@ -15,6 +15,14 @@
  */
 #include "pytorch_extension_utils.h"
 
+void softmax(at::Tensor workspace_buffer, at::Tensor logits, at::Tensor output,
+             std::optional<at::Tensor> maybe_temperature_arr, double temperature_val,
+             bool enable_pdl);
+
+void sampling_from_logits(at::Tensor logits, at::Tensor output,
+                          std::optional<at::Tensor> maybe_indices, bool deterministic,
+                          std::optional<at::Generator> gen);
+
 void sampling_from_probs(at::Tensor probs, at::Tensor output,
                          std::optional<at::Tensor> maybe_indices, bool deterministic,
                          std::optional<at::Generator> gen);
@@ -56,6 +64,10 @@ void chain_speculative_sampling(at::Tensor draft_probs, at::Tensor draft_token_i
                                 std::optional<at::Generator> gen);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
+  // Online safe softmax with temperature scaling
+  m.def("softmax", softmax);
+  // Sample from logits (equivalent to softmax + sampling_from_probs)
+  m.def("sampling_from_logits", sampling_from_logits);
   // Sample from probabilities
   m.def("sampling_from_probs", sampling_from_probs);
   // Top-k sampling from probabilities

--- a/flashinfer/csrc_rocm/sampling.cu
+++ b/flashinfer/csrc_rocm/sampling.cu
@@ -21,6 +21,58 @@ typedef hipStream_t cudaStream_t;
 
 using namespace flashinfer;
 
+void softmax(at::Tensor workspace_buffer, at::Tensor logits, at::Tensor output,
+             std::optional<at::Tensor> maybe_temperature_arr, double temperature_val,
+             bool enable_pdl) {
+  CHECK_INPUT(workspace_buffer);
+  CHECK_INPUT(logits);
+  CHECK_INPUT(output);
+  auto device = logits.device();
+  CHECK_DIM(2, logits);  // logits: (batch_size, vocab_size)
+  unsigned int batch_size = logits.size(0);
+  unsigned int vocab_size = logits.size(1);
+
+  bool has_temperature_arr = maybe_temperature_arr.has_value();
+
+  const at::cuda::OptionalHIPGuardMasqueradingAsCUDA device_guard(device);
+  auto stream = at::cuda::getCurrentHIPStream();
+  gpuError_t status = sampling::OnlineSoftmax<float>(
+      static_cast<float*>(logits.data_ptr()), static_cast<float*>(output.data_ptr()), batch_size,
+      vocab_size,
+      has_temperature_arr ? static_cast<float*>(maybe_temperature_arr->data_ptr()) : nullptr,
+      static_cast<float>(temperature_val), workspace_buffer.data_ptr(),
+      workspace_buffer.element_size() * workspace_buffer.size(0), enable_pdl, stream);
+  TORCH_CHECK(status == gpuSuccess,
+              "OnlineSoftmax failed with error code " + std::string(hipGetErrorString(status)));
+}
+
+void sampling_from_logits(at::Tensor logits, at::Tensor output,
+                          std::optional<at::Tensor> maybe_indices, bool deterministic,
+                          std::optional<at::Generator> gen_) {
+  CHECK_INPUT(logits);
+  auto device = logits.device();
+  CHECK_DIM(2, logits);  // logits: (batch_size, vocab_size)
+  unsigned int batch_size = output.size(0);
+  unsigned int vocab_size = logits.size(1);
+
+  uint64_t philox_seed, philox_offset;
+  auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
+      gen_, at::cuda::detail::getDefaultCUDAGenerator());
+  std::lock_guard<std::mutex> lock(gen->mutex_);
+  at::PhiloxCudaState rng_engine_inputs = gen->philox_cuda_state(batch_size * vocab_size);
+  philox_seed = rng_engine_inputs.seed_.val;
+  philox_offset = rng_engine_inputs.offset_.val;
+
+  const at::cuda::OptionalHIPGuardMasqueradingAsCUDA device_guard(device);
+  auto stream = at::cuda::getCurrentHIPStream();
+  gpuError_t status = sampling::SamplingFromLogits(
+      static_cast<float*>(logits.data_ptr()), static_cast<int*>(output.data_ptr()),
+      maybe_indices.has_value() ? static_cast<int*>(maybe_indices->data_ptr()) : nullptr,
+      batch_size, vocab_size, deterministic, philox_seed, philox_offset, stream);
+  TORCH_CHECK(status == gpuSuccess, "SamplingFromLogits failed with error code " +
+                                        std::string(hipGetErrorString(status)));
+}
+
 void sampling_from_probs(at::Tensor probs, at::Tensor output,
                          std::optional<at::Tensor> maybe_indices, bool deterministic,
                          std::optional<at::Generator> gen_) {

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -233,6 +233,10 @@ def gen_jit_spec(
     elif IS_HIP:
         cuda_cflags += [
             "-ffast-math",  # HIP equivalent of -use_fast_math
+            "-fno-finite-math-only",  # Re-enable inf/NaN: clang's -ffast-math includes
+            # -ffinite-math-only which breaks kernels that use -inf
+            # as a sentinel (e.g. online-softmax Map+Reduce path).
+            # CUDA -use_fast_math does NOT enable finite-math-only.
         ]
 
     if verbose:

--- a/include/gpu_iface/utils.cuh
+++ b/include/gpu_iface/utils.cuh
@@ -27,6 +27,11 @@ __forceinline__ __device__ __host__ T1 ceil_div(const T1 x, const T2 y) {
   return (x + y - 1) / y;
 }
 
+template <typename T1, typename T2>
+__forceinline__ __device__ __host__ T1 round_up(const T1 x, const T2 y) {
+  return ceil_div(x, y) * y;
+}
+
 #if defined(PLATFORM_CUDA_DEVICE)
 inline std::pair<int, int> GetCudaComputeCapability() {
   int device_id = 0;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,7 @@ testpaths = [
     "tests/test_norm_hip.py",
     "tests/test_page.py",
     "tests/test_rope_hip.py",
+    "tests/test_sampling_hip.py",
     "tests/test_single_prefill_kernels_hip.py",
     "tests/test_sliding_window_hip.py",
 ]


### PR DESCRIPTION
## Port `OnlineSoftmax` / `SamplingFromLogits` to HIP and fix HIP compilation issues

### Summary

- Extends the unified `include/flashinfer/sampling.cuh` to support the two new upstream v0.3.1 kernels (`OnlineSoftmax`, `SamplingFromLogits`) on HIP/ROCm
- Adds the corresponding HIP torch wrappers and op registrations in `csrc_rocm/`
- Adds new test groups to `test_sampling_hip.py` covering softmax, sampling-from-logits, frequency validation, variable-k sampling, and neg-inf inputs
- Fixes three HIP-specific compilation/correctness bugs uncovered during testing

### Changes

**`include/flashinfer/sampling.cuh`**
- Restore `gpu_iface` portability headers (`macros.hpp`, `gpu_runtime_compat.hpp`, `dispatch.cuh`) unconditionally so `FI_GPU_CALL` / `gpuError_t` / `gpuStream_t` are available on both CUDA and HIP
- Guard HIP-specific includes (`hiprand`, `hipcub`, `gpu_iface` math/utils/vec_dtypes) under `#ifdef PLATFORM_HIP_DEVICE`
- Add `MaxReduceOp`/`MinReduceOp` for HIP via the `hipcub::Max`/`Min` alias
- Replace `cuda::std::numeric_limits` with `std::numeric_limits` throughout the new kernels
- Port `GenerateGumbelNoise` to use `hiprand` (4× `hiprand_uniform` instead of `curand_uniform4`, which does not exist in hiprand)
- Port `OnlineSoftmax` and `SamplingFromLogits` host functions: `gpuError_t`/`gpuStream_t`, `FI_GPU_CALL` + `gpuFuncSetAttribute`/`gpuLaunchKernel`; PDL blocks guarded by `#ifndef PLATFORM_HIP_DEVICE`
- **Bug fix:** Add `round_up` to `include/gpu_iface/utils.cuh` — it was defined only in the CUDA-path `utils.cuh` but called from code compiled on both paths
- **Bug fix:** Add `template` keyword to dependent-type template method calls (`.template Reduce<VEC_SIZE>`, `.template Sum<VEC_SIZE>`) — amdclang++ (Clang-based) enforces the C++ standard here while NVCC was permissive

**`flashinfer/csrc_rocm/sampling.cu` / `flashinfer_sampling_ops.cu`**
- Add `softmax()` and `sampling_from_logits()` HIP wrappers using `OptionalHIPGuardMasqueradingAsCUDA` and `getCurrentHIPStream()`
- Register both ops in the `TORCH_LIBRARY_FRAGMENT`

**`flashinfer/jit/core.py`**
- **Bug fix:** Add `-fno-finite-math-only` after `-ffast-math` in the HIP JIT compile flags. Clang's `-ffast-math` includes `-ffinite-math-only`, which treats infinity as undefined behavior and silently corrupts the `OnlineSoftmax` Map+Reduce kernel path (used for `batch_size ≤ 128`, `vocab_size ≥ 24576`), producing all-NaN output. CUDA's `-use_fast_math` does not enable `--finite-math-only`, so this divergence only affected HIP.

**`tests/test_sampling_hip.py`**
- Add `test_softmax` (parametrized over batch size, vocab size, temperature scalar/array, neg-inf inputs)
- Add `test_sampling_from_logits` (validity check)
- Add `test_sampling_from_logits_freq` (3M-sample frequency validation)
- Add `test_top_k_sampling_with_variable_k`
- Add `neginf_input` parameter to `test_top_k_mask_logits`

### Test plan
- [x] `pytest tests/test_sampling_hip.py` — 774 passed, 18 skipped (expected: `k > vocab_size` skip guards), 0 failures on gfx942
<img width="860" height="31" alt="image" src="https://github.com/user-attachments/assets/8a1699b2-a5e4-4dcf-9b23-bfbee7a11209" />
