### PR TITLE
Add prefill and decode aliases to sys.modules

### DIFF
--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -253,6 +253,11 @@ elif IS_HIP:
     from . import decode_rocm as decode
     from . import prefill_rocm as prefill
 
+    import sys
+
+    sys.modules["flashinfer.prefill"] = sys.modules["flashinfer.prefill_rocm"]
+    sys.modules["flashinfer.decode"] = sys.modules["flashinfer.decode_rocm"]
+
     from .utils import next_positive_power_of_2 as next_positive_power_of_2
 else:
     # CPU-only torch (no CUDA or HIP)


### PR DESCRIPTION
Fixes import issues for direct imports of `flashinfer.prefill` and `flashinfer.decode` sub-module.

```bash
# python -c "from flashinfer.decode import BatchDecodeWithPagedKVCacheWrapper"
[aiter] import [module_aiter_enum] under /app/aiter/aiter/jit/module_aiter_enum.so
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/app/flashinfer/flashinfer/decode.py", line 25, in <module>
    from .cudnn import cudnn_batch_decode_with_kv_cache as cudnn_batch_decode_with_kv_cache
  File "/app/flashinfer/flashinfer/cudnn/__init__.py", line 1, in <module>
    from .decode import cudnn_batch_decode_with_kv_cache
  File "/app/flashinfer/flashinfer/cudnn/decode.py", line 6, in <module>
    from .utils import get_cudnn_fmha_gen_module
  File "/app/flashinfer/flashinfer/cudnn/utils.py", line 19, in <module>
    from ..jit.cubin_loader import setup_cubin_loader
  File "/app/flashinfer/flashinfer/jit/cubin_loader.py", line 28, in <module>
    from .env import FLASHINFER_CUBIN_DIR
ImportError: cannot import name 'FLASHINFER_CUBIN_DIR' from 'flashinfer.jit.env' (/app/flashinfer/flashinfer/jit/env.py)
```

The issue was although the `prefill_rocm` and `decode_rocm` modules are introduced as aliases in `flashinfer.__init__` it does not prevent import failures if the modules `flashinfer.prefill` and `flashinfer.decode` are imported directly. The PR fixes the issue properly by adding these into `sys.modules`.