### PR TITLE
[Perf] Improve fa2 occupancy and overall kernel performance by tweaking block size cost model

### DIFF
--- a/include/flashinfer/attention/generic/prefill.cuh
+++ b/include/flashinfer/attention/generic/prefill.cuh
@@ -1670,9 +1670,27 @@ gpuError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::DT
          !USE_FP16_QK_REDUCTION)
             ? 2
             : (ELEMS_PER_FRAGMENT / NUM_MMA_Q);
-    const uint32_t max_num_mma_kv_smem =
-        (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ)) /
-        ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV * sizeof(DTypeKV));
+    // On HIP (CDNA3), cap KV smem at half of LDS per CU to allow 2 workgroups/CU.
+    // Without this cap, CTA_TILE_Q=64 savings in q_smem are automatically
+    // consumed by a larger NUM_MMA_KV, keeping smem at 48 KB (1 block/CU).
+    // With the cap, CTA_TILE_Q=64+head_dim=128 → 32 KB smem → 2 blocks/CU.
+    // Always use at least min_valid_mma_kv (IsInvalid: NUM_MMA_D_VO==4 → must be even).
+#if defined(PLATFORM_HIP_DEVICE)
+    const uint32_t q_smem_bytes_ = CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ);
+    const uint32_t kv_budget_ =
+        (static_cast<uint32_t>(max_smem_per_threadblock) / 2u > q_smem_bytes_)
+            ? static_cast<uint32_t>(max_smem_per_threadblock) / 2u - q_smem_bytes_
+            : 0u;
+    constexpr uint32_t min_valid_mma_kv_ = (HEAD_DIM_VO / 16u == 4u) ? 2u : 1u;
+#else
+    const uint32_t kv_budget_ =
+        static_cast<uint32_t>(max_smem_per_threadblock) -
+        CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ);
+    constexpr uint32_t min_valid_mma_kv_ = 1u;
+#endif
+    const uint32_t max_num_mma_kv_smem = std::max(
+        min_valid_mma_kv_, static_cast<uint32_t>(kv_budget_ / ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 *
+                                                               NUM_WARPS_KV * sizeof(DTypeKV))));
 
     // control NUM_MMA_KV for maximum warp occupancy
     DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
@@ -2398,9 +2416,26 @@ gpuError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Param
           ? 2
           : (ELEMS_PER_FRAGMENT / NUM_MMA_Q);
 
-  const uint32_t max_num_mma_kv_smem =
-      (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ)) /
-      ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV * sizeof(DTypeKV));
+  // On HIP (CDNA3), cap KV smem at half of LDS per CU to allow 2 workgroups/CU.
+  // Without this cap, CTA_TILE_Q=64 savings in q_smem are automatically
+  // consumed by a larger NUM_MMA_KV, keeping smem at 48 KB (1 block/CU).
+  // With the cap, CTA_TILE_Q=64+head_dim=128 → 32 KB smem → 2 blocks/CU.
+  // Always use at least min_valid_mma_kv (IsInvalid: NUM_MMA_D_VO==4 → must be even).
+#if defined(PLATFORM_HIP_DEVICE)
+  const uint32_t q_smem_bytes_ = CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ);
+  const uint32_t kv_budget_ =
+      (static_cast<uint32_t>(max_smem_per_threadblock) / 2u > q_smem_bytes_)
+          ? static_cast<uint32_t>(max_smem_per_threadblock) / 2u - q_smem_bytes_
+          : 0u;
+  constexpr uint32_t min_valid_mma_kv_ = (HEAD_DIM_VO / 16u == 4u) ? 2u : 1u;
+#else
+  const uint32_t kv_budget_ =
+      static_cast<uint32_t>(max_smem_per_threadblock) - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ);
+  constexpr uint32_t min_valid_mma_kv_ = 1u;
+#endif
+  const uint32_t max_num_mma_kv_smem = std::max(
+      min_valid_mma_kv_, static_cast<uint32_t>(kv_budget_ / ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 *
+                                                             NUM_WARPS_KV * sizeof(DTypeKV))));
 
   DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
     using KTraits =
@@ -2496,9 +2531,26 @@ gpuError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Params
           ? 2
           : (ELEMS_PER_FRAGMENT / NUM_MMA_Q);
 
-  const uint32_t max_num_mma_kv_smem =
-      (max_smem_per_threadblock - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ)) /
-      ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV * sizeof(DTypeKV));
+  // On HIP (CDNA3), cap KV smem at half of LDS per CU to allow 2 workgroups/CU.
+  // Without this cap, CTA_TILE_Q=64 savings in q_smem are automatically
+  // consumed by a larger NUM_MMA_KV, keeping smem at 48 KB (1 block/CU).
+  // With the cap, CTA_TILE_Q=64+head_dim=128 → 32 KB smem → 2 blocks/CU.
+  // Always use at least min_valid_mma_kv (IsInvalid: NUM_MMA_D_VO==4 → must be even).
+#if defined(PLATFORM_HIP_DEVICE)
+  const uint32_t q_smem_bytes_ = CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ);
+  const uint32_t kv_budget_ =
+      (static_cast<uint32_t>(max_smem_per_threadblock) / 2u > q_smem_bytes_)
+          ? static_cast<uint32_t>(max_smem_per_threadblock) / 2u - q_smem_bytes_
+          : 0u;
+  constexpr uint32_t min_valid_mma_kv_ = (HEAD_DIM_VO / 16u == 4u) ? 2u : 1u;
+#else
+  const uint32_t kv_budget_ =
+      static_cast<uint32_t>(max_smem_per_threadblock) - CTA_TILE_Q * HEAD_DIM_QK * sizeof(DTypeQ);
+  constexpr uint32_t min_valid_mma_kv_ = 1u;
+#endif
+  const uint32_t max_num_mma_kv_smem = std::max(
+      min_valid_mma_kv_, static_cast<uint32_t>(kv_budget_ / ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 *
+                                                             NUM_WARPS_KV * sizeof(DTypeKV))));
 
   DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem, max_num_mma_kv_reg), NUM_MMA_KV, {
     using KTraits =

--- a/include/gpu_iface/utils.cuh
+++ b/include/gpu_iface/utils.cuh
@@ -85,16 +85,20 @@ inline uint32_t FA2DetermineCtaTileQ(int64_t avg_packed_qo_len, uint32_t head_di
     }
   }
 #elif defined(PLATFORM_HIP_DEVICE)
-  // HIP version: AMD GPUs have 64KB shared memory limit with warp size 64
-  // For head_dim >= 256, CTA_TILE_Q=16 requires >64KB shared memory
-  // Always use CTA_TILE_Q=64 for large head dimensions
-  if (head_dim >= 256) {
-    return 64;
-  } else if (avg_packed_qo_len > 64 && head_dim < 256) {
-    return 128;
-  } else {
-    return avg_packed_qo_len <= 16 ? 16 : 64;
-  }
+  // CDNA3 (MI300X) occupancy-aware tile selection.
+  //
+  // LDS per CU on gfx942 is 64 KB. SharedStorageQKVO with CTA_TILE_Q=128 and
+  // head_dim=128 occupies 48 KB, fitting only 1 block/CU → 4 wavefronts/CU
+  // (12.5% of the 32-wavefront HW maximum), leaving MFMA units idle >93% of
+  // the time.
+  //
+  // CTA_TILE_Q=64 with head_dim=128 → 32 KB smem → 2 blocks/CU → 8 wavefronts,
+  // doubling latency-hiding capacity and MFMA utilization.  For head_dim≥256
+  // the Q tile alone is ≥32 KB so 64 is already the largest viable Q tile.
+  // CTA_TILE_Q=16 is retained for very short sequences (avg ≤ 16 rows) to
+  // avoid launching an excessive number of near-empty threadblocks.
+  (void)head_dim;  // no longer needed; all head_dims benefit from CTA_TILE_Q=64
+  return avg_packed_qo_len <= 16 ? 16 : 64;
 #endif
 }
 

--- a/include/gpu_iface/utils.cuh
+++ b/include/gpu_iface/utils.cuh
@@ -93,11 +93,16 @@ inline uint32_t FA2DetermineCtaTileQ(int64_t avg_packed_qo_len, uint32_t head_di
   // the time.
   //
   // CTA_TILE_Q=64 with head_dim=128 → 32 KB smem → 2 blocks/CU → 8 wavefronts,
-  // doubling latency-hiding capacity and MFMA utilization.  For head_dim≥256
-  // the Q tile alone is ≥32 KB so 64 is already the largest viable Q tile.
-  // CTA_TILE_Q=16 is retained for very short sequences (avg ≤ 16 rows) to
-  // avoid launching an excessive number of near-empty threadblocks.
-  (void)head_dim;  // no longer needed; all head_dims benefit from CTA_TILE_Q=64
+  // doubling latency-hiding capacity and MFMA utilization.
+  //
+  // For head_dim >= 256, CTA_TILE_Q=16 is non-viable on CDNA3: get_num_warps_q(16)=1
+  // forces NUM_WARPS_KV=4, so even the minimum NUM_MMA_KV=1 configuration produces
+  // smem = Q(8 KB) + K(32 KB) + V(32 KB) = 72 KB, exceeding the 64 KB LDS ceiling.
+  // 2 blocks/CU is also impossible since the Q tile alone occupies 32 KB = half of LDS,
+  // so CTA_TILE_Q=64 is the correct choice for all sequence lengths at head_dim >= 256.
+  if (head_dim >= 256) return 64;
+  // CTA_TILE_Q=16 is retained for very short sequences (avg ≤ 16 rows) with head_dim < 256
+  // to avoid launching an excessive number of near-empty threadblocks.
   return avg_packed_qo_len <= 16 ? 16 : 64;
 #endif
 }


### PR DESCRIPTION
## [ROCm] FA2 prefill: double CU occupancy via LDS-aware tile selection (CDNA3)

### Background

On MI300X (gfx942) the LDS per CU is 64 KB. The FA2 single-prefill kernel with 
`CTA_TILE_Q=128` and `head_dim=128` allocates a `SharedStorageQKVO` of 48 KB per
threadblock (32 KB Q + 8 KB K + 8 KB V). Because 48 KB × 2 = 96 KB > 64 KB, only
**1 block per CU** can co-reside, leaving the hardware at **4 wavefronts / CU** out of a
maximum of 32 (12.5% occupancy). Hardware counter data (`SQ_WAIT_INST_ANY`) confirmed
that 27–37% of active cycles all wavefronts are simultaneously stalled at
`block.sync()` barriers in the inner KV loop, with nothing to schedule in. MFMA
utilization was measured at 3–7% of the 1307 TFLOPS peak.

### Changes

#### `include/gpu_iface/utils.cuh` — `FA2DetermineCtaTileQ` (HIP path)

Simplified the HIP tile-selection function to always return `CTA_TILE_Q = 64` for
sequences longer than 16 tokens, removing the `CTA_TILE_Q = 128` path entirely:

#### `include/flashinfer/attention/generic/prefill.cuh` — three dispatcher sites

Reducing `CTA_TILE_Q` alone is **not sufficient**. The dispatcher computes
`NUM_MMA_KV` to fill whatever smem budget remains after the Q tile. Halving the Q
tile (32 KB → 16 KB) caused `NUM_MMA_KV` to auto-scale 2 → 4, consuming the freed
budget and keeping total smem at 48 KB. A second fix caps the budget at
`max_smem / 2` on HIP, targeting ≤ 32 KB per block. The `min_valid_mma_kv_` guard
prevents `NUM_MMA_KV = 1` for `head_dim=64`, which would violate the `IsInvalid()`
parity constraint (`NUM_MMA_D_VO == 4` requires even `NUM_MMA_KV`). The same fix is
applied to all three dispatcher sites: `SinglePrefillWithKVCacheDispatched`,
`BatchPrefillWithRaggedKVCacheDispatched`, and `BatchPrefillWithPagedKVCacheDispatched`.
### Result

All configs now compile to `KernelTraits<..., 64u, 1u, 2u, ...>` on HIP:

| Smem component | Before | After |
|---|---|---|
| Q tile (`CTA_TILE_Q × head_dim`) | 32 KB | **16 KB** |
| K tile (`NUM_MMA_KV=2`) | 8 KB | 8 KB |
| V tile (`NUM_MMA_KV=2`) | 8 KB | 8 KB |
| **Total** | **48 KB → 1 block/CU** | **32 KB → 2 blocks/CU** |

Register pressure also dropped: `VGPR_Count` 68–80 → 16–24, `Accum_VGPR_Count`
212–216 → 176–184 (due to `NUM_MMA_Q` 2 → 1). The kernel now sits at the joint
LDS + AGPR ceiling of 2 blocks/CU (`floor(512 AGPRs/SIMD ÷ 208 VGPRs/wave) = 2`).

**Measured throughput** (`num_qo_heads=32`, `num_kv_heads=32`, `head_dim=128`, MI300X):

| Config | Before | After | Δ |
|---|---|---|---|
| seq=512 causal | 29.8 TFLOPS | 32.7 TFLOPS | +10% |
| seq=1024 causal | 38.4 TFLOPS | 43.4 TFLOPS | +13% |
| seq=2048 causal | 41.1 TFLOPS | 50.0 TFLOPS | +21% |
| seq=4096 causal | 44.7 TFLOPS | **73.7 TFLOPS** | **+65%** |
| seq=8192 causal | 67.4 TFLOPS | **84.4 TFLOPS** | **+25%** |
| seq=512 non-causal | 62.0 TFLOPS | 65.6 TFLOPS | +6% |
| seq=1024 non-causal | 77.4 TFLOPS | 83.7 TFLOPS | +8% |
| seq=2048 non-causal | 81.2 TFLOPS | 88.9 TFLOPS | +10% |
| seq=4096 non-causal | 77.1 TFLOPS | **92.2 TFLOPS** | **+20%** |

### Testing

- `examples/single_prefill_example.py` — pass
- `examples/batch_prefill_example.py` — pass
- `pytest tests/rocm_tests/test_single_prefill_kernels_hip.py tests/rocm_tests/test_batch_prefill_kernels_hip.py` — **4932 passed**

<img width="1154" height="27" alt="image" src="https://github.com/user-attachments/assets/d406b9fe-70cc-4aea-914c-c4f9bf380cab" />

