### PR TITLE
fix(hip): correct bf16 rowsum MMA and custom-mask MFMA row indexing on CDNA3

### DIFF
--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -401,12 +401,12 @@ def gen_jit_spec(
         check_rocm_arch()
         verbose = os.environ.get("FLASHINFER_JIT_VERBOSE", "0") == "1"
 
-        cflags = ["-O3", "-std=c++17", "-Wno-switch-bool"]
+        cflags = ["-O3", "-std=c++20", "-Wno-switch-bool"]
         # Use dynamically-generated flags from CompilationContext (includes arch flags)
         cflags += current_compilation_context.get_hipcc_flags_list()  # type: ignore[attr-defined]
         cuda_cflags = [
             "-O3",
-            "-std=c++17",
+            "-std=c++20",
             "-DFLASHINFER_ENABLE_F16",
             "-DFLASHINFER_ENABLE_BF16",
             "-DFLASHINFER_ENABLE_FP8_E4M3",

--- a/include/flashinfer/attention/generic/prefill.cuh
+++ b/include/flashinfer/attention/generic/prefill.cuh
@@ -805,7 +805,6 @@ __device__ __forceinline__ void logits_transform(
     const dim3 tid = threadIdx, const uint32_t kv_head_idx = blockIdx.z) {
   constexpr uint32_t TPR = KTraits::THREADS_PER_BMATRIX_ROW_SET;
   constexpr uint32_t NAPTR = KTraits::NUM_ACCUM_ROWS_PER_THREAD;
-  constexpr uint32_t LIS = KTraits::LOGITS_INDEX_STRIDE;
 
   const uint32_t lane_idx = tid.x;
   uint32_t q[KTraits::NUM_MMA_Q][NAPTR], r[KTraits::NUM_MMA_Q][NAPTR];
@@ -815,7 +814,7 @@ __device__ __forceinline__ void logits_transform(
   for (uint32_t mma_q = 0; mma_q < KTraits::NUM_MMA_Q; ++mma_q) {
 #pragma unroll
     for (uint32_t j = 0; j < NAPTR; ++j) {
-      group_size.divmod(qo_packed_idx_base + mma_q * 16 + lane_idx / TPR + LIS * j, q[mma_q][j],
+      group_size.divmod(qo_packed_idx_base + mma_q * 16 + (lane_idx / TPR) * NAPTR + j, q[mma_q][j],
                         r[mma_q][j]);
     }
   }
@@ -872,14 +871,13 @@ __device__ __forceinline__ void logits_mask(
   constexpr MaskMode MASK_MODE = KTraits::MASK_MODE;
   constexpr uint32_t TPR = KTraits::THREADS_PER_BMATRIX_ROW_SET;
   constexpr uint32_t NAPTR = KTraits::NUM_ACCUM_ROWS_PER_THREAD;
-  constexpr uint32_t LIS = KTraits::LOGITS_INDEX_STRIDE;
 
   uint32_t q[NUM_MMA_Q][NAPTR], r[NUM_MMA_Q][NAPTR];
 #pragma unroll
   for (uint32_t mma_q = 0; mma_q < NUM_MMA_Q; ++mma_q) {
 #pragma unroll
     for (uint32_t j = 0; j < NAPTR; ++j) {
-      group_size.divmod(qo_packed_idx_base + mma_q * 16 + lane_idx / TPR + LIS * j, q[mma_q][j],
+      group_size.divmod(qo_packed_idx_base + mma_q * 16 + (lane_idx / TPR) * NAPTR + j, q[mma_q][j],
                         r[mma_q][j]);
     }
   }

--- a/include/gpu_iface/backend/hip/mma_hip.h
+++ b/include/gpu_iface/backend/hip/mma_hip.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <bit>
+#include <type_traits>
+
 #include "gpu_iface/mma_types.hpp"
 #include "gpu_iface/platform.hpp"
 
@@ -206,10 +209,23 @@ __device__ __forceinline__ void load_quad_transposed_fragment(uint32_t* R, const
 template <typename DType>
 __device__ __forceinline__ void m16k16_rowsum_f16f16f32(float* d, DType* s_frag) {
   static_assert(sizeof(DType) == 2, "DType must be 16-bit type");
+  static_assert(std::is_same_v<DType, __half> || std::is_same_v<DType, __hip_bfloat16>,
+                "DType must be __half or __hip_bfloat16");
+
   f16x4 a = reinterpret_cast<const f16x4*>(s_frag)[0];
-  f16x4 b = {f16(1.0f), f16(1.0f), f16(1.0f), f16(1.0f)};
   f32x4 c = {d[0], d[1], d[2], d[3]};
-  f32x4 out = __builtin_amdgcn_mfma_f32_16x16x16f16(a, b, c, 0, 0, 0);
+  f32x4 out;
+
+  if constexpr (std::is_same_v<DType, __half>) {
+    f16x4 b = {f16(1.0f), f16(1.0f), f16(1.0f), f16(1.0f)};
+    out = __builtin_amdgcn_mfma_f32_16x16x16f16(a, b, c, 0, 0, 0);
+  } else if constexpr (std::is_same_v<DType, __hip_bfloat16>) {
+    constexpr uint32_t bf16_one_pair = 0x3F803F80u;  // two bf16 1.0 values packed
+    constexpr uint64_t bf16_ones = (uint64_t{bf16_one_pair} << 32) | bf16_one_pair;
+    f16x4 b = std::bit_cast<f16x4>(bf16_ones);
+    out = __builtin_amdgcn_mfma_f32_16x16x16bf16_1k(a, b, c, 0, 0, 0);
+  }
+
   d[0] = out.x;
   d[1] = out.y;
   d[2] = out.z;

--- a/tests/rocm_tests/test_batch_prefill_bf16_custom_mask_hip.py
+++ b/tests/rocm_tests/test_batch_prefill_bf16_custom_mask_hip.py
@@ -1,0 +1,462 @@
+# SPDX-FileCopyrightText: 2025 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for BatchPrefillWithPagedKVCacheWrapper with bfloat16 and custom masks.
+
+These tests target two bugs that were found in the HIP FA2 kernels on CDNA3:
+
+  Bug 1 (bf16 rowsum): m16k16_rowsum_f16f16f32() used the fp16 MFMA intrinsic
+  unconditionally, misinterpreting bf16(1.0) as fp16(1.875) and inflating the
+  softmax denominator.  Caught by test_batch_prefill_paged_kv_bf16_correctness
+  which compares BatchPrefill bf16 output against a naive PyTorch reference.
+
+  Bug 2 (custom mask MFMA row-mapping): logits_transform() and logits_mask()
+  used an interleaved packed-index pattern instead of contiguous bands, causing
+  the wrong GQA head to be masked for 3/4 of packed query rows.  Caught by
+  test_batch_prefill_custom_mask_gqa_correctness which uses a custom mask with
+  group_size > 1 and compares against a naive PyTorch reference, and by
+  test_custom_mask_all_true_matches_causal which checks that an all-True custom
+  mask produces the same output as the causal (kNone) code path.
+"""
+
+import math
+
+import pytest
+import torch
+
+import flashinfer
+
+# Monkey-patch flashinfer.quantization on older versions where the JIT-compiled
+# quantization module fails to build on ROCm (cub/cub.cuh missing in <= 0.2.5).
+try:
+    flashinfer.quantization.packbits(
+        torch.ones(8, dtype=torch.bool, device="cpu"), bitorder="little"
+    )
+except Exception:
+    import flashinfer.quantization as _fiq
+
+    def _pt_packbits(x, bitorder="big"):
+        x = x.to(torch.bool).view(-1).to(torch.uint8)
+        pad = (8 - x.size(0) % 8) % 8
+        if pad:
+            x = torch.cat([x, torch.zeros(pad, dtype=torch.uint8, device=x.device)])
+        x = x.reshape(-1, 8)
+        if bitorder == "big":
+            shifts = torch.arange(7, -1, -1, device=x.device, dtype=torch.uint8)
+        else:
+            shifts = torch.arange(0, 8, device=x.device, dtype=torch.uint8)
+        return (x << shifts).sum(dim=1, dtype=torch.uint8)
+
+    def _pt_segment_packbits(x, indptr, bitorder="big"):
+        seglen = indptr[1:] - indptr[:-1]
+        packed_len = (seglen + 7) // 8
+        indptr_new = torch.zeros_like(indptr)
+        indptr_new[1:] = torch.cumsum(packed_len, 0)
+        y = torch.zeros(int(indptr_new[-1].item()), dtype=torch.uint8, device=x.device)
+        for i in range(len(seglen)):
+            seg = x[indptr[i] : indptr[i + 1]]
+            packed = _pt_packbits(seg, bitorder)
+            y[indptr_new[i] : indptr_new[i + 1]] = packed[
+                : indptr_new[i + 1] - indptr_new[i]
+            ]
+        return y, indptr_new
+
+    _fiq.packbits = lambda x, bitorder="big": _pt_packbits(x, bitorder)
+    _fiq.segment_packbits = _pt_segment_packbits
+    _fiq._packbits = lambda x, bitorder: _pt_packbits(x, bitorder)
+    if hasattr(flashinfer, "prefill"):
+        import flashinfer.prefill as _fip
+
+        if hasattr(_fip, "segment_packbits"):
+            _fip.segment_packbits = _pt_segment_packbits
+        if hasattr(_fip, "packbits"):
+            _fip.packbits = lambda x, bitorder="big": _pt_packbits(x, bitorder)
+
+
+def _plan_with_custom_mask(
+    wrapper,
+    qo_indptr,
+    kv_indptr,
+    kv_indices,
+    kv_last_page_len,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    page_size,
+    dtype,
+    custom_mask_flat,
+):
+    """Call wrapper.plan() with custom mask, adapting to the FlashInfer version.
+
+    v0.2.5 uses ``custom_mask=`` (raw bool tensor, internally calls
+    segment_packbits).  v0.5.3+ uses ``packed_custom_mask=`` +
+    ``qk_indptr=`` (pre-packed uint8).  This helper tries the newer API
+    first and falls back to the older one.
+    """
+    import inspect
+
+    sig = inspect.signature(wrapper.plan)
+
+    if "qk_indptr" in sig.parameters:
+        packed = _packbits(custom_mask_flat, bitorder="little")
+        batch_size = qo_indptr.shape[0] - 1
+        qo_lens = qo_indptr[1:] - qo_indptr[:-1]
+        kv_lens_per_seq = []
+        pages_per = kv_indptr[1:] - kv_indptr[:-1]
+        for i in range(batch_size):
+            kv_lens_per_seq.append(
+                (int(pages_per[i].item()) - 1) * page_size
+                + int(kv_last_page_len[i].item())
+            )
+        qk_indptr = torch.zeros(
+            batch_size + 1, dtype=torch.int32, device=qo_indptr.device
+        )
+        for i in range(batch_size):
+            qk_indptr[i + 1] = (
+                qk_indptr[i] + int(qo_lens[i].item()) * kv_lens_per_seq[i]
+            )
+        wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            causal=False,
+            q_data_type=dtype,
+            kv_data_type=dtype,
+            packed_custom_mask=packed,
+            qk_indptr=qk_indptr,
+        )
+    else:
+        wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            custom_mask=custom_mask_flat,
+            q_data_type=dtype,
+            kv_data_type=dtype,
+        )
+
+
+def _packbits(mask_flat, bitorder="little"):
+    """Pack a boolean tensor into uint8, with fallback for broken JIT on ROCm
+    <= 0.2.5 where cub/cub.cuh is missing.
+    """
+    try:
+        return flashinfer.quantization.packbits(mask_flat, bitorder=bitorder)
+    except (RuntimeError, ImportError):
+        x = mask_flat.to(torch.uint8)
+        pad = (8 - x.shape[0] % 8) % 8
+        if pad:
+            x = torch.cat([x, torch.zeros(pad, dtype=torch.uint8, device=x.device)])
+        x = x.reshape(-1, 8)
+        if bitorder == "big":
+            shifts = torch.arange(7, -1, -1, device=x.device, dtype=torch.uint8)
+        else:
+            shifts = torch.arange(0, 8, device=x.device, dtype=torch.uint8)
+        return (x << shifts).sum(dim=1, dtype=torch.uint8)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _naive_attention(q, k, v, causal=False, custom_mask=None):
+    """Pure-PyTorch multi-head attention reference (supports GQA)."""
+    qo_len, num_qo_heads, head_dim = q.shape
+    kv_len, num_kv_heads, _ = k.shape
+    group_size = num_qo_heads // num_kv_heads
+
+    if group_size > 1:
+        k = k.repeat_interleave(group_size, dim=1)
+        v = v.repeat_interleave(group_size, dim=1)
+
+    scale = 1.0 / math.sqrt(head_dim)
+    q_t = q.transpose(0, 1).float()
+    k_t = k.transpose(0, 1).float()
+    v_t = v.transpose(0, 1).float()
+
+    scores = torch.matmul(q_t, k_t.transpose(1, 2)) * scale
+
+    if custom_mask is not None:
+        scores = scores.masked_fill(~custom_mask.unsqueeze(0), float("-inf"))
+    elif causal:
+        mask = torch.tril(
+            torch.ones(qo_len, kv_len, device=q.device, dtype=torch.bool),
+            diagonal=(kv_len - qo_len),
+        )
+        scores = scores.masked_fill(~mask.unsqueeze(0), float("-inf"))
+
+    attn = torch.softmax(scores, dim=-1)
+    out = torch.matmul(attn, v_t)
+    return out.transpose(0, 1).to(q.dtype)
+
+
+def _build_paged_kv(batch_size, kv_len, page_size, num_kv_heads, head_dim, dtype):
+    """Build a paged KV cache with random data and sequential page indices."""
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_pages = num_pages_per_seq * batch_size
+    k_cache = torch.randn(
+        total_pages, page_size, num_kv_heads, head_dim, device="cuda:0", dtype=dtype
+    )
+    v_cache = torch.randn(
+        total_pages, page_size, num_kv_heads, head_dim, device="cuda:0", dtype=dtype
+    )
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device="cuda:0")
+        * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_pages, dtype=torch.int32, device="cuda:0")
+    kv_last_page_len = torch.full(
+        (batch_size,),
+        (kv_len - 1) % page_size + 1,
+        dtype=torch.int32,
+        device="cuda:0",
+    )
+    return k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len
+
+
+def _gather_kv_from_pages(
+    k_cache, v_cache, kv_indptr, kv_last_page_len, batch_idx, page_size
+):
+    """Gather contiguous K/V for one sequence from paged cache."""
+    start_page = kv_indptr[batch_idx].item()
+    end_page = kv_indptr[batch_idx + 1].item()
+    last_len = kv_last_page_len[batch_idx].item()
+    k_parts = [k_cache[p] for p in range(start_page, end_page - 1)]
+    k_parts.append(k_cache[end_page - 1][:last_len])
+    v_parts = [v_cache[p] for p in range(start_page, end_page - 1)]
+    v_parts.append(v_cache[end_page - 1][:last_len])
+    return torch.cat(k_parts, dim=0), torch.cat(v_parts, dim=0)
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: bf16 BatchPrefill correctness (rowsum MMA type confusion)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("batch_size", [2, 4])
+@pytest.mark.parametrize("kv_len", [128, 512])
+@pytest.mark.parametrize("qo_len", [1, 24])
+@pytest.mark.parametrize("num_kv_heads", [4, 8])
+@pytest.mark.parametrize("num_qo_heads", [8, 32])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("page_size", [16])
+def test_batch_prefill_paged_kv_bf16_correctness(
+    batch_size,
+    kv_len,
+    qo_len,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    page_size,
+):
+    if num_qo_heads % num_kv_heads != 0:
+        pytest.skip("num_qo_heads must be divisible by num_kv_heads")
+    if qo_len > kv_len:
+        pytest.skip("qo_len > kv_len not supported with causal")
+
+    dtype = torch.bfloat16
+    q = torch.randn(
+        batch_size * qo_len, num_qo_heads, head_dim, device="cuda:0", dtype=dtype
+    )
+    k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len = _build_paged_kv(
+        batch_size, kv_len, page_size, num_kv_heads, head_dim, dtype
+    )
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device="cuda:0") * qo_len
+    )
+
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(workspace, kv_layout="NHD")
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=True,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    o = wrapper.run(q, (k_cache, v_cache))
+
+    for i in range(batch_size):
+        qi = q[qo_indptr[i] : qo_indptr[i + 1]]
+        ki, vi = _gather_kv_from_pages(
+            k_cache, v_cache, kv_indptr, kv_last_page_len, i, page_size
+        )
+        o_ref = _naive_attention(qi, ki, vi, causal=True)
+        o_i = o[qo_indptr[i] : qo_indptr[i + 1]]
+        torch.testing.assert_close(o_i.float(), o_ref.float(), rtol=1e-2, atol=5e-2)
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: custom mask with GQA (MFMA C/D row-mapping error)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("batch_size", [2, 4])
+@pytest.mark.parametrize("kv_len", [128, 512])
+@pytest.mark.parametrize("qo_len", [8, 24])
+@pytest.mark.parametrize("num_kv_heads", [4])
+@pytest.mark.parametrize("num_qo_heads", [4, 16, 32])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("page_size", [16])
+def test_batch_prefill_custom_mask_gqa_correctness(
+    batch_size,
+    kv_len,
+    qo_len,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    page_size,
+):
+    if num_qo_heads % num_kv_heads != 0:
+        pytest.skip("num_qo_heads must be divisible by num_kv_heads")
+    if qo_len > kv_len:
+        pytest.skip("qo_len > kv_len not supported with causal")
+
+    dtype = torch.bfloat16
+    q = torch.randn(
+        batch_size * qo_len, num_qo_heads, head_dim, device="cuda:0", dtype=dtype
+    )
+    k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len = _build_paged_kv(
+        batch_size, kv_len, page_size, num_kv_heads, head_dim, dtype
+    )
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device="cuda:0") * qo_len
+    )
+
+    # Build per-sequence causal custom masks
+    custom_masks = []
+    for _ in range(batch_size):
+        mask = torch.tril(
+            torch.ones(qo_len, kv_len, device="cuda:0", dtype=torch.bool),
+            diagonal=(kv_len - qo_len),
+        )
+        custom_masks.append(mask)
+    flat_mask = torch.cat([m.flatten() for m in custom_masks])
+
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(workspace, kv_layout="NHD")
+    _plan_with_custom_mask(
+        wrapper,
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        dtype,
+        flat_mask,
+    )
+    o = wrapper.run(q, (k_cache, v_cache))
+
+    for i in range(batch_size):
+        qi = q[qo_indptr[i] : qo_indptr[i + 1]]
+        ki, vi = _gather_kv_from_pages(
+            k_cache, v_cache, kv_indptr, kv_last_page_len, i, page_size
+        )
+        o_ref = _naive_attention(qi, ki, vi, custom_mask=custom_masks[i])
+        o_i = o[qo_indptr[i] : qo_indptr[i + 1]]
+        torch.testing.assert_close(o_i.float(), o_ref.float(), rtol=1e-2, atol=5e-2)
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 (supplementary): all-True custom mask must match causal (kNone) path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("num_kv_heads", [4])
+@pytest.mark.parametrize("num_qo_heads", [4, 16, 32])
+@pytest.mark.parametrize("head_dim", [128])
+def test_custom_mask_all_true_matches_causal(
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+):
+    if num_qo_heads % num_kv_heads != 0:
+        pytest.skip("num_qo_heads must be divisible by num_kv_heads")
+
+    batch_size = 2
+    kv_len = 256
+    qo_len = 16
+    page_size = 16
+    dtype = torch.bfloat16
+
+    q = torch.randn(
+        batch_size * qo_len, num_qo_heads, head_dim, device="cuda:0", dtype=dtype
+    )
+    k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len = _build_paged_kv(
+        batch_size, kv_len, page_size, num_kv_heads, head_dim, dtype
+    )
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device="cuda:0") * qo_len
+    )
+
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+
+    # Run with causal=True (kNone path)
+    wrapper_causal = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        workspace, kv_layout="NHD"
+    )
+    wrapper_causal.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=True,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    o_causal = wrapper_causal.run(q, (k_cache, v_cache))
+
+    # Run with custom mask = causal mask (kCustom path)
+    custom_masks = []
+    for _ in range(batch_size):
+        mask = torch.tril(
+            torch.ones(qo_len, kv_len, device="cuda:0", dtype=torch.bool),
+            diagonal=(kv_len - qo_len),
+        )
+        custom_masks.append(mask)
+    flat_mask = torch.cat([m.flatten() for m in custom_masks])
+
+    wrapper_custom = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        workspace, kv_layout="NHD"
+    )
+    _plan_with_custom_mask(
+        wrapper_custom,
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        dtype,
+        flat_mask,
+    )
+    o_custom = wrapper_custom.run(q, (k_cache, v_cache))
+
+    torch.testing.assert_close(o_custom.float(), o_causal.float(), rtol=1e-2, atol=5e-2)


### PR DESCRIPTION
## Summary

Two bugs in the HIP/ROCm FA2 attention kernels produce silently wrong results on AMD MI300x (gfx942) when using **bfloat16** and/or **custom attention masks with GQA**.

### Bug 1: bf16 rowsum MMA type confusion (`mma_hip.h`)

`m16k16_rowsum_f16f16f32()` unconditionally calls the fp16 MFMA intrinsic (`__builtin_amdgcn_mfma_f32_16x16x16f16`) and constructs the B operand as `_Float16(1.0)`, even when `DType` is `__hip_bfloat16`. The hardware reinterprets the `bf16(1.0)` bit pattern `0x3F80` as `fp16(1.875)`, inflating the softmax denominator by **1.875x per tile accumulation**.

**Symptom**: Draft token acceptance rate in speculative decoding collapsed to <10% (vs ~65% expected). BatchPrefill outputs are systematically underscaled vs PyTorch SDPA reference.

**Fix**: Dispatch to `__builtin_amdgcn_mfma_f32_16x16x16bf16_1k` for bfloat16 with correctly packed `bf16(1.0)` B operands (`0x3F803F80`).

Note: `mma_sync_m16n16k16_row_col_f16f16f32` in the same file already correctly dispatches between fp16 and bf16 -- only `m16k16_rowsum` was missed.

### Bug 2: MFMA C/D register row-mapping in custom mask path (`prefill.cuh`)

`logits_transform()` and `logits_mask()` compute the packed query index using an **interleaved** pattern (`lane_idx/TPR + LIS*j`) that does not match the CDNA3 MFMA C/D register layout. On MI300x, the `mfma_f32_16x16x16` instruction maps each thread to **4 contiguous rows** (thread `c` owns rows `4c, 4c+1, 4c+2, 4c+3`), not interleaved.

This causes the custom mask and logits transform to be applied to the **wrong GQA head** for 3 out of every 4 packed query rows when `group_size > 1`. The `kNone` (no mask) path is unaffected because it doesn't use `group_size.divmod()`.

**Diagnostic observations:**
- `kNone` mode: cosine similarity to SDPA reference ~ 1.0 (correct)
- `kCustom` with all-True mask: cosine similarity to SDPA reference ~ 0.41 (broken)
- Per-head: GQA heads with `r == 0` correct; heads with `r >= 1` wrong
- `group_size == 1` (no GQA): all heads correct

**Fix**: Use contiguous-band indexing `(lane_idx/TPR) * NAPTR + j` in both `logits_transform()` and `logits_mask()`. Note that `write_lse()` and `write_o_reg_gmem()` in the same file already use the correct contiguous mapping.

## Test plan

- [x] BatchPrefill bf16 outputs match PyTorch SDPA reference (max abs diff < 0.05)
- [x] BatchDecode still passes (was already correct)
- [x] Custom mask with GQA (group_size > 1): per-head outputs correct for all r values
- [x] All-True custom mask matches kNone output
- [x] Tested on AMD Instinct MI300x (gfx942), ROCm 7.1.1, PyTorch 2.8

## Files changed

- `include/gpu_iface/backend/hip/mma_hip.h` -- bf16 rowsum fix
- `include/flashinfer/attention/generic/prefill.cuh` -- MFMA row-mapping fix (2 locations)