### PR TITLE
Reduce the threshold from 0.99 to 0.98

### DIFF
--- a/tests/rocm_tests/test_logits_processor_hip.py
+++ b/tests/rocm_tests/test_logits_processor_hip.py
@@ -159,8 +159,8 @@ class TestLogitsPipeCompilationHIP:
 
         similarity_compiled = torch.cosine_similarity(freq_compiled, probs)
         similarity_no_compile = torch.cosine_similarity(freq_no_compile, probs)
-        assert similarity_compiled > 0.99, f"Compiled similarity: {similarity_compiled}"
-        assert similarity_no_compile > 0.99, (
+        assert similarity_compiled > 0.98, f"Compiled similarity: {similarity_compiled}"
+        assert similarity_no_compile > 0.98, (
             f"Non-compiled similarity: {similarity_no_compile}"
         )
 


### PR DESCRIPTION
Fix flaky tests on Rocm 7.2 by slightly reducing the accuracy threshold