### PR TITLE
Add AITER version check to Flashinfer and configure AITER during Docker build

### DIFF
--- a/docker/Dockerfile.rocm_ci
+++ b/docker/Dockerfile.rocm_ci
@@ -27,6 +27,7 @@ ARG ROCM_VERSION=7.1.1
 ARG PY_VERSION=3.12
 ARG TORCH_VERSION=2.8.0
 ARG MAMBA_ENV_NAME=base
+ARG AITER_ROCM_VERSION=0.1.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
@@ -51,6 +52,7 @@ RUN curl -L micro.mamba.pm/install.sh | bash && \
     ~/.local/bin/micromamba run -n ${MAMBA_ENV_NAME} ~/.local/bin/micromamba install python=${PY_VERSION} -c conda-forge --override-channels -y && \
     ~/.local/bin/micromamba run -n ${MAMBA_ENV_NAME} pip install cmake pybind11 build ninja scikit-build-core setuptools-scm numpy pytest pytest-xdist && \
     ~/.local/bin/micromamba run -n ${MAMBA_ENV_NAME} pip install torch==${TORCH_VERSION} -f https://repo.radeon.com/rocm/manylinux/rocm-rel-${ROCM_VERSION}/ && \
+    ~/.local/bin/micromamba run -n ${MAMBA_ENV_NAME} pip install amd_aiter==${AITER_ROCM_VERSION} --extra-index-url https://pypi.amd.com/rocm-${ROCM_VERSION}/simple && \
     /bin/bash -c "eval \"\$(~/.local/bin/micromamba shell hook --shell bash)\" && \
     micromamba activate ${MAMBA_ENV_NAME} && \
     cd /root/flashinfer/ && \

--- a/flashinfer/prefill_rocm.py
+++ b/flashinfer/prefill_rocm.py
@@ -62,7 +62,13 @@ if HAS_AITER:
 # Page sizes natively supported by the AITER CK kernel in linear
 # (non-vectorized) paged KV layout.  For any other page size the AITER
 # backend flattens pages into a token-level (page_size=1) buffer first.
-_AITER_NATIVE_PAGE_SIZES = frozenset({16, 1024})
+
+from importlib.metadata import version
+
+if version("amd-aiter") == "0.1.10":
+    _AITER_NATIVE_PAGE_SIZES = frozenset({128, 256, 1024})
+else:
+    _AITER_NATIVE_PAGE_SIZES = frozenset({16, 1024})
 
 
 def make_hashable_cache(func):


### PR DESCRIPTION
This PR adds a version check for the AITER backend. `AITER v0.1.10` uses a different set of `page_sizes` as opposed to `AITER v0.1.12`. This PR accommodates the `page_size` difference. 

This PR also installs AITER during the build stage of the CI to run AITER unit tests in CI. 