### PR TITLE
Feature/run tests in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ pytest -k "test_decode_kernels_hip"
 
 # Verbose output
 pytest -v
+
+# if the system has multiple GPUs, run tests parallely on the multiple GPUS
+pytest -n auto # automatically select all available GPUs
+pytest -n 4 # Run on the specified number of GPUs
 ```
 
 The default test configuration is specified in [pyproject.toml](pyproject.toml) under the `testpaths` setting.

--- a/flashinfer/hip_utils.py
+++ b/flashinfer/hip_utils.py
@@ -221,6 +221,22 @@ def validate_flashinfer_rocm_arch(
     return arch_flags, arch_set
 
 
+def get_available_gpu_count() -> int:
+    """
+    Query the number of AMD GPUs visible to the current process.
+
+    Uses torch.cuda.device_count(), which maps to the HIP runtime on ROCm and
+    respects HIP_VISIBLE_DEVICES / CUDA_VISIBLE_DEVICES.  torch is a required
+    dependency of amd-flashinfer, so no fallback is needed.
+
+    Returns:
+        int: Number of visible GPUs (0 if none are visible to this process).
+    """
+    import torch
+
+    return torch.cuda.device_count()
+
+
 def check_torch_rocm_compatibility() -> None:
     """
     Verify that PyTorch is installed with compatible ROCm support.
@@ -253,7 +269,8 @@ def check_torch_rocm_compatibility() -> None:
             "  2. Install PyTorch for ROCm:\n"
             "     pip install torch==2.7.1 --index-url https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4/\n\n"
             "See https://github.com/rocm/flashinfer for detailed installation instructions.\n"
-            + "=" * 70
+            + "="
+            * 70
         )
 
     # ROCm version compatibility warning

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ Documentation = "https://rocm.docs.amd.com/projects/install-on-linux/en/latest/i
 [project.optional-dependencies]
 dev = [
     "pytest",
+    "pytest-xdist",
 ]
 
 [build-system]

--- a/tests/rocm_tests/conftest.py
+++ b/tests/rocm_tests/conftest.py
@@ -1,15 +1,58 @@
-"""
-Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+# Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+import os
 
-  http://www.apache.org/licenses/LICENSE-2.0
+from flashinfer.hip_utils import get_available_gpu_count
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+
+def pytest_configure(config):
+    """Pin each pytest-xdist worker to a dedicated physical GPU.
+
+    When running under xdist (pytest -n <N>), each worker receives a unique
+    PYTEST_XDIST_WORKER env var (e.g. "gw0", "gw1", ...).  We map the numeric
+    suffix directly to a GPU ordinal and restrict the worker process to that
+    device by setting HIP_VISIBLE_DEVICES (and CUDA_VISIBLE_DEVICES for
+    compatibility).  Tests continue to address the device as index 0 and are
+    transparently routed to their assigned physical GPU — no test changes
+    required.
+    """
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker_id is None or not worker_id.startswith("gw"):
+        return
+
+    gpu_index = int(worker_id[2:])
+    n_gpus = get_available_gpu_count()
+    if gpu_index >= n_gpus:
+        raise RuntimeError(
+            f"xdist worker {worker_id} requires GPU {gpu_index} but only "
+            f"{n_gpus} GPU(s) are available. Pass a lower value to -n."
+        )
+    os.environ["HIP_VISIBLE_DEVICES"] = str(gpu_index)
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_index)
+
+
+def pytest_xdist_auto_num_workers(config):
+    """Return the number of available AMD GPUs for 'pytest -n auto'.
+
+    Raises RuntimeError if no GPUs are detected so the failure is explicit
+    rather than silently falling back to single-process execution.
+    """
+    n = get_available_gpu_count()
+    if n == 0:
+        raise RuntimeError(
+            "pytest -n auto: no AMD GPUs detected (torch.cuda.device_count() == 0). "
+            "Check HIP_VISIBLE_DEVICES or ROCm installation."
+        )
+    return n


### PR DESCRIPTION
Adds a pytest xdist configuration to utilize multiple GPUs if available to run tests in parallel. The changes on my 7 GPU node cut the test suite run time from ~40 mins to <6 mins.