### PR TITLE
Enable activation kernels on v0.3.1 API once more.

### DIFF
--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -160,6 +160,9 @@ elif IS_HIP:
     # HIP/ROCm Imports (AMD-ported modules)
     # ========================================
     from . import jit as jit
+    from .activation import gelu_and_mul as gelu_and_mul
+    from .activation import gelu_tanh_and_mul as gelu_tanh_and_mul
+    from .activation import silu_and_mul as silu_and_mul
     from .decode_rocm import (
         BatchDecodeWithPagedKVCacheWrapper as BatchDecodeWithPagedKVCacheWrapper,
     )  # type: ignore[no-redef]

--- a/flashinfer/jit/activation.py
+++ b/flashinfer/jit/activation.py
@@ -33,7 +33,7 @@ if IS_HIP:
     auto stream = at::hip::getCurrentHIPStream();
     DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
       uint32_t vec_size = 16 / sizeof(c_type);
-      uint32_t block_size = std::min(d / vec_size, 1024U);
+      uint32_t block_size = std::max(1U, std::min(d / vec_size, 1024U));
       dim3 gridDim(num_tokens);
       dim3 blockDim(block_size);
 

--- a/flashinfer/jit/activation.py
+++ b/flashinfer/jit/activation.py
@@ -1,18 +1,7 @@
-"""
-Copyright (c) 2024 by FlashInfer team.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# SPDX-FileCopyrightText: 2023-2025 Flashinfer team
+# SPDX-FileCopyrightText: 2025 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
 
 import os
 
@@ -21,8 +10,52 @@ import jinja2
 from . import env as jit_env
 from .core import JitSpec, gen_jit_spec
 from .utils import write_if_different
+from ..device_utils import IS_HIP
 
-activation_templ = r"""
+if IS_HIP:
+    activation_templ = r"""
+  #include <gpu_iface/platform.hpp>
+  #include <flashinfer/attention/generic/activation.cuh>
+  #include "pytorch_extension_utils.h"
+  #include <hip/hip_runtime.h>
+
+  {% set func_name = act_func_name ~ '_and_mul' %}
+
+  using namespace flashinfer;
+
+  {{ act_func_def }}
+
+  void {{ func_name }}(at::Tensor& out, at::Tensor& input, bool enable_pdl) {
+    int d = input.size(-1) / 2;
+    int64_t num_tokens = input.numel() / input.size(-1);
+
+    const c10::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(out.device());
+    auto stream = at::hip::getCurrentHIPStream();
+    DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
+      uint32_t vec_size = 16 / sizeof(c_type);
+      uint32_t block_size = std::min(d / vec_size, 1024U);
+      dim3 gridDim(num_tokens);
+      dim3 blockDim(block_size);
+
+      auto kernel = flashinfer::activation::act_and_mul_kernel<c_type, {{ act_func_name }}>;
+
+      hipLaunchKernelGGL(kernel, gridDim, blockDim, 0, stream,
+                         static_cast<c_type*>(out.data_ptr()),
+                         static_cast<c_type*>(input.data_ptr()), d);
+
+      hipError_t err = hipGetLastError();
+      TORCH_CHECK(err == hipSuccess, "Failed to launch kernel: ", hipGetErrorString(err));
+
+      return true;
+    });
+  }
+
+  TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
+    m.def("{{ func_name }}", {{ func_name }});
+  }
+  """
+else:
+    activation_templ = r"""
 #include <flashinfer/activation.cuh>
 #include "pytorch_extension_utils.h"
 #include <cuda_runtime.h>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ filterwarnings = [
 addopts = "-v"
 # HIP-specific test files - running 'pytest' with no args runs only these
 testpaths = [
+    "tests/test_activation.py",
     "tests/test_aot_hip.py",
     "tests/test_batch_decode_kernels_hip.py",
     "tests/test_batch_decode_vllm.py",
@@ -205,6 +206,7 @@ branch = true
 # AMD/HIP modified files - auto-updated by GitHub Action - DO NOT EDIT THIS SECTION MANUALLY
 include = [
     "flashinfer/__init__.py",
+    "flashinfer/activation.py",
     "flashinfer/aiter_utils.py",
     "flashinfer/aot_hip.py",
     "flashinfer/compilation_context_hip.py",
@@ -213,6 +215,7 @@ include = [
     "flashinfer/get_include_paths.py",
     "flashinfer/hip_utils.py",
     "flashinfer/jit/__init__.py",
+    "flashinfer/jit/activation.py",
     "flashinfer/jit/attention/__init__.py",
     "flashinfer/jit/attention/pytorch_hip.py",
     "flashinfer/jit/core.py",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,15 @@ import flashinfer
 # Build TORCH_COMPILE_FNS list conditionally based on available modules
 TORCH_COMPILE_FNS = []
 
+# Add activation functions (available on both CUDA and HIP)
+TORCH_COMPILE_FNS.extend(
+    [
+        flashinfer.activation.silu_and_mul,
+        flashinfer.activation.gelu_and_mul,
+        flashinfer.activation.gelu_tanh_and_mul,
+    ]
+)
+
 # Add cascade functions if available (CUDA only)
 if hasattr(flashinfer, "cascade"):
     TORCH_COMPILE_FNS.extend(


### PR DESCRIPTION
Re-enables FlashInfer fused activation (SiLU/GeLU/GeLU-tanh + mul) kernels on the v0.3.1-based trunk, and turns the activation unit tests back on so the restored functionality is exercised in CI.

**Changes:**
- Adds activation ops to the torch.compile monkeypatch list used by tests.
- Enables `tests/test_activation.py` in the default pytest `testpaths`.
- Updates HIP JIT activation code generation and exports activation entrypoints for the HIP backend.

<img width="1082" height="28" alt="image" src="https://github.com/user-attachments/assets/e31bf27d-9c6f-40a7-ae74-1aae9adffc08" />





