### PR TITLE
[FIX] Fixes scikit-build editable installs in latest trunk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ csrc/nv_internal/tensorrt_llm/cutlass_instantiations/
 docs/generated/
 flashinfer/_build_meta.py
 flashinfer/data/
+flashinfer/include
 flashinfer/_version.py
 flashinfer/__config__.py
 flashinfer/jit/aot_config.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,3 +17,33 @@ install(
   FILES_MATCHING
   REGEX "\\.(cuh|h|hpp)$"
   PATTERN "distributed" EXCLUDE)
+
+# In editable installs, create flashinfer/include as a symlink to the source
+# include/ directory so that get_include_paths.py (Path(__file__).parent /
+# "include") resolves to the live headers immediately without any cmake rebuild.
+# Guarded by SKBUILD_STATE so the symlink is only created for editable builds;
+# wheel and sdist builds continue to use the install(DIRECTORY …) copy above.
+if(SKBUILD_STATE MATCHES "^editable")
+  install(
+    CODE "
+    set(_inc_src \"${CMAKE_SOURCE_DIR}/include\")
+    set(_inc_dst \"${CMAKE_SOURCE_DIR}/flashinfer/include\")
+    set(_needs_link TRUE)
+    if(IS_SYMLINK \"\${_inc_dst}\")
+      file(READ_SYMLINK \"\${_inc_dst}\" _existing)
+      if(\"\${_existing}\" STREQUAL \"\${_inc_src}\")
+        set(_needs_link FALSE)
+      else()
+        file(REMOVE \"\${_inc_dst}\")
+      endif()
+    elseif(IS_DIRECTORY \"\${_inc_dst}\")
+      file(REMOVE_RECURSE \"\${_inc_dst}\")
+    elseif(EXISTS \"\${_inc_dst}\")
+      file(REMOVE \"\${_inc_dst}\")
+    endif()
+    if(_needs_link)
+      file(CREATE_LINK \"\${_inc_src}\" \"\${_inc_dst}\" SYMBOLIC)
+      message(STATUS \"flashinfer: symlinked flashinfer/include -> include/\")
+    endif()
+  ")
+endif()

--- a/flashinfer/get_include_paths.py
+++ b/flashinfer/get_include_paths.py
@@ -4,19 +4,21 @@
 
 import os
 import pathlib
-from sysconfig import get_path
 
 
 def _get_package_root_dir():
     """Return the root directory of the flashinfer package.
+
+    Uses the location of this file so the path is correct for both regular
+    installs (site-packages/flashinfer/) and scikit-build-core inplace editable
+    installs (source_root/flashinfer/).
 
     Returns
     -------
     package_root_dir : str
         Path to the root directory of the flashinfer package.
     """
-    platlib = get_path("platlib")
-    return os.path.join(platlib, "flashinfer")
+    return str(pathlib.Path(__file__).parent)
 
 
 def get_include():

--- a/flashinfer/get_include_paths.py
+++ b/flashinfer/get_include_paths.py
@@ -10,8 +10,10 @@ def _get_package_root_dir():
     """Return the root directory of the flashinfer package.
 
     Uses the location of this file so the path is correct for both regular
-    installs (site-packages/flashinfer/) and scikit-build-core inplace editable
-    installs (source_root/flashinfer/).
+    installs (site-packages/flashinfer/) and editable installs. With
+    scikit-build-core's default ``redirect`` editable mode, Python sources
+    are loaded from the source tree while compiled artifacts may live under
+    ``_skbuild/editable``.
 
     Returns
     -------


### PR DESCRIPTION
## Fix editable install: header changes in `include/` not reflected in JIT

### Problem

`pip install -e .` of `amd-flashinfer` did not pick up changes made to 
C++ headers under `include/` without a full reinstall. The JIT kept
compiling against a stale copy of the headers.

**Root cause — two cooperating bugs:**

1. **scikit-build-core 0.12 changed the default editable mode.** With
   `experimental = true`, the default is now `redirect` mode, where
   cmake installs artifacts to a private build directory
   (`_skbuild/editable/platlib/`) rather than directly into
   `site-packages` as older versions did.

2. **`get_include_paths.py` hardcoded `sysconfig.get_path("platlib")`.**
   This always returns the real `site-packages` directory, which no
   longer holds the cmake-installed headers in redirect mode. The JIT
   therefore resolved `FLASHINFER_INCLUDE_DIR` to a path that was either
   stale or nonexistent.

### Fix

| File | Change |
|------|--------|
| `CMakeLists.txt` | Add `install(CODE …)` block that creates `flashinfer/include` as a symlink → `{source_root}/include/` in the source tree during every cmake install step. Because it is a symlink, header edits are visible immediately—no cmake rebuild required. The block is idempotent: it skips recreation if the symlink already points to the correct target. |
| `flashinfer/get_include_paths.py` | Replace `sysconfig.get_path("platlib")` with `pathlib.Path(__file__).parent`. This resolves correctly in both editable installs (source tree, follows symlink) and regular installs (site-packages, real directory). |
| `.gitignore` | Ignore `flashinfer/include` (without trailing slash, so the pattern matches both directories and symlinks). |

### Behaviour after this fix

* Run `pip install -e .` once to (re-)initialize the editable install.
* Any subsequent edit to a file under `include/` is picked up by the
  JIT on the next `import flashinfer`—no reinstall needed.
* Wheel and sdist builds are unaffected: `install(DIRECTORY …)` still
  copies real header files into the wheel; the source-tree symlink is a
  developer-side artefact that is git-ignored.
  
  Fixes #206 