### PR TITLE
Add AITER_ROCM_VERSION

### DIFF
--- a/docker/Dockerfile.rocm_ci
+++ b/docker/Dockerfile.rocm_ci
@@ -27,7 +27,8 @@ ARG ROCM_VERSION=7.1.1
 ARG PY_VERSION=3.12
 ARG TORCH_VERSION=2.8.0
 ARG MAMBA_ENV_NAME=base
-ARG AITER_ROCM_VERSION=0.1.10
+ARG AITER_VERSION=0.1.10
+ARG AITER_ROCM_VERSION=7.1.1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
@@ -52,7 +53,7 @@ RUN curl -L micro.mamba.pm/install.sh | bash && \
     ~/.local/bin/micromamba run -n ${MAMBA_ENV_NAME} ~/.local/bin/micromamba install python=${PY_VERSION} -c conda-forge --override-channels -y && \
     ~/.local/bin/micromamba run -n ${MAMBA_ENV_NAME} pip install cmake pybind11 build ninja scikit-build-core setuptools-scm numpy pytest pytest-xdist && \
     ~/.local/bin/micromamba run -n ${MAMBA_ENV_NAME} pip install torch==${TORCH_VERSION} -f https://repo.radeon.com/rocm/manylinux/rocm-rel-${ROCM_VERSION}/ && \
-    ~/.local/bin/micromamba run -n ${MAMBA_ENV_NAME} pip install amd_aiter==${AITER_ROCM_VERSION} --extra-index-url https://pypi.amd.com/rocm-${ROCM_VERSION}/simple && \
+    ~/.local/bin/micromamba run -n ${MAMBA_ENV_NAME} pip install amd_aiter==${AITER_VERSION} --extra-index-url https://pypi.amd.com/rocm-${AITER_ROCM_VERSION}/simple && \
     /bin/bash -c "eval \"\$(~/.local/bin/micromamba shell hook --shell bash)\" && \
     micromamba activate ${MAMBA_ENV_NAME} && \
     cd /root/flashinfer/ && \


### PR DESCRIPTION
We are using `${ROCM_VERSION}` for AITER installation. For different integration contexts, the `ROCM_VERSION` will be different. This causes CI to fail on `ROCm 7.2.0`. This PR adds a separate `ARG` which is set inside of `Dockerfile.rocm_ci` and is not passed as a part of CI integration context. This pins AITER packaging to one particular version 
