### PR TITLE
[Feature] Add automatic GPU memory cleanup fixture for ROCm tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import gc
 import json
 import os
 import types
@@ -204,27 +203,7 @@ def is_cuda_oom_error_str(e: str) -> bool:
     return "CUDA" in e and "out of memory" in e
 
 
-def clear_cuda_cache(device: torch.device) -> None:
-    total_memory = get_device_properties(device).total_memory
-    reserved_memory = torch.cuda.memory_reserved()
-
-    # FLASHINFER_TEST_MEMORY_THRESHOLD: threshold for PyTorch reserved memory usage (default: 0.75)
-    threshold = float(os.environ.get("FLASHINFER_TEST_MEMORY_THRESHOLD", "0.75"))
-
-    if reserved_memory > threshold * total_memory:
-        gc.collect()
-        torch.cuda.empty_cache()
-
-
-@pytest.fixture(autouse=True, scope="function")
-def clear_gpu_memory():
-    yield
-    if torch.cuda.is_available():
-        device = torch.device("cuda:0")
-        clear_cuda_cache(device)  # Use the existing function
-
-
-@pytest.hookimpl(tryfirst=True)
+@pytest.hookimpl(wrapper=True)
 def pytest_runtest_call(item):
     # skip OOM error and missing JIT cache errors
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import gc
 import json
 import os
 import types
@@ -203,7 +204,27 @@ def is_cuda_oom_error_str(e: str) -> bool:
     return "CUDA" in e and "out of memory" in e
 
 
-@pytest.hookimpl(wrapper=True)
+def clear_cuda_cache(device: torch.device) -> None:
+    total_memory = get_device_properties(device).total_memory
+    reserved_memory = torch.cuda.memory_reserved()
+
+    # FLASHINFER_TEST_MEMORY_THRESHOLD: threshold for PyTorch reserved memory usage (default: 0.75)
+    threshold = float(os.environ.get("FLASHINFER_TEST_MEMORY_THRESHOLD", "0.75"))
+
+    if reserved_memory > threshold * total_memory:
+        gc.collect()
+        torch.cuda.empty_cache()
+
+
+@pytest.fixture(autouse=True, scope="function")
+def clear_gpu_memory():
+    yield
+    if torch.cuda.is_available():
+        device = torch.device("cuda:0")
+        clear_cuda_cache(device)  # Use the existing function
+
+
+@pytest.hookimpl(tryfirst=True)
 def pytest_runtest_call(item):
     # skip OOM error and missing JIT cache errors
     try:

--- a/tests/rocm_tests/conftest.py
+++ b/tests/rocm_tests/conftest.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 import os
+import pytest
+import torch
 
 from flashinfer.hip_utils import get_available_gpu_count
 
@@ -56,3 +59,23 @@ def pytest_xdist_auto_num_workers(config):
             "Check HIP_VISIBLE_DEVICES or ROCm installation."
         )
     return n
+
+
+def _maybe_clear_gpu_memory(device: torch.device) -> None:
+    total_memory = torch.cuda.get_device_properties(device).total_memory
+    reserved_memory = torch.cuda.memory_reserved()
+
+    # FLASHINFER_TEST_MEMORY_THRESHOLD: threshold for PyTorch reserved memory usage (default: 0.75)
+    threshold = float(os.environ.get("FLASHINFER_TEST_MEMORY_THRESHOLD", "0.75"))
+
+    if reserved_memory > threshold * total_memory:
+        gc.collect()
+        torch.cuda.empty_cache()
+
+
+@pytest.fixture(autouse=True, scope="function")
+def clear_gpu_memory():
+    yield
+    if torch.cuda.is_available():
+        # Assume single GPU per worker due to device pinning in pytest_configure
+        _maybe_clear_gpu_memory(torch.device("cuda"))

--- a/tests/rocm_tests/conftest.py
+++ b/tests/rocm_tests/conftest.py
@@ -63,7 +63,7 @@ def pytest_xdist_auto_num_workers(config):
 
 def _maybe_clear_gpu_memory(device: torch.device) -> None:
     total_memory = torch.cuda.get_device_properties(device).total_memory
-    reserved_memory = torch.cuda.memory_reserved()
+    reserved_memory = torch.cuda.memory_reserved(device)
 
     # FLASHINFER_TEST_MEMORY_THRESHOLD: threshold for PyTorch reserved memory usage (default: 0.75)
     threshold = float(os.environ.get("FLASHINFER_TEST_MEMORY_THRESHOLD", "0.75"))


### PR DESCRIPTION
## 📌 Description

Introduces an automatic pytest fixture that monitors and cleans GPU memory after each test in the ROCm test suite.

- Add `_maybe_clear_gpu_memory()` helper function to conditionally clear GPU cache based on memory threshold
- Add `clear_gpu_memory` fixture with `autouse=True` to run automatically after each test
- Configurable threshold via `FLASHINFER_TEST_MEMORY_THRESHOLD` environment variable (default: 0.75)