### PR TITLE
Add AITER backend support for Flashinfer SinglePrefill

### DIFF
--- a/examples/single_prefill_example.py
+++ b/examples/single_prefill_example.py
@@ -108,7 +108,6 @@ def single_prefill_with_kv_cache_example(
     pos_encoding_mode: str,
     logits_soft_cap: float,
     return_lse: bool,
-    backend: str = "auto",
 ):
     """
     Run single_prefill_with_kv_cache and verify the output against a naive PyTorch reference implementation.
@@ -163,7 +162,6 @@ def single_prefill_with_kv_cache_example(
             kv_layout=kv_layout,
             pos_encoding_mode=pos_encoding_mode,
             logits_soft_cap=logits_soft_cap,
-            backend=backend,
         )
         print(f"  FlashInfer output shape: {o.shape}, LSE shape: {lse.shape}")
         # Compute reference in FP32 for better accuracy
@@ -199,7 +197,6 @@ def single_prefill_with_kv_cache_example(
             kv_layout=kv_layout,
             pos_encoding_mode=pos_encoding_mode,
             logits_soft_cap=logits_soft_cap,
-            backend=backend,
         )
         print(f"  FlashInfer output shape: {o.shape}")
 
@@ -233,20 +230,19 @@ if __name__ == "__main__":
 
     # Self-attention with logits soft cap
     single_prefill_with_kv_cache_example(
-        128, 128, 1, 1, 64, False, "NHD", "NONE", 8.0, False, backend="aiter"
+        128, 128, 1, 1, 64, False, "NHD", "NONE", 8.0, False
     )
-
-    # # Self-attention without logits soft cap
+    # Self-attention without logits soft cap
     single_prefill_with_kv_cache_example(
-        128, 128, 1, 1, 64, False, "NHD", "NONE", 0.0, False, backend="aiter"
+        128, 128, 1, 1, 64, False, "NHD", "NONE", 0.0, False
     )
     # Multi-head attention (MHA)
     single_prefill_with_kv_cache_example(
-        128, 128, 4, 4, 64, False, "NHD", "NONE", 8.0, False, backend="aiter"
+        128, 128, 4, 4, 64, False, "NHD", "NONE", 8.0, False
     )
     # Grouped query attention (GQA)
     single_prefill_with_kv_cache_example(
-        128, 128, 8, 4, 64, False, "NHD", "NONE", 8.0, False, backend="aiter"
+        128, 128, 8, 4, 64, False, "NHD", "NONE", 8.0, False
     )
     # GQA with qo_len < kv_len (typical prefill)
     single_prefill_with_kv_cache_example(
@@ -254,21 +250,21 @@ if __name__ == "__main__":
     )
     # GQA with LSE enabled
     single_prefill_with_kv_cache_example(
-        15, 127, 8, 4, 64, False, "NHD", "NONE", 0.0, True, backend="aiter"
+        15, 127, 8, 4, 64, False, "NHD", "NONE", 0.0, True
     )
     # GQA with soft cap and LSE enabled
     single_prefill_with_kv_cache_example(
-        15, 127, 8, 4, 64, False, "NHD", "NONE", 8.0, True, backend="aiter"
+        15, 127, 8, 4, 64, False, "NHD", "NONE", 8.0, True
     )
 
-    # # Test case specifically for threadblock_sync_mdo_states validation
-    # # This config triggers CTA_TILE_Q=16, NUM_WARPS_KV=4, calling threadblock_sync_mdo_states
-    # print("\n" + "=" * 60)
-    # print("Testing threadblock_sync_mdo_states (CTA_TILE_Q=16, NUM_WARPS_KV=4)")
-    # print("=" * 60)
-    # single_prefill_with_kv_cache_example(
-    #     16, 128, 1, 1, 64, False, "NHD", "NONE", 0.0, False
-    # )
-    # single_prefill_with_kv_cache_example(
-    #     16, 128, 1, 1, 64, False, "NHD", "NONE", 0.0, True
-    # )
+    # Test case specifically for threadblock_sync_mdo_states validation
+    # This config triggers CTA_TILE_Q=16, NUM_WARPS_KV=4, calling threadblock_sync_mdo_states
+    print("\n" + "=" * 60)
+    print("Testing threadblock_sync_mdo_states (CTA_TILE_Q=16, NUM_WARPS_KV=4)")
+    print("=" * 60)
+    single_prefill_with_kv_cache_example(
+        16, 128, 1, 1, 64, False, "NHD", "NONE", 0.0, False
+    )
+    single_prefill_with_kv_cache_example(
+        16, 128, 1, 1, 64, False, "NHD", "NONE", 0.0, True
+    )

--- a/examples/single_prefill_example.py
+++ b/examples/single_prefill_example.py
@@ -108,6 +108,7 @@ def single_prefill_with_kv_cache_example(
     pos_encoding_mode: str,
     logits_soft_cap: float,
     return_lse: bool,
+    backend: str = "auto",
 ):
     """
     Run single_prefill_with_kv_cache and verify the output against a naive PyTorch reference implementation.
@@ -162,6 +163,7 @@ def single_prefill_with_kv_cache_example(
             kv_layout=kv_layout,
             pos_encoding_mode=pos_encoding_mode,
             logits_soft_cap=logits_soft_cap,
+            backend=backend,
         )
         print(f"  FlashInfer output shape: {o.shape}, LSE shape: {lse.shape}")
         # Compute reference in FP32 for better accuracy
@@ -197,6 +199,7 @@ def single_prefill_with_kv_cache_example(
             kv_layout=kv_layout,
             pos_encoding_mode=pos_encoding_mode,
             logits_soft_cap=logits_soft_cap,
+            backend=backend,
         )
         print(f"  FlashInfer output shape: {o.shape}")
 
@@ -230,19 +233,20 @@ if __name__ == "__main__":
 
     # Self-attention with logits soft cap
     single_prefill_with_kv_cache_example(
-        128, 128, 1, 1, 64, False, "NHD", "NONE", 8.0, False
+        128, 128, 1, 1, 64, False, "NHD", "NONE", 8.0, False, backend="aiter"
     )
-    # Self-attention without logits soft cap
+
+    # # Self-attention without logits soft cap
     single_prefill_with_kv_cache_example(
-        128, 128, 1, 1, 64, False, "NHD", "NONE", 0.0, False
+        128, 128, 1, 1, 64, False, "NHD", "NONE", 0.0, False, backend="aiter"
     )
     # Multi-head attention (MHA)
     single_prefill_with_kv_cache_example(
-        128, 128, 4, 4, 64, False, "NHD", "NONE", 8.0, False
+        128, 128, 4, 4, 64, False, "NHD", "NONE", 8.0, False, backend="aiter"
     )
     # Grouped query attention (GQA)
     single_prefill_with_kv_cache_example(
-        128, 128, 8, 4, 64, False, "NHD", "NONE", 8.0, False
+        128, 128, 8, 4, 64, False, "NHD", "NONE", 8.0, False, backend="aiter"
     )
     # GQA with qo_len < kv_len (typical prefill)
     single_prefill_with_kv_cache_example(
@@ -250,21 +254,21 @@ if __name__ == "__main__":
     )
     # GQA with LSE enabled
     single_prefill_with_kv_cache_example(
-        15, 127, 8, 4, 64, False, "NHD", "NONE", 0.0, True
+        15, 127, 8, 4, 64, False, "NHD", "NONE", 0.0, True, backend="aiter"
     )
     # GQA with soft cap and LSE enabled
     single_prefill_with_kv_cache_example(
-        15, 127, 8, 4, 64, False, "NHD", "NONE", 8.0, True
+        15, 127, 8, 4, 64, False, "NHD", "NONE", 8.0, True, backend="aiter"
     )
 
-    # Test case specifically for threadblock_sync_mdo_states validation
-    # This config triggers CTA_TILE_Q=16, NUM_WARPS_KV=4, calling threadblock_sync_mdo_states
-    print("\n" + "=" * 60)
-    print("Testing threadblock_sync_mdo_states (CTA_TILE_Q=16, NUM_WARPS_KV=4)")
-    print("=" * 60)
-    single_prefill_with_kv_cache_example(
-        16, 128, 1, 1, 64, False, "NHD", "NONE", 0.0, False
-    )
-    single_prefill_with_kv_cache_example(
-        16, 128, 1, 1, 64, False, "NHD", "NONE", 0.0, True
-    )
+    # # Test case specifically for threadblock_sync_mdo_states validation
+    # # This config triggers CTA_TILE_Q=16, NUM_WARPS_KV=4, calling threadblock_sync_mdo_states
+    # print("\n" + "=" * 60)
+    # print("Testing threadblock_sync_mdo_states (CTA_TILE_Q=16, NUM_WARPS_KV=4)")
+    # print("=" * 60)
+    # single_prefill_with_kv_cache_example(
+    #     16, 128, 1, 1, 64, False, "NHD", "NONE", 0.0, False
+    # )
+    # single_prefill_with_kv_cache_example(
+    #     16, 128, 1, 1, 64, False, "NHD", "NONE", 0.0, True
+    # )

--- a/examples/single_prefill_example.py
+++ b/examples/single_prefill_example.py
@@ -268,3 +268,4 @@ if __name__ == "__main__":
     single_prefill_with_kv_cache_example(
         16, 128, 1, 1, 64, False, "NHD", "NONE", 0.0, True
     )
+    

--- a/examples/single_prefill_example.py
+++ b/examples/single_prefill_example.py
@@ -268,4 +268,3 @@ if __name__ == "__main__":
     single_prefill_with_kv_cache_example(
         16, 128, 1, 1, 64, False, "NHD", "NONE", 0.0, True
     )
-    

--- a/flashinfer/prefill_rocm.py
+++ b/flashinfer/prefill_rocm.py
@@ -180,12 +180,9 @@ def _get_aiter_single_prefill_module():
 
         # Normalise k/v to NHD flat layout: [kv_len, num_kv_heads, head_dim].
         # We use mha_batch_prefill_func with page_size=1 (flat 3D KV layout)
-        # rather than flash_attn_varlen_func.  The varlen CK kernel has a
-        # device-side abort when kv_len is large (e.g. 512) and qo_len > kv_len
-        # with return_lse=True.  The batch_prefill kernel with page_size=1 is
-        # the same "buffer allocation" approach used by aiter_paged_run for
-        # non-native page sizes and correctly handles qo_len > kv_len
-        # (verified by AITER's own test_batch_prefill with (1024, 1023) etc.).
+        #The batch_prefill kernel with page_size=1 is the same "buffer allocation" 
+        # approach used by aiter_paged_run for non-native page sizes and correctly 
+        # handles qo_len > kv_len (verified by AITER's test_batch_prefill with (1024, 1023) etc.).
         if layout == TensorLayout["NHD"].value:
             # k shape: [kv_len, num_kv_heads, head_dim]
             kv_len = k.shape[0]


### PR DESCRIPTION
This PR integrates experimental support of AITER backend as an alternative to FA2 for Single Prefill operations with paged KV cache

Key Changes

**Key Changes**

- AITER Backend Detection & Setup
  - Added runtime detection for AITER availability on ROCm systems
  - Introduced `HAS_AITER` flag and aiter_mha_module import
  - Fallback to FA2 backend when AITER is not installed

- AITER Backend Implementation
  - `_get_aiter_single_prefill_module()`: Module-like namespace providing uniform interface with FA2
  - `aiter_paged_run()`: Main execution function for paged KV cache with AITER backend
  - `_aiter_noop_plan()`: No-op planning function (AITER doesn't require separate planning)

- Features
  - Full paged KV cache support
  - Causal masking and window attention support
  - Logits soft-capping support

- Test Coverage
  - Added unit tests to compare AITER single prefill calls with FA2 single prefill calls
  - Parametrized tests to run with both "fa2" and "aiter" backends
  - Added backend-specific test skipping (e.g., AITER with causal mode or non-NHD layouts)
  - Extended `test_single_prefill_with_kv_cache()`

Unit Test Results
* **test_single_prefill_kernels_hip.py**
```
===================================== 1444 passed, 480 skipped in 6.35s =====================================
```
* **Complete ROCm Flashinfer Test Suite**
```
=====================================  26036 passed, 2841 skipped in 426.81s (0:07:06) ===================================== 
```
To test:

Install pandas - dependency for AITER
```
pip install pandas
```

Install AITER

```
git clone --recursive https://github.com/ROCm/aiter.git
cd aiter
python setup.py develop
```

JIT Install Flashinfer
```
FLASHINFER_HIP_ARCHITECTURES=gfx942 \
  python -m pip wheel . --wheel-dir=./dist/ --no-deps --no-build-isolation -v
cd dist && pip install amd_flashinfer-*.whl
```

Run Tests
```
pytest tests/test_single_prefill_kernels_hip.py
```
Full Test Suite - From the Flashinfer src dir:
```
pytest
```