### PR TITLE
[Fix] Add support for both CUDA and HIP generator headers in sampling.cu

### DIFF
--- a/flashinfer/csrc_rocm/sampling.cu
+++ b/flashinfer/csrc_rocm/sampling.cu
@@ -10,6 +10,14 @@ typedef hipStream_t cudaStream_t;
 #endif
 
 #include <ATen/Utils.h>
+#include <ATen/core/Generator.h>
+
+// Use HIP generator header if available, otherwise fall back to CUDA header
+#if __has_include(<ATen/hip/HIPGeneratorImpl.h>)
+#include <ATen/hip/HIPGeneratorImpl.h>
+#else
+#include <ATen/cuda/CUDAGeneratorImpl.h>
+#endif
 
 #include <flashinfer/sampling.cuh>
 


### PR DESCRIPTION
## 📌 Description

Adds conditional compilation to support both torch 2.8 and 2.9+ by detecting which generator header is available in the current environment.

- Use `__has_include` preprocessor check to detect available header
- Include `ATen/hip/HIPGeneratorImpl.h` for torch 2.9+ (native HIP support)
- Fall back to `ATen/cuda/CUDAGeneratorImpl.h` for torch 2.8 (and earlier)