### PR TITLE
fix(hip): clamp max_num_kv_chunks to avoid SIGFPE in single decode on CPX devices

### DIFF
--- a/include/flashinfer/attention/generic/decode.cuh
+++ b/include/flashinfer/attention/generic/decode.cuh
@@ -704,7 +704,11 @@ gpuError_t SingleDecodeWithKVCacheDispatched(Params params, typename Params::DTy
         FLASHINFER_ERROR(err_msg.str());
       }
       uint32_t max_grid_size = uint32_t(num_blocks_per_sm) * uint32_t(num_sm);
-      uint32_t max_num_kv_chunks = max_grid_size / num_kv_heads;
+      // Clamp to >=1: when num_kv_heads > max_grid_size (e.g. MI308X CPX has 20
+      // CUs vs 32 kv-heads), the integer division would underflow to 0 and the
+      // ceil_div below would SIGFPE. With max_num_kv_chunks=1 we just don't
+      // split KV further, which is the correct fallback.
+      uint32_t max_num_kv_chunks = max(max_grid_size / num_kv_heads, 1U);
 
       // AMD CDNA3: Use larger chunk size to reduce synchronization overhead
       uint32_t kv_chunk_size = max(ceil_div(seq_len, max_num_kv_chunks), 512U);

--- a/include/flashinfer/attention/generic/decode.cuh
+++ b/include/flashinfer/attention/generic/decode.cuh
@@ -705,7 +705,7 @@ gpuError_t SingleDecodeWithKVCacheDispatched(Params params, typename Params::DTy
       }
       uint32_t max_grid_size = uint32_t(num_blocks_per_sm) * uint32_t(num_sm);
       // Clamp to >=1: when num_kv_heads > max_grid_size (e.g. MI308X CPX has 20
-      // CUs vs 32 kv-heads), the integer division would underflow to 0 and the
+      // CUs vs 32 kv-heads), the integer division would truncate to 0 and the
       // ceil_div below would SIGFPE. With max_num_kv_chunks=1 we just don't
       // split KV further, which is the correct fallback.
       uint32_t max_num_kv_chunks = max(max_grid_size / num_kv_heads, 1U);


### PR DESCRIPTION
## Summary

- `tests/attention/test_logits_cap.py::test_single_decode_logits_soft_cap` SIGFPEs at `(seq_len=257, num_heads=32, head_dim=256, soft_cap=1.0)` on MI308X CPX (20 CUs).
- Root cause: in `SingleDecodeWithKVCacheDispatched`'s partition-KV path, `max_num_kv_chunks = max_grid_size / num_kv_heads` underflows to 0 when `num_kv_heads > max_grid_size` (e.g. 20 CUs × 1 block/SM = 20 < 32 kv-heads). The next line then calls `ceil_div(seq_len, 0)` → SIGFPE in the host launch code.
- Fix: clamp `max_num_kv_chunks` to `>= 1`. With the clamp, the kernel falls back to one CTA per kv-head (no further KV split) — the correct behavior when the device can't fit all kv-heads simultaneously.

The existing guard at line 700 only catches `num_blocks_per_sm == 0`; it does not cover this divisor-underflow case.

## Test plan

- [x] Minimal repro (`seq_len ∈ {256, 257, 320, 729, 33001}`, `head_dim=256`, `num_heads=32`) returns valid output instead of crashing.
- [x] `pytest tests/attention/test_logits_cap.py` — all 450 cases pass (was crashing on first head_dim=256 / num_heads=32 / seq_len>256 case).
- [x] Run full ROCm test suite in CI to confirm no regressions in non-CPX paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)