### PR TITLE
fix(hip): small-kernel correctness and test coverage for CDNA3 (activation, norm, rope)

### DIFF
--- a/flashinfer/csrc_rocm/activation.cu
+++ b/flashinfer/csrc_rocm/activation.cu
@@ -37,17 +37,15 @@ void silu_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl) {
   int64_t num_tokens = input.numel() / input.size(-1);
 
   const c10::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(out.device());
-  auto stream = at::hip::getCurrentHIPStream();
+  const hipStream_t stream = at::hip::getCurrentHIPStream();
 
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
     uint32_t vec_size = 16 / sizeof(c_type);
 
     uint64_t gridDim = num_tokens;
     uint64_t blockDim = std::min(d / vec_size, 1024U);
-    uint64_t dynamicSmemBytes = 0;
-    hipStream_t stream = stream;
 
-    activation::act_and_mul_kernel<c_type, silu><<<gridDim, blockDim, dynamicSmemBytes, stream>>>(
+    activation::act_and_mul_kernel<c_type, silu><<<gridDim, blockDim, 0, stream>>>(
         static_cast<c_type*>(out.data_ptr()), static_cast<c_type*>(input.data_ptr()), d);
 
     hipError_t err = hipGetLastError();
@@ -62,18 +60,15 @@ void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl) {
   int64_t num_tokens = input.numel() / input.size(-1);
 
   const c10::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(out.device());
-  auto stream = at::hip::getCurrentHIPStream();
+  const hipStream_t stream = at::hip::getCurrentHIPStream();
 
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
     uint32_t vec_size = 16 / sizeof(c_type);
     uint64_t gridDim = num_tokens;
     uint64_t blockDim = std::min(d / vec_size, 1024U);
-    uint64_t dynamicSmemBytes = 0;
-    hipStream_t stream = stream;
 
-    activation::act_and_mul_kernel<c_type, gelu_tanh>
-        <<<gridDim, blockDim, dynamicSmemBytes, stream>>>(
-            static_cast<c_type*>(out.data_ptr()), static_cast<c_type*>(input.data_ptr()), d);
+    activation::act_and_mul_kernel<c_type, gelu_tanh><<<gridDim, blockDim, 0, stream>>>(
+        static_cast<c_type*>(out.data_ptr()), static_cast<c_type*>(input.data_ptr()), d);
 
     hipError_t err = hipGetLastError();
     TORCH_CHECK(err == hipSuccess, "Failed to launch kernel: ", hipGetErrorString(err));
@@ -86,19 +81,15 @@ void gelu_and_mul(at::Tensor& out, at::Tensor& input, bool enable_pdl) {
   int d = input.size(-1) / 2;
   int64_t num_tokens = input.numel() / input.size(-1);
   const c10::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(out.device());
-  auto stream = at::hip::getCurrentHIPStream();
+  const hipStream_t stream = at::hip::getCurrentHIPStream();
 
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FP16(input.scalar_type(), c_type, [&] {
     uint32_t vec_size = 16 / sizeof(c_type);
 
     uint64_t gridDim = num_tokens;
     uint64_t blockDim = std::min(d / vec_size, 1024U);
-    uint64_t dynamicSmemBytes = 0;
-    hipStream_t stream = stream;
 
-    auto kernel = activation::act_and_mul_kernel<c_type, gelu>;
-
-    activation::act_and_mul_kernel<c_type, gelu><<<gridDim, blockDim, dynamicSmemBytes, stream>>>(
+    activation::act_and_mul_kernel<c_type, gelu><<<gridDim, blockDim, 0, stream>>>(
         static_cast<c_type*>(out.data_ptr()), static_cast<c_type*>(input.data_ptr()), d);
 
     hipError_t err = hipGetLastError();

--- a/include/gpu_iface/backend/hip/math_hip.h
+++ b/include/gpu_iface/backend/hip/math_hip.h
@@ -65,14 +65,12 @@ __forceinline__ __device__ float ptx_rcp(float x) { return __frcp_rn(x); }
 
 template <typename T>
 __forceinline__ __device__ T shfl_xor_sync(T x, int lane_mask) {
-  // FIXME (diptorupd): The shfl_xor_sync is used to implement a butterfly
-  // reduction pattern. The caller in decode.cuh most likely assumes that the
-  // warp size is 32 and the lane_mask is going from 16, 8, 4, 2, 1.
-  // Given that AMDGPU for CDNA3 has a warp size of 64, the lane_mask based on
-  // the warp size of 32 might lead to incorrect exchanges between the
-  // threads. The issue requires further investigation, for now I have hard
-  // coded the warp size to 32 when calling shfl_xor.
-  return __shfl_xor(x, lane_mask, 32);
+  // CDNA3 wavefront width is 64. Use the full wavefront width so that
+  // cross-lane exchanges work correctly across all 64 lanes. All current
+  // callers (norm, decode, prefill, mla) use lane_mask values ≤ 16, so
+  // the exchange pattern is identical to a width=32 call for those callers,
+  // but this is the semantically correct value for CDNA3.
+  return __shfl_xor(x, lane_mask, 64);
 }
 
 /// @brief Wrapper for math intrinsic 1/sqrt(x)

--- a/include/gpu_iface/backend/hip/mma_hip.h
+++ b/include/gpu_iface/backend/hip/mma_hip.h
@@ -222,7 +222,8 @@ __device__ __forceinline__ void m16k16_rowsum_f16f16f32(float* d, DType* s_frag)
   } else if constexpr (std::is_same_v<DType, __hip_bfloat16>) {
     constexpr uint32_t bf16_one_pair = 0x3F803F80u;  // two bf16 1.0 values packed
     constexpr uint64_t bf16_ones = (uint64_t{bf16_one_pair} << 32) | bf16_one_pair;
-    f16x4 b = std::bit_cast<f16x4>(bf16_ones);
+    f16x4 b;
+    __builtin_memcpy(&b, &bf16_ones, sizeof(f16x4));
     out = __builtin_amdgcn_mfma_f32_16x16x16bf16_1k(a, b, c, 0, 0, 0);
   }
 

--- a/include/gpu_iface/backend/hip/mma_hip.h
+++ b/include/gpu_iface/backend/hip/mma_hip.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <bit>
 #include <type_traits>
 
 #include "gpu_iface/mma_types.hpp"
@@ -222,6 +221,7 @@ __device__ __forceinline__ void m16k16_rowsum_f16f16f32(float* d, DType* s_frag)
   } else if constexpr (std::is_same_v<DType, __hip_bfloat16>) {
     constexpr uint32_t bf16_one_pair = 0x3F803F80u;  // two bf16 1.0 values packed
     constexpr uint64_t bf16_ones = (uint64_t{bf16_one_pair} << 32) | bf16_one_pair;
+    static_assert(sizeof(f16x4) == sizeof(bf16_ones), "f16x4 size mismatch");
     f16x4 b;
     __builtin_memcpy(&b, &bf16_ones, sizeof(f16x4));
     out = __builtin_amdgcn_mfma_f32_16x16x16bf16_1k(a, b, c, 0, 0, 0);

--- a/tests/rocm_tests/test_activation_hip.py
+++ b/tests/rocm_tests/test_activation_hip.py
@@ -1,0 +1,109 @@
+"""
+Copyright (c) 2026 Advanced Micro Devices, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+HIP/ROCm tests for fused activation kernels: silu_and_mul, gelu_tanh_and_mul,
+gelu_and_mul.
+
+Each test generates input of shape (num_tokens, 2*d), runs the flashinfer
+fused kernel, and compares against a pure-PyTorch reference computed in fp32
+and cast back to the target dtype.
+
+Shapes cover:
+  - Small d values (< 64 elements / vec_size, partial last wavefront)
+  - Typical LLM FFN sizes (LLaMA-2 11008, Mistral 14336, Phi-3 14336 / 2)
+  - Large d values that hit the 1024-thread blockDim cap
+  - Non-power-of-two d values (e.g., 5504 = LLaMA-2 11008 // 2)
+"""
+
+import pytest
+import torch
+
+import flashinfer
+
+
+def _silu_and_mul_ref(x: torch.Tensor) -> torch.Tensor:
+    d = x.shape[-1] // 2
+    gate, up = x.float()[..., :d], x.float()[..., d:]
+    return (gate / (1.0 + torch.exp(-gate)) * up).to(x.dtype)
+
+
+def _gelu_tanh_and_mul_ref(x: torch.Tensor) -> torch.Tensor:
+    d = x.shape[-1] // 2
+    gate, up = x.float()[..., :d], x.float()[..., d:]
+    y = torch.nn.functional.gelu(gate, approximate="tanh") * up
+    return y.to(x.dtype)
+
+
+def _gelu_and_mul_ref(x: torch.Tensor) -> torch.Tensor:
+    d = x.shape[-1] // 2
+    gate, up = x.float()[..., :d], x.float()[..., d:]
+    y = torch.nn.functional.gelu(gate, approximate="none") * up
+    return y.to(x.dtype)
+
+
+# (num_tokens, d) — input tensor is (num_tokens, 2*d)
+# d values chosen to cover: < blockDim threshold, wave64-unaligned (5504),
+# typical LLM dims, blockDim-cap boundary (8192→1024 threads).
+_SHAPES = [
+    (1, 64),
+    (1, 128),
+    (4, 256),
+    (8, 512),
+    (1, 2752),  # 5504 // 2 — from LLaMA-2 intermediate with GQA
+    (4, 4096),
+    (8, 5504),  # LLaMA-2 ffn_dim // 2  (non-multiple-of-64-threads)
+    (16, 7168),  # Mistral-7B ffn_dim // 2
+    (1, 8192),  # hits 1024-thread cap
+    (4, 14336),  # Llama-3-70B ffn_dim // 2, multiple stride iterations
+]
+
+
+@pytest.mark.parametrize("num_tokens,d", _SHAPES)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_silu_and_mul(num_tokens, d, dtype):
+    torch.manual_seed(42)
+    x = torch.randn(num_tokens, 2 * d, device="cuda", dtype=dtype)
+    ref = _silu_and_mul_ref(x)
+    out = flashinfer.activation.silu_and_mul(x)
+    rtol, atol = (2e-2, 2e-2) if dtype == torch.bfloat16 else (1e-3, 1e-3)
+    torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("num_tokens,d", _SHAPES)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_gelu_tanh_and_mul(num_tokens, d, dtype):
+    torch.manual_seed(42)
+    x = torch.randn(num_tokens, 2 * d, device="cuda", dtype=dtype)
+    ref = _gelu_tanh_and_mul_ref(x)
+    out = flashinfer.activation.gelu_tanh_and_mul(x)
+    rtol, atol = (2e-2, 2e-2) if dtype == torch.bfloat16 else (1e-3, 1e-3)
+    torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("num_tokens,d", _SHAPES)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_gelu_and_mul(num_tokens, d, dtype):
+    torch.manual_seed(42)
+    x = torch.randn(num_tokens, 2 * d, device="cuda", dtype=dtype)
+    ref = _gelu_and_mul_ref(x)
+    out = flashinfer.activation.gelu_and_mul(x)
+    rtol, atol = (2e-2, 2e-2) if dtype == torch.bfloat16 else (1e-3, 1e-3)
+    torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
+
+
+if __name__ == "__main__":
+    test_silu_and_mul(8, 5504, torch.float16)
+    test_gelu_tanh_and_mul(8, 7168, torch.float16)
+    test_gelu_and_mul(8, 7168, torch.bfloat16)

--- a/tests/rocm_tests/test_activation_hip.py
+++ b/tests/rocm_tests/test_activation_hip.py
@@ -35,20 +35,23 @@ import flashinfer
 
 def _silu_and_mul_ref(x: torch.Tensor) -> torch.Tensor:
     d = x.shape[-1] // 2
-    gate, up = x.float()[..., :d], x.float()[..., d:]
+    x_f32 = x.float()
+    gate, up = x_f32[..., :d], x_f32[..., d:]
     return (gate / (1.0 + torch.exp(-gate)) * up).to(x.dtype)
 
 
 def _gelu_tanh_and_mul_ref(x: torch.Tensor) -> torch.Tensor:
     d = x.shape[-1] // 2
-    gate, up = x.float()[..., :d], x.float()[..., d:]
+    x_f32 = x.float()
+    gate, up = x_f32[..., :d], x_f32[..., d:]
     y = torch.nn.functional.gelu(gate, approximate="tanh") * up
     return y.to(x.dtype)
 
 
 def _gelu_and_mul_ref(x: torch.Tensor) -> torch.Tensor:
     d = x.shape[-1] // 2
-    gate, up = x.float()[..., :d], x.float()[..., d:]
+    x_f32 = x.float()
+    gate, up = x_f32[..., :d], x_f32[..., d:]
     y = torch.nn.functional.gelu(gate, approximate="none") * up
     return y.to(x.dtype)
 

--- a/tests/rocm_tests/test_norm_hip.py
+++ b/tests/rocm_tests/test_norm_hip.py
@@ -43,11 +43,11 @@ def gemma_rms_norm(x, w, eps=1e-6):
 
 def gemma_fused_add_rms_norm(x, residual, w, eps=1e-6):
     orig_dtype = x.dtype
-    x = x + residual
-    residual = x
-    x = x.float()
-    variance = x.pow(2).mean(dim=-1, keepdim=True)
-    x = x * torch.rsqrt(variance + eps)
+    # Add in float32 to match the kernel, which promotes both operands before adding.
+    x_f32 = x.float() + residual.float()
+    residual = x_f32.to(orig_dtype)
+    variance = x_f32.pow(2).mean(dim=-1, keepdim=True)
+    x = x_f32 * torch.rsqrt(variance + eps)
     x = x * (1.0 + w.float())
     x = x.to(orig_dtype)
     return x, residual
@@ -67,7 +67,7 @@ def fused_add_rms_norm(x, residual, weight, eps):
 
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("hidden_size", [111, 500, 1024, 3072, 3584, 4096, 8192])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("specify_out", [True, False])
 @pytest.mark.parametrize("enable_pdl", [False])
 @pytest.mark.parametrize("contiguous", [True, False])
@@ -87,12 +87,13 @@ def test_norm(batch_size, hidden_size, dtype, specify_out, enable_pdl, contiguou
     else:
         y = flashinfer.norm.rmsnorm(x, w, enable_pdl=enable_pdl)
 
-    torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
+    rtol, atol = (1.6e-2, 1.6e-2) if dtype == torch.bfloat16 else (1e-3, 1e-3)
+    torch.testing.assert_close(y_ref, y, rtol=rtol, atol=atol)
 
 
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("hidden_size", [111, 500, 1024, 3072, 3584, 4096, 8192])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("enable_pdl", [False])
 @pytest.mark.parametrize("contiguous", [True, False])
 def test_fused_add_rmsnorm(batch_size, hidden_size, dtype, enable_pdl, contiguous):
@@ -117,13 +118,14 @@ def test_fused_add_rmsnorm(batch_size, hidden_size, dtype, enable_pdl, contiguou
         x_fused, residual_fused, weight, eps, enable_pdl=enable_pdl
     )
 
-    torch.testing.assert_close(x_fused, x_native, rtol=1e-3, atol=1e-3)
-    torch.testing.assert_close(residual_fused, residual_native, rtol=1e-3, atol=1e-3)
+    rtol, atol = (1.6e-2, 1.6e-2) if dtype == torch.bfloat16 else (1e-3, 1e-3)
+    torch.testing.assert_close(x_fused, x_native, rtol=rtol, atol=atol)
+    torch.testing.assert_close(residual_fused, residual_native, rtol=rtol, atol=atol)
 
 
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("hidden_size", [111, 500, 1024, 3072, 3584, 4096, 8192])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("specify_out", [True, False])
 @pytest.mark.parametrize("enable_pdl", [False])
 @pytest.mark.parametrize("contiguous", [True, False])
@@ -145,12 +147,13 @@ def test_gemma_norm(
     else:
         y = flashinfer.norm.gemma_rmsnorm(x, w, enable_pdl=enable_pdl)
 
-    torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
+    rtol, atol = (1.6e-2, 1.6e-2) if dtype == torch.bfloat16 else (1e-3, 1e-3)
+    torch.testing.assert_close(y_ref, y, rtol=rtol, atol=atol)
 
 
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("hidden_size", [111, 500, 1024, 3072, 3584, 4096, 8192])
-@pytest.mark.parametrize("dtype", [torch.float16])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("enable_pdl", [False])
 @pytest.mark.parametrize("contiguous", [True, False])
 def test_gemma_fused_add_rmsnorm(
@@ -177,8 +180,9 @@ def test_gemma_fused_add_rmsnorm(
         x_fused, residual_fused, weight, eps, enable_pdl=enable_pdl
     )
 
-    torch.testing.assert_close(x_fused, x_native, rtol=1e-3, atol=1e-3)
-    torch.testing.assert_close(residual_fused, residual_native, rtol=1e-3, atol=1e-3)
+    rtol, atol = (1.6e-2, 1.6e-2) if dtype == torch.bfloat16 else (1e-3, 1e-3)
+    torch.testing.assert_close(x_fused, x_native, rtol=rtol, atol=atol)
+    torch.testing.assert_close(residual_fused, residual_native, rtol=rtol, atol=atol)
 
 
 if __name__ == "__main__":

--- a/tests/rocm_tests/test_rope_hip.py
+++ b/tests/rocm_tests/test_rope_hip.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-
 # HIP-specific version of test_rope.py
 #
 # Included tests:
@@ -36,12 +35,13 @@ limitations under the License.
 
 import pytest
 import torch
-from rope_reference import *
 
 import flashinfer
-from flashinfer.rope import (
-    rope_quantize_fp8,
-    rope_quantize_fp8_append_paged_kv_cache,
+from flashinfer.rope import rope_quantize_fp8, rope_quantize_fp8_append_paged_kv_cache
+from tests.test_helpers.rope_reference import (
+    RotaryEmbedding,
+    apply_rotary_emb,
+    precompute_freqs_cis,
 )
 
 
@@ -1049,9 +1049,11 @@ def test_rope_quantize_fp8_append_paged_kv_cache_decode_hip(
     kv_page_indices_e = torch.arange(n_pages_e, dtype=torch.int32, device=device)
     kv_last_page_len_e = torch.tensor(
         [
-            num_existing_tokens % page_size
-            if num_existing_tokens % page_size != 0
-            else page_size
+            (
+                num_existing_tokens % page_size
+                if num_existing_tokens % page_size != 0
+                else page_size
+            )
         ]
         + [0] * (batch_size - 1),
         dtype=torch.int32,


### PR DESCRIPTION
## Summary

- **Fix UB in `activation.cu`**: `hipStream_t stream = stream` inside each DISPATCH lambda was a C++ self-initialisation (RHS refers to the uninitialized variable, not the outer `getCurrentHIPStream()` return). Moved stream acquisition outside the lambda. Also removes dead `dynamicSmemBytes` locals and an unused `auto kernel =` binding in `gelu_and_mul`.
- **Fix `shfl_xor_sync` width for CDNA3** (`math_hip.h`): changed `__shfl_xor(x, lane_mask, 32)` → `width=64`. Resolves the FIXME left in place. All existing callers use `lane_mask ≤ 16`, so the exchange pattern is identical; the change is semantically correct for 64-lane wavefronts and future-proofs callers.
- **Restore C++17 compatibility in `mma_hip.h`**: `std::bit_cast` (C++20) in the bf16 rowsum path caused JIT recompile failures under `-std=c++17`. Replaced with `__builtin_memcpy`.
- **Fix `gemma_fused_add_rms_norm` reference** (`test_norm_hip.py`): reference was accumulating `x + residual` in bf16 (~15% error vs kernel's fp32 promotion). Fixed to match kernel behaviour.
- **Add bfloat16 coverage to all norm tests**: `rmsnorm`, `fused_add_rmsnorm`, `gemma_rmsnorm`, `gemma_fused_add_rmsnorm` were fp16-only; bf16 dispatch path was completely untested.
- **Add `test_activation_hip.py`**: first test coverage for `silu_and_mul`, `gelu_tanh_and_mul`, `gelu_and_mul` on ROCm — 60 tests across fp16/bf16 and 10 shapes covering partial wavefronts, wave64-unaligned sizes, and the 1024-thread cap.
- **Fix rope test wildcard import**: replace `from rope_reference import *` with explicit named imports from `tests.test_helpers.rope_reference`.

## Test plan

- [x] `pytest tests/rocm_tests/test_norm_hip.py -m "not slow"` — 672 passed (fp16 + bf16)
- [x] `pytest tests/rocm_tests/test_activation_hip.py -m "not slow"` — 60 passed (fp16 + bf16)
- [x] `pytest tests/rocm_tests/test_rope_hip.py -m "not slow"` — 7850 passed, 5 skipped
- [x] `benchmarks/rocm_benchmarks/bench_fa2_prefill.py --timing-only` — no regression (seq=4096 causal ~72.9 TFLOPS)

<img width="404" height="25" alt="image" src="https://github.com/user-attachments/assets/f30138c0-f6e8-42ca-92b5-a10c2103e9c0" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)