### PR TITLE
Move HIP_VISIBLE_DEVICES setting to top-level conftests.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,19 @@ from pathlib import Path
 from typing import Any, Dict, Set
 
 import pytest
+
+# Pin this worker to a dedicated GPU BEFORE torch initializes the ROCm/CUDA
+# runtime.  PYTEST_XDIST_WORKER is injected into each worker subprocess by
+# pytest-xdist before any Python code runs ("gw0", "gw1", ...).  Setting
+# HIP_VISIBLE_DEVICES here makes the ROCm runtime start up with exactly one
+# device so all device-0 references inside tests transparently route to the
+# assigned physical GPU.  This must happen before `import torch`.
+_xdist_worker = os.environ.get("PYTEST_XDIST_WORKER", "")
+if _xdist_worker.startswith("gw"):
+    _gpu_index = int(_xdist_worker[2:])
+    os.environ["HIP_VISIBLE_DEVICES"] = str(_gpu_index)
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(_gpu_index)
+
 import torch
 from torch.torch_version import TorchVersion
 from torch.torch_version import __version__ as torch_version

--- a/tests/rocm_tests/conftest.py
+++ b/tests/rocm_tests/conftest.py
@@ -12,35 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from flashinfer.hip_utils import get_available_gpu_count
-
-
-def pytest_configure(config):
-    """Pin each pytest-xdist worker to a dedicated physical GPU.
-
-    When running under xdist (pytest -n <N>), each worker receives a unique
-    PYTEST_XDIST_WORKER env var (e.g. "gw0", "gw1", ...).  We map the numeric
-    suffix directly to a GPU ordinal and restrict the worker process to that
-    device by setting HIP_VISIBLE_DEVICES (and CUDA_VISIBLE_DEVICES for
-    compatibility).  Tests continue to address the device as index 0 and are
-    transparently routed to their assigned physical GPU — no test changes
-    required.
-    """
-    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
-    if worker_id is None or not worker_id.startswith("gw"):
-        return
-
-    gpu_index = int(worker_id[2:])
-    n_gpus = get_available_gpu_count()
-    if gpu_index >= n_gpus:
-        raise RuntimeError(
-            f"xdist worker {worker_id} requires GPU {gpu_index} but only "
-            f"{n_gpus} GPU(s) are available. Pass a lower value to -n."
-        )
-    os.environ["HIP_VISIBLE_DEVICES"] = str(gpu_index)
-    os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_index)
 
 
 def pytest_xdist_auto_num_workers(config):


### PR DESCRIPTION
The previous attempt to run tests in parallel #176 did not schedule tests on multiple GPUs and the speed up was coming from using multiple CPU workers. However, all pytest workers were using the same GPU and could cause intermittent failures.

The PR fixes the issue properly by moving the setting of HIP_VISIBLE_DEVICES to top-level conftests,py