### PR TITLE
feat(bench): improve prefill rocm benchmark scripts

### DIFF
--- a/benchmarks/rocm_benchmarks/bench_aiter_prefill.py
+++ b/benchmarks/rocm_benchmarks/bench_aiter_prefill.py
@@ -27,6 +27,9 @@ Run:
     # Full roofline pipeline (timing + counter collection + roofline PNG):
     python benchmarks/rocm_benchmarks/bench_aiter_prefill.py
 
+    # Override batch size for paged sections (0 = disable paged sections):
+    python benchmarks/rocm_benchmarks/bench_aiter_prefill.py --batch 8
+
     # Select a different counter preset:
     python benchmarks/rocm_benchmarks/bench_aiter_prefill.py --counters occupancy
     python benchmarks/rocm_benchmarks/bench_aiter_prefill.py --counters stall
@@ -46,12 +49,14 @@ Run:
 
 Output files (all gitignored):
     benchmarks/rocm_benchmarks/<label>_timing.csv
+    benchmarks/rocm_benchmarks/<label>_meta.json
     benchmarks/rocm_benchmarks/<label>_counters.yml
     benchmarks/rocm_benchmarks/<label>_counter_collection.csv
     benchmarks/rocm_benchmarks/<label>_roofline.png   (roofline preset only)
 
 Counter presets available out of the box:
-    roofline  — FetchSize, WriteSize, MFMA ops, TCC DRAM requests (default)
+    roofline  — FetchSize, WriteSize, MFMA ops, TCC DRAM requests,
+                SQ_VALU_MFMA_BUSY_CYCLES (default)
     compute   — MFMA ops and cycle counters
     memory    — L2 and DRAM bandwidth breakdown
     basic     — minimal: FetchSize / WriteSize only
@@ -62,32 +67,35 @@ Counter presets available out of the box:
 
     Or pass a path to a YAML file in rocprofv3 native job format.
 
-Design note — why --counters is parsed at module level
--------------------------------------------------------
+Design note — why --counters / --batch are parsed at module level
+-----------------------------------------------------------------
 rocprofv3 re-executes this script as a subprocess (passing the same sys.argv)
 to collect hardware counters. The RocmProfiler object must therefore be
 constructed at module import time with the correct `counters=` value, so that
 both the outer driver and the inner rocprofv3 subprocess use the same preset.
-We extract --counters / --label here (using parse_known_args so we don't
-conflict with the profiler's own argparse), strip them from sys.argv, and then
-pass the values to the RocmProfiler constructor.
+We extract --counters / --label / --batch here (using parse_known_args so we
+don't conflict with the profiler's own argparse), strip them from sys.argv,
+and then pass the values to the RocmProfiler constructor.
 """
 
 import argparse
 import logging
-import math
 import sys
 from pathlib import Path
 
 import torch
 
 import flashinfer
-from flashinfer.jit.core import logger
+from flashinfer.jit.core import logger as _jit_logger
 
-logger.setLevel(logging.ERROR)
+# Suppress routine JIT INFO/DEBUG output; WARNING still surfaces compile errors.
+_jit_logger.setLevel(logging.WARNING)
 
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "rocm_profiler"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "rocm_profiler"))
 from rocm_profiler import KernelConfig, RocmProfiler
+
+# vLLM max_num_seqs=256 with mixed prefill+decode → prefill burst of ~8 seqs is mid-range.
+_DEFAULT_BATCH = 8
 
 # ---------------------------------------------------------------------------
 # Bench-script-level argument parsing
@@ -109,6 +117,16 @@ _bench_parser.add_argument(
     metavar="PREFIX",
     help="Output-file label prefix (default: 'aiter' for roofline, 'aiter_<preset>' otherwise).",
 )
+_bench_parser.add_argument(
+    "--batch",
+    type=int,
+    default=_DEFAULT_BATCH,
+    metavar="N",
+    help=(
+        "batch_size for the paged-KV sections (0 = disable paged sections). "
+        f"Default: {_DEFAULT_BATCH}."
+    ),
+)
 _bench_args, _remaining = _bench_parser.parse_known_args()
 sys.argv = [sys.argv[0]] + _remaining
 
@@ -129,7 +147,7 @@ _NUM_KV_HEADS = 4
 _HEAD_DIM = 64
 _DTYPE = torch.float16
 _CAUSAL = True
-_BATCH = 4
+_BATCH = _bench_args.batch
 
 _OUTPUT_DIR = str(Path(__file__).parent)
 
@@ -137,22 +155,16 @@ _OUTPUT_DIR = str(Path(__file__).parent)
 def _flops(
     q_len: int, kv_len: int, num_qo_heads: int, head_dim: int, causal: bool
 ) -> int:
-    return q_len * kv_len * num_qo_heads * head_dim * (2 if causal else 4)
+    # For causal with q_len < kv_len the mask removes only the last q*(q-1)/2
+    # entries of the attended set, not half the matrix (which factor=2 assumed).
+    attended = q_len * kv_len - q_len * (q_len - 1) // 2 if causal else q_len * kv_len
+    return attended * num_qo_heads * head_dim * 4
 
 
 def _bytes(
     q_len: int, kv_len: int, num_qo_heads: int, num_kv_heads: int, head_dim: int
 ) -> int:
-    return (
-        2
-        * head_dim
-        * (
-            q_len * num_qo_heads
-            + kv_len * num_kv_heads
-            + kv_len * num_kv_heads
-            + q_len * num_qo_heads
-        )
-    )
+    return 2 * head_dim * (2 * q_len * num_qo_heads + 2 * kv_len * num_kv_heads)
 
 
 def _build_paged_kv(batch, kv_len, page_size, num_kv_heads, head_dim, dtype, device):
@@ -164,7 +176,6 @@ def _build_paged_kv(batch, kv_len, page_size, num_kv_heads, head_dim, dtype, dev
         num_full_pages += 1
     total_pages = num_full_pages * batch
 
-    # kv_data layout: [total_pages, 2, page_size, num_kv_heads, head_dim]  (NHD paged)
     kv_data = torch.randn(
         total_pages, 2, page_size, num_kv_heads, head_dim, dtype=dtype, device=device
     )
@@ -172,7 +183,10 @@ def _build_paged_kv(batch, kv_len, page_size, num_kv_heads, head_dim, dtype, dev
     kv_indptr = (
         torch.arange(batch + 1, dtype=torch.int32, device=device) * num_full_pages
     )
-    kv_indices = torch.arange(total_pages, dtype=torch.int32, device=device)
+    _rng = torch.Generator(device=device).manual_seed(42)
+    kv_indices = torch.randperm(
+        total_pages, dtype=torch.int32, device=device, generator=_rng
+    )
     kv_last_page_len = torch.full(
         (batch,), last_tokens, dtype=torch.int32, device=device
     )
@@ -211,11 +225,15 @@ def _make_configs() -> list[KernelConfig]:
                 ),
                 theoretical_flops=flops,
                 theoretical_bytes=theo_bytes,
+                num_tokens=_Q_LEN,
                 label=f"single  kv={kv_len:>5d}",
             )
         )
 
     # ── Batch-paged prefill — native-paged path ──────────────────────────────
+    if _BATCH == 0:
+        return configs
+
     for kv_len in _KV_LENS:
         q, kv_data, qo_indptr, kv_indptr, kv_indices, kv_last_page_len = (
             _build_paged_kv(
@@ -258,6 +276,7 @@ def _make_configs() -> list[KernelConfig]:
                 ),
                 theoretical_flops=flops,
                 theoretical_bytes=theo_bytes,
+                num_tokens=_BATCH * _Q_LEN,
                 label=f"batch(native,p={native_page:>3d})  kv={kv_len:>5d}",
             )
         )
@@ -305,6 +324,7 @@ def _make_configs() -> list[KernelConfig]:
                 ),
                 theoretical_flops=flops,
                 theoretical_bytes=theo_bytes,
+                num_tokens=_BATCH * _Q_LEN,
                 label=f"batch(flat,  p={flat_gather_page:>3d})  kv={kv_len:>5d}",
             )
         )

--- a/benchmarks/rocm_benchmarks/bench_aiter_prefill.py
+++ b/benchmarks/rocm_benchmarks/bench_aiter_prefill.py
@@ -67,15 +67,13 @@ Counter presets available out of the box:
 
     Or pass a path to a YAML file in rocprofv3 native job format.
 
-Design note — why --counters / --batch are parsed at module level
------------------------------------------------------------------
-rocprofv3 re-executes this script as a subprocess (passing the same sys.argv)
-to collect hardware counters. The RocmProfiler object must therefore be
-constructed at module import time with the correct `counters=` value, so that
-both the outer driver and the inner rocprofv3 subprocess use the same preset.
-We extract --counters / --label / --batch here (using parse_known_args so we
-don't conflict with the profiler's own argparse), strip them from sys.argv,
-and then pass the values to the RocmProfiler constructor.
+Design note — why bench flags are parsed at module level
+---------------------------------------------------------
+rocprofv3 re-executes this script as a subprocess with the same sys.argv to
+collect hardware counters.  All bench-specific flags must therefore be parsed
+at module import time so the subprocess builds identical configs to the outer
+timing run.  RocmProfiler uses parse_known_args internally, so bench flags
+remaining in sys.argv are silently ignored by its own argparse.
 """
 
 import argparse
@@ -98,7 +96,7 @@ from rocm_profiler import KernelConfig, RocmProfiler
 _DEFAULT_BATCH = 8
 
 # ---------------------------------------------------------------------------
-# Bench-script-level argument parsing
+# Bench-script-level argument parsing (see design note above)
 # ---------------------------------------------------------------------------
 _bench_parser = argparse.ArgumentParser(add_help=False)
 _bench_parser.add_argument(
@@ -127,8 +125,7 @@ _bench_parser.add_argument(
         f"Default: {_DEFAULT_BATCH}."
     ),
 )
-_bench_args, _remaining = _bench_parser.parse_known_args()
-sys.argv = [sys.argv[0]] + _remaining
+_bench_args, _ = _bench_parser.parse_known_args()
 
 _counters = _bench_args.counters
 _label = (

--- a/benchmarks/rocm_benchmarks/bench_aiter_prefill.py
+++ b/benchmarks/rocm_benchmarks/bench_aiter_prefill.py
@@ -13,67 +13,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-AITER prefill benchmark: single-prefill and batch-paged-prefill via backend="aiter".
+AITER prefill benchmark: single-prefill and batch-paged via backend="aiter".
 
-Shapes: Sample production profile — q_len=256, GQA 16/4, HD=64, causal,
-        kv ∈ {512, 1024, 2048, 3072, 4096, 8192}
-
-Batch-paged tested over two page-size regimes:
-  page_size=256  — native-paged path (mha_batch_prefill)
-  page_size=16   — flat-gather path  (mha_fwd via index_select + varlen)
+Shapes: q=256, GQA 16/4, HD=64, causal, kv ∈ {512, 1024, 2048, 3072, 4096, 8192}.
+Paged regimes: page_size=256 (native-paged) and page_size=16 (flat-gather).
 
 Run:
-
-    # Full roofline pipeline (timing + counter collection + roofline PNG):
-    python benchmarks/rocm_benchmarks/bench_aiter_prefill.py
-
-    # Override batch size for paged sections (0 = disable paged sections):
-    python benchmarks/rocm_benchmarks/bench_aiter_prefill.py --batch 8
-
-    # Select a different counter preset:
-    python benchmarks/rocm_benchmarks/bench_aiter_prefill.py --counters occupancy
+    python benchmarks/rocm_benchmarks/bench_aiter_prefill.py               # full pipeline
+    python benchmarks/rocm_benchmarks/bench_aiter_prefill.py --timing-only # no profiling
+    python benchmarks/rocm_benchmarks/bench_aiter_prefill.py --replot      # regenerate plot
+    python benchmarks/rocm_benchmarks/bench_aiter_prefill.py --batch 0    # single only
     python benchmarks/rocm_benchmarks/bench_aiter_prefill.py --counters stall
-    python benchmarks/rocm_benchmarks/bench_aiter_prefill.py --counters compute
-
-    # Override the output file label prefix:
-    python benchmarks/rocm_benchmarks/bench_aiter_prefill.py --label aiter_bench
-
-    # Timing only (no rocprofv3):
-    python benchmarks/rocm_benchmarks/bench_aiter_prefill.py --timing-only
-
-    # Regenerate plot from existing CSVs (no GPU required):
-    python benchmarks/rocm_benchmarks/bench_aiter_prefill.py --replot
-
-    # List all available counter presets:
     python benchmarks/rocm_benchmarks/bench_aiter_prefill.py --list-presets
 
-Output files (all gitignored):
-    benchmarks/rocm_benchmarks/<label>_timing.csv
-    benchmarks/rocm_benchmarks/<label>_meta.json
-    benchmarks/rocm_benchmarks/<label>_counters.yml
-    benchmarks/rocm_benchmarks/<label>_counter_collection.csv
-    benchmarks/rocm_benchmarks/<label>_roofline.png   (roofline preset only)
-
-Counter presets available out of the box:
-    roofline  — FetchSize, WriteSize, MFMA ops, TCC DRAM requests,
-                SQ_VALU_MFMA_BUSY_CYCLES (default)
-    compute   — MFMA ops and cycle counters
-    memory    — L2 and DRAM bandwidth breakdown
-    basic     — minimal: FetchSize / WriteSize only
-    occupancy — SQ_WAVES, SQ_BUSY_CYCLES, SQ_VALU_MFMA_BUSY_CYCLES,
-                SQ_WAIT_INST_ANY, SQ_INSTS_LDS
-    stall     — SQ_INSTS_MFMA, SQ_WAIT_INST_VMEM, SQ_VALU_MFMA_BUSY_CYCLES,
-                SQ_WAIT_INST_LDS, SQ_BUSY_CYCLES
-
-    Or pass a path to a YAML file in rocprofv3 native job format.
-
-Design note — why bench flags are parsed at module level
----------------------------------------------------------
-rocprofv3 re-executes this script as a subprocess with the same sys.argv to
-collect hardware counters.  All bench-specific flags must therefore be parsed
-at module import time so the subprocess builds identical configs to the outer
-timing run.  RocmProfiler uses parse_known_args internally, so bench flags
-remaining in sys.argv are silently ignored by its own argparse.
+Design note: bench flags are parsed at module level because rocprofv3 re-executes this
+script as a subprocess per PMC pass with the same sys.argv.  Module-level parsing ensures
+the subprocess builds identical configs to the outer timing run.
 """
 
 import argparse

--- a/benchmarks/rocm_benchmarks/bench_fa2_prefill.py
+++ b/benchmarks/rocm_benchmarks/bench_fa2_prefill.py
@@ -13,18 +13,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-Single-prefill roofline benchmark using rocm_profiler.
+FA2 prefill benchmark: single-prefill, batch-ragged-prefill, and
+batch-paged-prefill via backend="fa2".
 
 Run:
 
     # Full roofline pipeline (timing + counter collection + roofline PNG):
     python benchmarks/rocm_benchmarks/bench_fa2_prefill.py
 
-    # Production shapes, multiple backends (timing compared side-by-side):
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --backends fa2,fa3,aiter
+    # Use a production GQA model shape (Llama-3-8B: GQA 32/8 hd=128):
+    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --model llama3-8b
 
-    # Arithmetic-intensity sweep (old symmetric sweep):
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --shape-set intensity
+    # Add asymmetric chunked-prefill configs (q=256, kv sweeps):
+    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --q-len 256
+
+    # Add batch-prefill configs alongside single-prefill (default batch sizes):
+    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --batch 4 --paged 8
 
     # Select a different counter preset:
     python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --counters occupancy
@@ -32,7 +36,7 @@ Run:
     python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --counters compute
 
     # Override the output file label prefix:
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --counters occupancy --label my_label
+    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --counters occupancy --label fa2_occ
 
     # Timing only (no rocprofv3):
     python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --timing-only
@@ -53,11 +57,29 @@ Output files (all gitignored):
     benchmarks/rocm_benchmarks/<label>_counter_collection.csv
     benchmarks/rocm_benchmarks/<label>_roofline.png   (roofline preset only)
 
-Shape sets:
-    production  — Alibaba production sweep: q=256, GQA 16/4, hd=64,
-                  kv ∈ {512,1024,2048,3072,4096,8192}, causal (default)
-    intensity   — Arithmetic-intensity sweep: q=kv, MHA 32/32, hd=128,
-                  causal + non-causal, crosses MI300X ridge at seq≈1024
+Model presets (--model):
+    intensity  — MHA 32/32 hd=128, causal+non-causal sweep (default).
+                 Good for roofline analysis; covers the MI300X ridge point.
+    llama3-8b  — GQA 32/8 hd=128, causal, kv∈{512..8192}
+    llama3-70b — GQA 64/8 hd=128, causal, kv∈{512..8192}
+    mistral-7b — GQA 32/8 hd=128, causal, kv∈{512..8192}
+
+Batch-prefill mode (--batch / --paged):
+    --batch N  Uses BatchPrefillWithRaggedKVCacheWrapper (fa2 backend) with
+               N sequences each of the same seq_len as the single-prefill sweep.
+    --paged N  Uses BatchPrefillWithPagedKVCacheWrapper (fa2 backend) with
+               N sequences.  Runs two page sizes by default (16 and 64).
+               Override with --page-size P to test a single page size.
+    batch_size=1 provides a direct single-vs-batch API overhead comparison.
+
+Asymmetric (chunked-prefill) mode (--q-len):
+    --q-len Q  Adds single-prefill configs with q_len=Q, kv_len swept over the
+               standard kv sequence lengths.  Models chunked prefill where a
+               short query attends to a long KV context.  Causal only.
+
+Paged KV indices:
+    Indices are drawn from torch.randperm (seed 42) to simulate memory
+    fragmentation in a real page pool.
 
 Counter presets available out of the box:
     roofline  — FetchSize, WriteSize, MFMA ops, TCC DRAM requests,
@@ -72,27 +94,27 @@ Counter presets available out of the box:
 
     Or pass a path to a YAML file in rocprofv3 native job format.
 
-Design note — why --counters/--shape-set/--backends are parsed at module level
--------------------------------------------------------------------------------
+Design note — why --counters / --model / --q-len / --batch / --paged are parsed at module level
+-----------------------------------------------------------------------------------------------
 rocprofv3 re-executes this script as a subprocess (passing the same sys.argv)
 to collect hardware counters.  The RocmProfiler object must therefore be
-constructed at module import time with the correct parameter values, so that
+constructed at module import time with the correct `counters=` value, so that
 both the outer driver and the inner rocprofv3 subprocess use the same preset.
-We extract these flags here (using parse_known_args so we don't conflict with
-the profiler's own argparse), strip them from sys.argv, and then pass the
-values to the RocmProfiler constructor.
+We extract all bench flags here (using parse_known_args so we don't conflict
+with the profiler's own argparse), strip them from sys.argv, and then pass
+the values to the RocmProfiler constructor.
 """
 
 import argparse
+import logging
 import math
 import sys
-import logging
 from pathlib import Path
 
 import torch
+
 import flashinfer
 from flashinfer.jit.core import logger as _jit_logger
-from flashinfer.aiter_utils import HAS_AITER
 
 # Suppress routine JIT INFO/DEBUG output; WARNING still surfaces compile errors.
 _jit_logger.setLevel(logging.WARNING)
@@ -100,12 +122,16 @@ _jit_logger.setLevel(logging.WARNING)
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "rocm_profiler"))
 from rocm_profiler import KernelConfig, RocmProfiler
 
+# vLLM max_num_batched_tokens=2048 at seq_len≈512 → ~4 seqs; paged burst mid-range → 8.
+_DEFAULT_BATCH_RAGGED = 4
+_DEFAULT_BATCH_PAGED = 8
+
 # ---------------------------------------------------------------------------
 # Bench-script-level argument parsing
 #
-# parse_known_args() extracts only these flags and leaves all others (
-# --timing-only, --skip-roofline, --replot, --list-presets, …) in sys.argv
-# for RocmProfiler._parse_args() to consume.
+# parse_known_args() extracts only bench flags and leaves all other
+# flags (--timing-only, --skip-roofline, --replot, --list-presets, …) in
+# sys.argv for RocmProfiler._parse_args() to consume.
 # ---------------------------------------------------------------------------
 _bench_parser = argparse.ArgumentParser(add_help=False)
 _bench_parser.add_argument(
@@ -122,171 +148,303 @@ _bench_parser.add_argument(
     "--label",
     default=None,
     metavar="PREFIX",
-    help="Output-file label prefix. Auto-derived from backends+shape-set if omitted.",
-)
-_bench_parser.add_argument(
-    "--shape-set",
-    default="production",
-    choices=["production", "intensity"],
     help=(
-        "'production' = Alibaba production shapes (q=256, GQA 16/4, hd=64, causal). "
-        "'intensity' = arithmetic-intensity sweep (q=kv, MHA 32/32, hd=128). "
-        "Default: production."
+        "Output-file label prefix (default: 'fa2' for the roofline preset, "
+        "'fa2_<preset>' for all others)."
     ),
 )
 _bench_parser.add_argument(
-    "--backends",
-    default="fa2",
-    metavar="BACKEND[,BACKEND...]",
+    "--model",
+    default="intensity",
+    choices=["intensity", "llama3-8b", "llama3-70b", "mistral-7b"],
     help=(
-        "Comma-separated backends to benchmark: fa2, fa3, aiter. "
-        "Counter collection applies to fa2 and fa3 (SinglePrefillWithKVCacheKernel); "
-        "aiter configs are timed but not counter-collected by default. "
-        "Default: fa2."
+        "Shape preset. 'intensity' = MHA 32/32 hd=128 sweep (default, good for "
+        "roofline). GQA presets match real model architectures: "
+        "llama3-8b (32/8 hd=128), llama3-70b (64/8 hd=128), mistral-7b (32/8 hd=128)."
+    ),
+)
+_bench_parser.add_argument(
+    "--q-len",
+    type=int,
+    default=0,
+    metavar="Q",
+    help=(
+        "When > 0, adds asymmetric single-prefill configs with q_len=Q and "
+        "kv_len swept over the standard sequence lengths (causal only). "
+        "Models chunked prefill / decode-step scenarios. Default: 0 (disabled)."
+    ),
+)
+_bench_parser.add_argument(
+    "--batch",
+    type=int,
+    default=_DEFAULT_BATCH_RAGGED,
+    metavar="N",
+    help=(
+        "batch_size for ragged-KV batch-prefill configs (0 = disabled). "
+        f"Default: {_DEFAULT_BATCH_RAGGED} (~vLLM max_num_batched_tokens=2048 "
+        "at seq_len=512)."
+    ),
+)
+_bench_parser.add_argument(
+    "--paged",
+    type=int,
+    default=_DEFAULT_BATCH_PAGED,
+    metavar="N",
+    help=(
+        "batch_size for paged-KV batch-prefill configs (0 = disabled). "
+        "Runs page_size=16 and page_size=64 by default; override with --page-size. "
+        f"Default: {_DEFAULT_BATCH_PAGED} (mid-range prefill burst in a "
+        "mixed prefill+decode paged system)."
+    ),
+)
+_bench_parser.add_argument(
+    "--page-size",
+    type=int,
+    default=0,
+    metavar="P",
+    help=(
+        "Override page size for --paged mode. When 0 (default), runs both "
+        "page_size=16 and page_size=64 automatically."
     ),
 )
 _bench_args, _remaining = _bench_parser.parse_known_args()
-# Strip these flags so RocmProfiler's own argparse doesn't error on them.
 sys.argv = [sys.argv[0]] + _remaining
 
 _counters = _bench_args.counters
-_shape_set = _bench_args.shape_set
-_backends: list[str] = [b.strip() for b in _bench_args.backends.split(",")]
-
-if _bench_args.label is not None:
-    _label = _bench_args.label
-else:
-    parts = ["-".join(_backends)]
-    if _shape_set != "production":
-        parts.append(_shape_set)
-    if _counters != "roofline":
-        parts.append(_counters)
-    _label = "_".join(parts)
+_model: str = _bench_args.model
+_q_len_asym: int = _bench_args.q_len
+_batch_size: int = _bench_args.batch
+_paged_size: int = _bench_args.paged
+# Page sizes to sweep: explicit override or default [16, 64]
+_page_sizes: list[int] = [_bench_args.page_size] if _bench_args.page_size > 0 else [16, 64]
+_label = (
+    _bench_args.label
+    if _bench_args.label is not None
+    else ("fa2" if _counters == "roofline" else f"fa2_{_counters}")
+)
 
 # ---------------------------------------------------------------------------
-# Shape sweep definitions
-# (q_len, kv_len, num_qo_heads, num_kv_heads, head_dim, causal)
+# Shape presets (seq_len, num_qo_heads, num_kv_heads, head_dim, causal)
 # ---------------------------------------------------------------------------
-
-# Production target: Alibaba inference distribution.
-# q_len=256 (new tokens), GQA 16/4, hd=64, causal-only.
-_PRODUCTION_SHAPES = [
-    (256, 512, 16, 4, 64, True),
-    (256, 1024, 16, 4, 64, True),
-    (256, 2048, 16, 4, 64, True),
-    (256, 3072, 16, 4, 64, True),
-    (256, 4096, 16, 4, 64, True),
-    (256, 8192, 16, 4, 64, True),
-]
-
-# Arithmetic-intensity sweep that crosses the MI300X ridge (~247 FLOPs/B)
-# near seq_len=1024.  Useful for roofline analysis across the memory/compute
-# boundary; not a realistic inference workload.
-_INTENSITY_SHAPES = [
-    # Causal
-    (512, 512, 32, 32, 128, True),
-    (1024, 1024, 32, 32, 128, True),
-    (2048, 2048, 32, 32, 128, True),
-    (4096, 4096, 32, 32, 128, True),
-    (8192, 8192, 32, 32, 128, True),
-    # Non-causal — 2× FLOPs at same bytes → 2× arithmetic intensity
-    (512, 512, 32, 32, 128, False),
-    (1024, 1024, 32, 32, 128, False),
-    (2048, 2048, 32, 32, 128, False),
-    (4096, 4096, 32, 32, 128, False),
-]
-
-_SHAPE_SETS: dict[str, list] = {
-    "production": _PRODUCTION_SHAPES,
-    "intensity": _INTENSITY_SHAPES,
+_MODEL_CONFIGS: dict[str, list[tuple]] = {
+    # MHA sweep — maximises arithmetic intensity range for roofline analysis.
+    # Crosses the MI300X ridge point (~247 FLOPs/B) near seq_len=1024.
+    "intensity": [
+        (512, 32, 32, 128, True),
+        (1024, 32, 32, 128, True),
+        (2048, 32, 32, 128, True),
+        (4096, 32, 32, 128, True),
+        (8192, 32, 32, 128, True),
+        (512, 32, 32, 128, False),
+        (1024, 32, 32, 128, False),
+        (2048, 32, 32, 128, False),
+        (4096, 32, 32, 128, False),
+    ],
+    # Llama-3-8B: GQA 32Q/8KV, hd=128 — causal only
+    "llama3-8b": [(s, 32, 8, 128, True) for s in [512, 1024, 2048, 4096, 8192]],
+    # Llama-3-70B: GQA 64Q/8KV, hd=128 — causal only
+    "llama3-70b": [(s, 64, 8, 128, True) for s in [512, 1024, 2048, 4096, 8192]],
+    # Mistral-7B: GQA 32Q/8KV, hd=128 — causal only
+    "mistral-7b": [(s, 32, 8, 128, True) for s in [512, 1024, 2048, 4096, 8192]],
 }
+_CONFIGS = _MODEL_CONFIGS[_model]
 
 _OUTPUT_DIR = str(Path(__file__).parent)
 
 
+# ---------------------------------------------------------------------------
+# FLOPs / bytes helpers
+# ---------------------------------------------------------------------------
+
+
+def _flops(q_len: int, kv_len: int, num_qo_heads: int, head_dim: int, causal: bool) -> int:
+    # For causal with q_len < kv_len the mask removes only the last q*(q-1)/2
+    # entries of the attended set, not half the matrix (which factor=2 assumes).
+    attended = q_len * kv_len - q_len * (q_len - 1) // 2 if causal else q_len * kv_len
+    return attended * num_qo_heads * head_dim * 4
+
+
+def _bytes(
+    q_len: int, kv_len: int, num_qo_heads: int, num_kv_heads: int, head_dim: int
+) -> int:
+    return 2 * head_dim * (2 * q_len * num_qo_heads + 2 * kv_len * num_kv_heads)
+
+
+# ---------------------------------------------------------------------------
+# Config builders
+# ---------------------------------------------------------------------------
+
+
 @torch.inference_mode()
-def _make_configs(
-    shapes: list,
-    backends: list[str],
-) -> list[KernelConfig]:
-    """
-    Build a KernelConfig list for a cross-product of shapes × backends.
+def _make_configs() -> list[KernelConfig]:
+    configs = []
 
-    For each (shape, backend) pair:
-      - Tensors are allocated at module import time (so rocprofv3 subprocess
-        reuse the same shapes without GPU reallocation).
-      - Q/K/V are scaled by 1/sqrt(head_dim) to keep dot-product magnitudes
-        in a safe fp16 range and avoid misleading NaN output during debug.
-    """
-    skipped: list[str] = []
-    configs: list[KernelConfig] = []
-    multi = len(backends) > 1
+    for seq_len, num_qo_heads, num_kv_heads, head_dim, causal in _CONFIGS:
+        q = torch.randn(seq_len, num_qo_heads, head_dim, dtype=torch.half, device="cuda")
+        k = torch.randn(seq_len, num_kv_heads, head_dim, dtype=torch.half, device="cuda")
+        v = torch.randn(seq_len, num_kv_heads, head_dim, dtype=torch.half, device="cuda")
 
-    for backend in backends:
-        if backend == "aiter" and not HAS_AITER:
-            skipped.append("aiter")
-            continue
-
-        for q_len, kv_len, num_qo_heads, num_kv_heads, head_dim, causal in shapes:
-            scale = 1.0 / math.sqrt(head_dim)
-            q = torch.randn(q_len, num_qo_heads, head_dim, dtype=torch.half, device="cuda") * scale
-            k = torch.randn(kv_len, num_kv_heads, head_dim, dtype=torch.half, device="cuda") * scale
-            v = torch.randn(kv_len, num_kv_heads, head_dim, dtype=torch.half, device="cuda") * scale
-
-            # FLOPs: two GEMMs (QK^T and AV), both of shape attended×head_dim.
-            # For causal with q_len ≤ kv_len, each query token i attends to
-            # kv_len-q_len+i+1 key positions → total attended pairs =
-            #   q_len*(kv_len-q_len) + q_len*(q_len+1)//2
-            #   = q_len*kv_len - q_len*(q_len-1)//2
-            # For non-causal every pair is attended.
-            if causal:
-                attended = q_len * kv_len - q_len * (q_len - 1) // 2
-            else:
-                attended = q_len * kv_len
-            flops = attended * num_qo_heads * head_dim * 4  # ×2 matmuls × ×2 mul-add
-
-            # Bytes (cold-cache lower bound, fp16):
-            #   Q: (q_len, num_qo_heads, head_dim) — read
-            #   K: (kv_len, num_kv_heads, head_dim) — read
-            #   V: (kv_len, num_kv_heads, head_dim) — read
-            #   O: (q_len, num_qo_heads, head_dim) — write
-            #   LSE: (q_len, num_qo_heads) × fp32 — write (return_lse variant)
-            theo_bytes = (
-                (2 * q_len * num_qo_heads + 2 * kv_len * num_kv_heads) * head_dim * 2
-                + q_len * num_qo_heads * 4
+        flops = _flops(seq_len, seq_len, num_qo_heads, head_dim, causal)
+        theo_bytes = _bytes(seq_len, seq_len, num_qo_heads, num_kv_heads, head_dim)
+        causal_str = "causal" if causal else "nc"
+        configs.append(
+            KernelConfig(
+                name=f"s{seq_len}_{causal_str}",
+                run_fn=torch.inference_mode()(
+                    lambda q=q, k=k, v=v, c=causal: (
+                        flashinfer.single_prefill_with_kv_cache_return_lse(
+                            q, k, v, causal=c, backend="fa2"
+                        )
+                    )
+                ),
+                theoretical_flops=flops,
+                theoretical_bytes=theo_bytes,
+                num_tokens=seq_len,
+                label=f"seq={seq_len:>5d}  {'causal' if causal else 'non-causal'}",
             )
+        )
 
-            causal_str = "causal" if causal else "nc"
-            backend_tag = f"_{backend}" if multi else ""
-            name = f"kv{kv_len}h{head_dim}_{causal_str}{backend_tag}"
+    if _q_len_asym > 0:
+        for seq_len, num_qo_heads, num_kv_heads, head_dim, causal in _CONFIGS:
+            if not causal or seq_len <= _q_len_asym:
+                continue  # asymmetric is causal-only; skip if kv not larger than q
+            kv_len = seq_len
+            q = torch.randn(
+                _q_len_asym, num_qo_heads, head_dim, dtype=torch.half, device="cuda"
+            )
+            k = torch.randn(kv_len, num_kv_heads, head_dim, dtype=torch.half, device="cuda")
+            v = torch.randn(kv_len, num_kv_heads, head_dim, dtype=torch.half, device="cuda")
 
-            if q_len == kv_len:
-                shape_label = f"seq={q_len:>5d}"
-            else:
-                shape_label = f"q={q_len} kv={kv_len:>5d}"
-            label = f"{shape_label} {'causal':6s} {backend}" if causal else f"{shape_label} {'nc':6s} {backend}"
-
+            flops = _flops(_q_len_asym, kv_len, num_qo_heads, head_dim, causal=True)
+            theo_bytes = _bytes(_q_len_asym, kv_len, num_qo_heads, num_kv_heads, head_dim)
             configs.append(
                 KernelConfig(
-                    name=name,
+                    name=f"q{_q_len_asym}_kv{kv_len}_causal",
                     run_fn=torch.inference_mode()(
-                        lambda q=q, k=k, v=v, c=causal, b=backend: (
-                            flashinfer.single_prefill_with_kv_cache(
-                                q, k, v, causal=c, backend=b, return_lse=True
+                        lambda q=q, k=k, v=v: (
+                            flashinfer.single_prefill_with_kv_cache_return_lse(
+                                q, k, v, causal=True, backend="fa2"
                             )
                         )
                     ),
                     theoretical_flops=flops,
                     theoretical_bytes=theo_bytes,
-                    label=label,
+                    num_tokens=_q_len_asym,
+                    label=f"q={_q_len_asym:>4d} kv={kv_len:>5d}  causal",
                 )
             )
 
-    if skipped:
-        print(
-            f"[bench] WARNING: skipping backends {skipped} — "
-            "not installed (install from https://github.com/ROCm/aiter).",
-            file=sys.stderr,
+    return configs
+
+
+@torch.inference_mode()
+def _make_batch_configs(batch_size: int) -> list[KernelConfig]:
+    workspace = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    configs = []
+    for seq_len, num_qo_heads, num_kv_heads, head_dim, causal in _CONFIGS:
+        q = torch.randn(
+            batch_size * seq_len, num_qo_heads, head_dim, dtype=torch.half, device="cuda"
+        )
+        k = torch.randn(
+            batch_size * seq_len, num_kv_heads, head_dim, dtype=torch.half, device="cuda"
+        )
+        v = torch.randn(
+            batch_size * seq_len, num_kv_heads, head_dim, dtype=torch.half, device="cuda"
+        )
+        indptr = torch.arange(
+            0, (batch_size + 1) * seq_len, seq_len, dtype=torch.int32, device="cuda"
+        )
+
+        wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+            workspace, "NHD", backend="fa2"
+        )
+        wrapper.plan(indptr, indptr, num_qo_heads, num_kv_heads, head_dim, causal=causal)
+
+        flops = batch_size * _flops(seq_len, seq_len, num_qo_heads, head_dim, causal)
+        theo_bytes = batch_size * _bytes(seq_len, seq_len, num_qo_heads, num_kv_heads, head_dim)
+        causal_str = "causal" if causal else "nc"
+        configs.append(
+            KernelConfig(
+                name=f"bs{batch_size}_s{seq_len}_{causal_str}",
+                run_fn=torch.inference_mode()(
+                    lambda q=q, k=k, v=v, w=wrapper: w.run(q, k, v, return_lse=True)
+                ),
+                theoretical_flops=flops,
+                theoretical_bytes=theo_bytes,
+                num_tokens=batch_size * seq_len,
+                label=(
+                    f"bs={batch_size} seq={seq_len:>5d}  "
+                    f"{'causal' if causal else 'non-causal'}"
+                ),
+            )
+        )
+    return configs
+
+
+@torch.inference_mode()
+def _make_paged_configs(batch_size: int, page_size: int) -> list[KernelConfig]:
+    workspace = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    configs = []
+    for seq_len, num_qo_heads, num_kv_heads, head_dim, causal in _CONFIGS:
+        pages_per_seq = math.ceil(seq_len / page_size)
+        last_page_len = seq_len - (pages_per_seq - 1) * page_size
+        total_pages = batch_size * pages_per_seq
+
+        q = torch.randn(
+            batch_size * seq_len, num_qo_heads, head_dim, dtype=torch.half, device="cuda"
+        )
+        kv_cache = torch.randn(
+            total_pages, 2, page_size, num_kv_heads, head_dim,
+            dtype=torch.half, device="cuda",
+        )
+
+        qo_indptr = torch.arange(
+            0, (batch_size + 1) * seq_len, seq_len, dtype=torch.int32, device="cuda"
+        )
+        paged_kv_indptr = torch.arange(
+            0, (batch_size + 1) * pages_per_seq, pages_per_seq,
+            dtype=torch.int32, device="cuda",
+        )
+        _rng = torch.Generator(device="cuda").manual_seed(42)
+        paged_kv_indices = torch.randperm(
+            total_pages, dtype=torch.int32, device="cuda", generator=_rng
+        )
+        paged_kv_last_page_len = torch.full(
+            (batch_size,), last_page_len, dtype=torch.int32, device="cuda"
+        )
+
+        wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+            workspace, "NHD", backend="fa2"
+        )
+        wrapper.plan(
+            qo_indptr,
+            paged_kv_indptr,
+            paged_kv_indices,
+            paged_kv_last_page_len,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            causal=causal,
+        )
+
+        flops = batch_size * _flops(seq_len, seq_len, num_qo_heads, head_dim, causal)
+        theo_bytes = batch_size * _bytes(seq_len, seq_len, num_qo_heads, num_kv_heads, head_dim)
+        causal_str = "causal" if causal else "nc"
+        configs.append(
+            KernelConfig(
+                name=f"paged{page_size}_bs{batch_size}_s{seq_len}_{causal_str}",
+                run_fn=torch.inference_mode()(
+                    lambda q=q, kv=kv_cache, w=wrapper: w.run(q, kv, return_lse=True)
+                ),
+                theoretical_flops=flops,
+                theoretical_bytes=theo_bytes,
+                num_tokens=batch_size * seq_len,
+                label=(
+                    f"paged(ps={page_size:>2d}) bs={batch_size} seq={seq_len:>5d}  "
+                    f"{'causal' if causal else 'non-causal'}"
+                ),
+            )
         )
     return configs
 
@@ -294,18 +452,30 @@ def _make_configs(
 if __name__ == "__main__":
     # Defer GPU tensor allocation: --replot and --list-presets don't need a CUDA device.
     _skip_gpu = "--replot" in sys.argv or "--list-presets" in sys.argv
-    shapes = _SHAPE_SETS[_shape_set]
 
-    # Counter collection via kernel_name_regex matches the FA2/FA3 kernel.
-    # AITER dispatches a different kernel; its dispatches won't appear in the
-    # counter CSV (timing is still accurate for all backends).
+    def _build_configs() -> list[KernelConfig]:
+        cfgs = _make_configs()
+        if _batch_size > 0:
+            cfgs += _make_batch_configs(_batch_size)
+        if _paged_size > 0:
+            for ps in _page_sizes:
+                cfgs += _make_paged_configs(_paged_size, ps)
+        return cfgs
+
+    # Widen regex when any batch/paged mode is active so counter collection
+    # covers BatchPrefillWithRaggedKVCacheKernel and BatchPrefillWithPagedKVCacheKernel.
+    _kernel_regex = (
+        "PrefillWith.*KVCacheKernel"
+        if (_batch_size > 0 or _paged_size > 0)
+        else "SinglePrefillWithKVCacheKernel"
+    )
     profiler = RocmProfiler(
-        configs=[] if _skip_gpu else _make_configs(shapes, _backends),
+        configs=[] if _skip_gpu else _build_configs(),
         num_warmup=3,
         dry_run_ms=100,
         repeat_ms=1000,
         counters=_counters,
-        kernel_name_regex="SinglePrefillWithKVCacheKernel",
+        kernel_name_regex=_kernel_regex,
         output_dir=_OUTPUT_DIR,
         label=_label,
         roofline=(_counters == "roofline"),

--- a/benchmarks/rocm_benchmarks/bench_fa2_prefill.py
+++ b/benchmarks/rocm_benchmarks/bench_fa2_prefill.py
@@ -65,12 +65,14 @@ Model presets (--model):
     mistral-7b — GQA 32/8 hd=128, causal, kv∈{512..8192}
 
 Batch-prefill mode (--batch / --paged):
-    --batch N  Uses BatchPrefillWithRaggedKVCacheWrapper (fa2 backend) with
-               N sequences each of the same seq_len as the single-prefill sweep.
-    --paged N  Uses BatchPrefillWithPagedKVCacheWrapper (fa2 backend) with
-               N sequences.  Runs two page sizes by default (16 and 64).
-               Override with --page-size P to test a single page size.
-    batch_size=1 provides a direct single-vs-batch API overhead comparison.
+    --batch N       Uses BatchPrefillWithRaggedKVCacheWrapper (fa2 backend)
+                    with N sequences.  Each sequence has q_len=--batch-q-len
+                    attending to kv_len swept over the standard range (causal).
+    --paged N       Uses BatchPrefillWithPagedKVCacheWrapper (fa2 backend)
+                    with N sequences.  Same asymmetric shape as --batch.
+                    Runs page_size=16 and page_size=64 by default.
+    --batch-q-len Q Fixed query length per sequence in batch configs.
+                    Default: 256 (chunked-prefill burst, same as AITER bench).
 
 Asymmetric (chunked-prefill) mode (--q-len):
     --q-len Q  Adds single-prefill configs with q_len=Q, kv_len swept over the
@@ -94,7 +96,7 @@ Counter presets available out of the box:
 
     Or pass a path to a YAML file in rocprofv3 native job format.
 
-Design note — why --counters / --model / --q-len / --batch / --paged are parsed at module level
+Design note — why --counters / --model / --q-len / --batch / --batch-q-len / --paged are parsed at module level
 -----------------------------------------------------------------------------------------------
 rocprofv3 re-executes this script as a subprocess (passing the same sys.argv)
 to collect hardware counters.  The RocmProfiler object must therefore be
@@ -125,6 +127,7 @@ from rocm_profiler import KernelConfig, RocmProfiler
 # vLLM max_num_batched_tokens=2048 at seq_len≈512 → ~4 seqs; paged burst mid-range → 8.
 _DEFAULT_BATCH_RAGGED = 4
 _DEFAULT_BATCH_PAGED = 8
+_DEFAULT_BATCH_Q_LEN = 256  # matches AITER bench _Q_LEN; represents a chunked-prefill burst
 
 # ---------------------------------------------------------------------------
 # Bench-script-level argument parsing
@@ -207,6 +210,18 @@ _bench_parser.add_argument(
         "page_size=16 and page_size=64 automatically."
     ),
 )
+_bench_parser.add_argument(
+    "--batch-q-len",
+    type=int,
+    default=_DEFAULT_BATCH_Q_LEN,
+    metavar="Q",
+    help=(
+        "Fixed query length per sequence for --batch and --paged configs. "
+        "Each batch sequence has q_len=Q attending to kv_len swept over the "
+        "standard range (causal only, kv_len > Q). "
+        f"Default: {_DEFAULT_BATCH_Q_LEN} (chunked-prefill burst, matches AITER bench)."
+    ),
+)
 _bench_args, _remaining = _bench_parser.parse_known_args()
 sys.argv = [sys.argv[0]] + _remaining
 
@@ -215,7 +230,7 @@ _model: str = _bench_args.model
 _q_len_asym: int = _bench_args.q_len
 _batch_size: int = _bench_args.batch
 _paged_size: int = _bench_args.paged
-# Page sizes to sweep: explicit override or default [16, 64]
+_batch_q_len: int = _bench_args.batch_q_len
 _page_sizes: list[int] = [_bench_args.page_size] if _bench_args.page_size > 0 else [16, 64]
 _label = (
     _bench_args.label
@@ -338,60 +353,66 @@ def _make_configs() -> list[KernelConfig]:
 
 
 @torch.inference_mode()
-def _make_batch_configs(batch_size: int) -> list[KernelConfig]:
+def _make_batch_configs(batch_size: int, q_len: int) -> list[KernelConfig]:
     workspace = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
     configs = []
     for seq_len, num_qo_heads, num_kv_heads, head_dim, causal in _CONFIGS:
+        kv_len = seq_len
+        if not causal or kv_len <= q_len:
+            continue  # asymmetric (q < kv) is causal-only; need kv_len > q_len
         q = torch.randn(
-            batch_size * seq_len, num_qo_heads, head_dim, dtype=torch.half, device="cuda"
+            batch_size * q_len, num_qo_heads, head_dim, dtype=torch.half, device="cuda"
         )
         k = torch.randn(
-            batch_size * seq_len, num_kv_heads, head_dim, dtype=torch.half, device="cuda"
+            batch_size * kv_len, num_kv_heads, head_dim, dtype=torch.half, device="cuda"
         )
         v = torch.randn(
-            batch_size * seq_len, num_kv_heads, head_dim, dtype=torch.half, device="cuda"
+            batch_size * kv_len, num_kv_heads, head_dim, dtype=torch.half, device="cuda"
         )
-        indptr = torch.arange(
-            0, (batch_size + 1) * seq_len, seq_len, dtype=torch.int32, device="cuda"
+        qo_indptr = torch.arange(
+            0, (batch_size + 1) * q_len, q_len, dtype=torch.int32, device="cuda"
+        )
+        kv_indptr = torch.arange(
+            0, (batch_size + 1) * kv_len, kv_len, dtype=torch.int32, device="cuda"
         )
 
         wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
             workspace, "NHD", backend="fa2"
         )
-        wrapper.plan(indptr, indptr, num_qo_heads, num_kv_heads, head_dim, causal=causal)
+        wrapper.plan(qo_indptr, kv_indptr, num_qo_heads, num_kv_heads, head_dim, causal=True)
 
-        flops = batch_size * _flops(seq_len, seq_len, num_qo_heads, head_dim, causal)
-        theo_bytes = batch_size * _bytes(seq_len, seq_len, num_qo_heads, num_kv_heads, head_dim)
-        causal_str = "causal" if causal else "nc"
+        flops = batch_size * _flops(q_len, kv_len, num_qo_heads, head_dim, causal=True)
+        theo_bytes = batch_size * _bytes(q_len, kv_len, num_qo_heads, num_kv_heads, head_dim)
         configs.append(
             KernelConfig(
-                name=f"bs{batch_size}_s{seq_len}_{causal_str}",
+                name=f"ragged_bs{batch_size}_q{q_len}_kv{kv_len}",
                 run_fn=torch.inference_mode()(
                     lambda q=q, k=k, v=v, w=wrapper: w.run(q, k, v, return_lse=True)
                 ),
                 theoretical_flops=flops,
                 theoretical_bytes=theo_bytes,
-                num_tokens=batch_size * seq_len,
-                label=(
-                    f"bs={batch_size} seq={seq_len:>5d}  "
-                    f"{'causal' if causal else 'non-causal'}"
-                ),
+                num_tokens=batch_size * q_len,
+                label=f"ragged bs={batch_size} q={q_len:>4d} kv={kv_len:>5d}",
             )
         )
     return configs
 
 
 @torch.inference_mode()
-def _make_paged_configs(batch_size: int, page_size: int) -> list[KernelConfig]:
+def _make_paged_configs(batch_size: int, page_size: int, q_len: int) -> list[KernelConfig]:
     workspace = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
     configs = []
     for seq_len, num_qo_heads, num_kv_heads, head_dim, causal in _CONFIGS:
-        pages_per_seq = math.ceil(seq_len / page_size)
-        last_page_len = seq_len - (pages_per_seq - 1) * page_size
+        kv_len = seq_len
+        if not causal or kv_len <= q_len:
+            continue  # asymmetric (q < kv) is causal-only; need kv_len > q_len
+
+        pages_per_seq = math.ceil(kv_len / page_size)
+        last_page_len = kv_len - (pages_per_seq - 1) * page_size
         total_pages = batch_size * pages_per_seq
 
         q = torch.randn(
-            batch_size * seq_len, num_qo_heads, head_dim, dtype=torch.half, device="cuda"
+            batch_size * q_len, num_qo_heads, head_dim, dtype=torch.half, device="cuda"
         )
         kv_cache = torch.randn(
             total_pages, 2, page_size, num_kv_heads, head_dim,
@@ -399,7 +420,7 @@ def _make_paged_configs(batch_size: int, page_size: int) -> list[KernelConfig]:
         )
 
         qo_indptr = torch.arange(
-            0, (batch_size + 1) * seq_len, seq_len, dtype=torch.int32, device="cuda"
+            0, (batch_size + 1) * q_len, q_len, dtype=torch.int32, device="cuda"
         )
         paged_kv_indptr = torch.arange(
             0, (batch_size + 1) * pages_per_seq, pages_per_seq,
@@ -425,25 +446,21 @@ def _make_paged_configs(batch_size: int, page_size: int) -> list[KernelConfig]:
             num_kv_heads,
             head_dim,
             page_size,
-            causal=causal,
+            causal=True,
         )
 
-        flops = batch_size * _flops(seq_len, seq_len, num_qo_heads, head_dim, causal)
-        theo_bytes = batch_size * _bytes(seq_len, seq_len, num_qo_heads, num_kv_heads, head_dim)
-        causal_str = "causal" if causal else "nc"
+        flops = batch_size * _flops(q_len, kv_len, num_qo_heads, head_dim, causal=True)
+        theo_bytes = batch_size * _bytes(q_len, kv_len, num_qo_heads, num_kv_heads, head_dim)
         configs.append(
             KernelConfig(
-                name=f"paged{page_size}_bs{batch_size}_s{seq_len}_{causal_str}",
+                name=f"paged{page_size}_bs{batch_size}_q{q_len}_kv{kv_len}",
                 run_fn=torch.inference_mode()(
                     lambda q=q, kv=kv_cache, w=wrapper: w.run(q, kv, return_lse=True)
                 ),
                 theoretical_flops=flops,
                 theoretical_bytes=theo_bytes,
-                num_tokens=batch_size * seq_len,
-                label=(
-                    f"paged(ps={page_size:>2d}) bs={batch_size} seq={seq_len:>5d}  "
-                    f"{'causal' if causal else 'non-causal'}"
-                ),
+                num_tokens=batch_size * q_len,
+                label=f"paged(ps={page_size:>2d}) bs={batch_size} q={q_len:>4d} kv={kv_len:>5d}",
             )
         )
     return configs
@@ -456,10 +473,10 @@ if __name__ == "__main__":
     def _build_configs() -> list[KernelConfig]:
         cfgs = _make_configs()
         if _batch_size > 0:
-            cfgs += _make_batch_configs(_batch_size)
+            cfgs += _make_batch_configs(_batch_size, _batch_q_len)
         if _paged_size > 0:
             for ps in _page_sizes:
-                cfgs += _make_paged_configs(_paged_size, ps)
+                cfgs += _make_paged_configs(_paged_size, ps, _batch_q_len)
         return cfgs
 
     # Widen regex when any batch/paged mode is active so counter collection

--- a/benchmarks/rocm_benchmarks/bench_fa2_prefill.py
+++ b/benchmarks/rocm_benchmarks/bench_fa2_prefill.py
@@ -13,97 +13,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-FA2 prefill benchmark: single-prefill, batch-ragged-prefill, and
-batch-paged-prefill via backend="fa2".
+FA2 prefill benchmark: single-prefill, batch-ragged, and batch-paged via backend="fa2".
 
 Run:
+    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py                        # full pipeline
+    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --timing-only          # no profiling
+    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --replot               # regenerate plot
+    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --model llama3-8b      # GQA shape
+    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --batch 0 --paged 0   # single only
+    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --counters stall       # stall preset
+    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --list-presets         # preset names
 
-    # Full roofline pipeline (timing + counter collection + roofline PNG):
-    # Runs single-prefill + ragged-batch (bs=4) + paged-batch (bs=8) by default.
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py
-
-    # Single-prefill only (disable batch sections):
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --batch 0 --paged 0
-
-    # Use a production GQA model shape (Llama-3-8B: GQA 32/8 hd=128):
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --model llama3-8b
-
-    # Add asymmetric chunked-prefill configs (q=256, kv sweeps):
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --q-len 256
-
-    # Select a different counter preset:
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --counters occupancy
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --counters stall
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --counters compute
-
-    # Override the output file label prefix:
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --counters occupancy --label fa2_occ
-
-    # Timing only (no rocprofv3):
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --timing-only
-
-    # Skip roofline plot after profiling:
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --skip-roofline
-
-    # Regenerate plot from existing CSVs (no GPU required):
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --replot
-
-    # List all available counter presets:
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --list-presets
-
-Output files (all gitignored):
-    benchmarks/rocm_benchmarks/<label>_timing.csv
-    benchmarks/rocm_benchmarks/<label>_meta.json
-    benchmarks/rocm_benchmarks/<label>_counters.yml
-    benchmarks/rocm_benchmarks/<label>_counter_collection.csv
-    benchmarks/rocm_benchmarks/<label>_roofline.png   (roofline preset only)
-
-Model presets (--model):
-    intensity  — MHA 32/32 hd=128, causal+non-causal sweep (default).
-                 Good for roofline analysis; covers the MI300X ridge point.
-    llama3-8b  — GQA 32/8 hd=128, causal, kv∈{512..8192}
-    llama3-70b — GQA 64/8 hd=128, causal, kv∈{512..8192}
-    mistral-7b — GQA 32/8 hd=128, causal, kv∈{512..8192}
-
-Batch-prefill mode (--batch / --paged):
-    --batch N       Uses BatchPrefillWithRaggedKVCacheWrapper (fa2 backend)
-                    with N sequences.  Each sequence has q_len=--batch-q-len
-                    attending to kv_len swept over the standard range (causal).
-    --paged N       Uses BatchPrefillWithPagedKVCacheWrapper (fa2 backend)
-                    with N sequences.  Same asymmetric shape as --batch.
-                    Runs page_size=16 and page_size=64 by default.
-    --batch-q-len Q Fixed query length per sequence in batch configs.
-                    Default: 256 (chunked-prefill burst, same as AITER bench).
-
-Asymmetric (chunked-prefill) mode (--q-len):
-    --q-len Q  Adds single-prefill configs with q_len=Q, kv_len swept over the
-               standard kv sequence lengths.  Models chunked prefill where a
-               short query attends to a long KV context.  Causal only.
-
-Paged KV indices:
-    Indices are drawn from torch.randperm (seed 42) to simulate memory
-    fragmentation in a real page pool.
-
-Counter presets available out of the box:
-    roofline  — FetchSize, WriteSize, MFMA ops, TCC DRAM requests,
-                SQ_VALU_MFMA_BUSY_CYCLES (default)
-    compute   — MFMA ops and cycle counters
-    memory    — L2 and DRAM bandwidth breakdown
-    basic     — minimal: FetchSize / WriteSize only
-    occupancy — SQ_WAVES, SQ_BUSY_CYCLES, SQ_VALU_MFMA_BUSY_CYCLES,
-                SQ_WAIT_INST_ANY, SQ_INSTS_LDS
-    stall     — SQ_INSTS_MFMA, SQ_WAIT_INST_VMEM, SQ_VALU_MFMA_BUSY_CYCLES,
-                SQ_WAIT_INST_LDS, SQ_BUSY_CYCLES
-
-    Or pass a path to a YAML file in rocprofv3 native job format.
-
-Design note — why bench flags are parsed at module level
----------------------------------------------------------
-rocprofv3 re-executes this script as a subprocess with the same sys.argv to
-collect hardware counters.  All bench-specific flags must therefore be parsed
-at module import time so the subprocess builds identical configs to the outer
-timing run.  RocmProfiler uses parse_known_args internally, so bench flags
-remaining in sys.argv are silently ignored by its own argparse.
+Design note: bench flags are parsed at module level because rocprofv3 re-executes this
+script as a subprocess per PMC pass with the same sys.argv.  Module-level parsing ensures
+the subprocess builds identical configs to the outer timing run.
 """
 
 import argparse

--- a/benchmarks/rocm_benchmarks/bench_fa2_prefill.py
+++ b/benchmarks/rocm_benchmarks/bench_fa2_prefill.py
@@ -19,16 +19,17 @@ batch-paged-prefill via backend="fa2".
 Run:
 
     # Full roofline pipeline (timing + counter collection + roofline PNG):
+    # Runs single-prefill + ragged-batch (bs=4) + paged-batch (bs=8) by default.
     python benchmarks/rocm_benchmarks/bench_fa2_prefill.py
+
+    # Single-prefill only (disable batch sections):
+    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --batch 0 --paged 0
 
     # Use a production GQA model shape (Llama-3-8B: GQA 32/8 hd=128):
     python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --model llama3-8b
 
     # Add asymmetric chunked-prefill configs (q=256, kv sweeps):
     python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --q-len 256
-
-    # Add batch-prefill configs alongside single-prefill (default batch sizes):
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --batch 4 --paged 8
 
     # Select a different counter preset:
     python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --counters occupancy
@@ -96,15 +97,13 @@ Counter presets available out of the box:
 
     Or pass a path to a YAML file in rocprofv3 native job format.
 
-Design note — why --counters / --model / --q-len / --batch / --batch-q-len / --paged are parsed at module level
------------------------------------------------------------------------------------------------
-rocprofv3 re-executes this script as a subprocess (passing the same sys.argv)
-to collect hardware counters.  The RocmProfiler object must therefore be
-constructed at module import time with the correct `counters=` value, so that
-both the outer driver and the inner rocprofv3 subprocess use the same preset.
-We extract all bench flags here (using parse_known_args so we don't conflict
-with the profiler's own argparse), strip them from sys.argv, and then pass
-the values to the RocmProfiler constructor.
+Design note — why bench flags are parsed at module level
+---------------------------------------------------------
+rocprofv3 re-executes this script as a subprocess with the same sys.argv to
+collect hardware counters.  All bench-specific flags must therefore be parsed
+at module import time so the subprocess builds identical configs to the outer
+timing run.  RocmProfiler uses parse_known_args internally, so bench flags
+remaining in sys.argv are silently ignored by its own argparse.
 """
 
 import argparse
@@ -130,11 +129,7 @@ _DEFAULT_BATCH_PAGED = 8
 _DEFAULT_BATCH_Q_LEN = 256  # matches AITER bench _Q_LEN; represents a chunked-prefill burst
 
 # ---------------------------------------------------------------------------
-# Bench-script-level argument parsing
-#
-# parse_known_args() extracts only bench flags and leaves all other
-# flags (--timing-only, --skip-roofline, --replot, --list-presets, …) in
-# sys.argv for RocmProfiler._parse_args() to consume.
+# Bench-script-level argument parsing (see design note above)
 # ---------------------------------------------------------------------------
 _bench_parser = argparse.ArgumentParser(add_help=False)
 _bench_parser.add_argument(
@@ -222,8 +217,7 @@ _bench_parser.add_argument(
         f"Default: {_DEFAULT_BATCH_Q_LEN} (chunked-prefill burst, matches AITER bench)."
     ),
 )
-_bench_args, _remaining = _bench_parser.parse_known_args()
-sys.argv = [sys.argv[0]] + _remaining
+_bench_args, _ = _bench_parser.parse_known_args()
 
 _counters = _bench_args.counters
 _model: str = _bench_args.model

--- a/benchmarks/rocm_benchmarks/bench_fa2_prefill.py
+++ b/benchmarks/rocm_benchmarks/bench_fa2_prefill.py
@@ -13,12 +13,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-FA2 single prefill roofline benchmark using rocm_profiler.
+Single-prefill roofline benchmark using rocm_profiler.
 
 Run:
 
     # Full roofline pipeline (timing + counter collection + roofline PNG):
     python benchmarks/rocm_benchmarks/bench_fa2_prefill.py
+
+    # Production shapes, multiple backends (timing compared side-by-side):
+    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --backends fa2,fa3,aiter
+
+    # Arithmetic-intensity sweep (old symmetric sweep):
+    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --shape-set intensity
 
     # Select a different counter preset:
     python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --counters occupancy
@@ -26,7 +32,7 @@ Run:
     python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --counters compute
 
     # Override the output file label prefix:
-    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --counters occupancy --label fa2_occ
+    python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --counters occupancy --label my_label
 
     # Timing only (no rocprofv3):
     python benchmarks/rocm_benchmarks/bench_fa2_prefill.py --timing-only
@@ -42,12 +48,20 @@ Run:
 
 Output files (all gitignored):
     benchmarks/rocm_benchmarks/<label>_timing.csv
+    benchmarks/rocm_benchmarks/<label>_meta.json
     benchmarks/rocm_benchmarks/<label>_counters.yml
     benchmarks/rocm_benchmarks/<label>_counter_collection.csv
     benchmarks/rocm_benchmarks/<label>_roofline.png   (roofline preset only)
 
+Shape sets:
+    production  — Alibaba production sweep: q=256, GQA 16/4, hd=64,
+                  kv ∈ {512,1024,2048,3072,4096,8192}, causal (default)
+    intensity   — Arithmetic-intensity sweep: q=kv, MHA 32/32, hd=128,
+                  causal + non-causal, crosses MI300X ridge at seq≈1024
+
 Counter presets available out of the box:
-    roofline  — FetchSize, WriteSize, MFMA ops, TCC DRAM requests (default)
+    roofline  — FetchSize, WriteSize, MFMA ops, TCC DRAM requests,
+                SQ_VALU_MFMA_BUSY_CYCLES (default)
     compute   — MFMA ops and cycle counters
     memory    — L2 and DRAM bandwidth breakdown
     basic     — minimal: FetchSize / WriteSize only
@@ -58,37 +72,40 @@ Counter presets available out of the box:
 
     Or pass a path to a YAML file in rocprofv3 native job format.
 
-Design note — why --counters is parsed at module level
--------------------------------------------------------
+Design note — why --counters/--shape-set/--backends are parsed at module level
+-------------------------------------------------------------------------------
 rocprofv3 re-executes this script as a subprocess (passing the same sys.argv)
 to collect hardware counters.  The RocmProfiler object must therefore be
-constructed at module import time with the correct `counters=` value, so that
+constructed at module import time with the correct parameter values, so that
 both the outer driver and the inner rocprofv3 subprocess use the same preset.
-We extract --counters / --label here (using parse_known_args so we don't
-conflict with the profiler's own argparse), strip them from sys.argv, and then
-pass the values to the RocmProfiler constructor.
+We extract these flags here (using parse_known_args so we don't conflict with
+the profiler's own argparse), strip them from sys.argv, and then pass the
+values to the RocmProfiler constructor.
 """
 
 import argparse
+import math
 import sys
 import logging
 from pathlib import Path
 
 import torch
 import flashinfer
-from flashinfer.jit.core import logger
+from flashinfer.jit.core import logger as _jit_logger
+from flashinfer.aiter_utils import HAS_AITER
 
-logger.setLevel(logging.ERROR)
+# Suppress routine JIT INFO/DEBUG output; WARNING still surfaces compile errors.
+_jit_logger.setLevel(logging.WARNING)
 
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "rocm_profiler"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "rocm_profiler"))
 from rocm_profiler import KernelConfig, RocmProfiler
 
 # ---------------------------------------------------------------------------
 # Bench-script-level argument parsing
 #
-# parse_known_args() extracts only --counters / --label and leaves all other
-# flags (--timing-only, --skip-roofline, --replot, --list-presets, …) in
-# sys.argv for RocmProfiler._parse_args() to consume.
+# parse_known_args() extracts only these flags and leaves all others (
+# --timing-only, --skip-roofline, --replot, --list-presets, …) in sys.argv
+# for RocmProfiler._parse_args() to consume.
 # ---------------------------------------------------------------------------
 _bench_parser = argparse.ArgumentParser(add_help=False)
 _bench_parser.add_argument(
@@ -105,84 +122,171 @@ _bench_parser.add_argument(
     "--label",
     default=None,
     metavar="PREFIX",
+    help="Output-file label prefix. Auto-derived from backends+shape-set if omitted.",
+)
+_bench_parser.add_argument(
+    "--shape-set",
+    default="production",
+    choices=["production", "intensity"],
     help=(
-        "Output-file label prefix (default: 'fa2' for the roofline preset, "
-        "'fa2_<preset>' for all others)."
+        "'production' = Alibaba production shapes (q=256, GQA 16/4, hd=64, causal). "
+        "'intensity' = arithmetic-intensity sweep (q=kv, MHA 32/32, hd=128). "
+        "Default: production."
+    ),
+)
+_bench_parser.add_argument(
+    "--backends",
+    default="fa2",
+    metavar="BACKEND[,BACKEND...]",
+    help=(
+        "Comma-separated backends to benchmark: fa2, fa3, aiter. "
+        "Counter collection applies to fa2 and fa3 (SinglePrefillWithKVCacheKernel); "
+        "aiter configs are timed but not counter-collected by default. "
+        "Default: fa2."
     ),
 )
 _bench_args, _remaining = _bench_parser.parse_known_args()
-# Strip --counters / --label so RocmProfiler's own argparse doesn't error on them.
+# Strip these flags so RocmProfiler's own argparse doesn't error on them.
 sys.argv = [sys.argv[0]] + _remaining
 
 _counters = _bench_args.counters
-_label = (
-    _bench_args.label
-    if _bench_args.label is not None
-    else ("fa2" if _counters == "roofline" else f"fa2_{_counters}")
-)
+_shape_set = _bench_args.shape_set
+_backends: list[str] = [b.strip() for b in _bench_args.backends.split(",")]
+
+if _bench_args.label is not None:
+    _label = _bench_args.label
+else:
+    parts = ["-".join(_backends)]
+    if _shape_set != "production":
+        parts.append(_shape_set)
+    if _counters != "roofline":
+        parts.append(_counters)
+    _label = "_".join(parts)
 
 # ---------------------------------------------------------------------------
-# Sweep configuration
-# (seq_len, num_qo_heads, num_kv_heads, head_dim, causal)
+# Shape sweep definitions
+# (q_len, kv_len, num_qo_heads, num_kv_heads, head_dim, causal)
 # ---------------------------------------------------------------------------
-_CONFIGS = [
-    # Causal sweep — crosses the MI300X ridge point (~247 FLOPs/B) near seq_len=1024
-    (512, 32, 32, 128, True),
-    (1024, 32, 32, 128, True),
-    (2048, 32, 32, 128, True),
-    (4096, 32, 32, 128, True),
-    (8192, 32, 32, 128, True),
-    # Non-causal sweep — 2× FLOPs, same bytes → 2× arithmetic intensity
-    (512, 32, 32, 128, False),
-    (1024, 32, 32, 128, False),
-    (2048, 32, 32, 128, False),
-    (4096, 32, 32, 128, False),
+
+# Production target: Alibaba inference distribution.
+# q_len=256 (new tokens), GQA 16/4, hd=64, causal-only.
+_PRODUCTION_SHAPES = [
+    (256, 512, 16, 4, 64, True),
+    (256, 1024, 16, 4, 64, True),
+    (256, 2048, 16, 4, 64, True),
+    (256, 3072, 16, 4, 64, True),
+    (256, 4096, 16, 4, 64, True),
+    (256, 8192, 16, 4, 64, True),
 ]
+
+# Arithmetic-intensity sweep that crosses the MI300X ridge (~247 FLOPs/B)
+# near seq_len=1024.  Useful for roofline analysis across the memory/compute
+# boundary; not a realistic inference workload.
+_INTENSITY_SHAPES = [
+    # Causal
+    (512, 512, 32, 32, 128, True),
+    (1024, 1024, 32, 32, 128, True),
+    (2048, 2048, 32, 32, 128, True),
+    (4096, 4096, 32, 32, 128, True),
+    (8192, 8192, 32, 32, 128, True),
+    # Non-causal — 2× FLOPs at same bytes → 2× arithmetic intensity
+    (512, 512, 32, 32, 128, False),
+    (1024, 1024, 32, 32, 128, False),
+    (2048, 2048, 32, 32, 128, False),
+    (4096, 4096, 32, 32, 128, False),
+]
+
+_SHAPE_SETS: dict[str, list] = {
+    "production": _PRODUCTION_SHAPES,
+    "intensity": _INTENSITY_SHAPES,
+}
 
 _OUTPUT_DIR = str(Path(__file__).parent)
 
 
 @torch.inference_mode()
-def _make_configs() -> list[KernelConfig]:
-    configs = []
-    for seq_len, num_qo_heads, num_kv_heads, head_dim, causal in _CONFIGS:
-        q = torch.randn(
-            seq_len, num_qo_heads, head_dim, dtype=torch.half, device="cuda"
-        )
-        k = torch.randn(
-            seq_len, num_kv_heads, head_dim, dtype=torch.half, device="cuda"
-        )
-        v = torch.randn(
-            seq_len, num_kv_heads, head_dim, dtype=torch.half, device="cuda"
-        )
+def _make_configs(
+    shapes: list,
+    backends: list[str],
+) -> list[KernelConfig]:
+    """
+    Build a KernelConfig list for a cross-product of shapes × backends.
 
-        # FLOPs: Q·Kᵀ + softmax(S)·V, causal mask halves each matmul
-        factor = 2 if causal else 4
-        flops = seq_len * seq_len * num_qo_heads * head_dim * factor
+    For each (shape, backend) pair:
+      - Tensors are allocated at module import time (so rocprofv3 subprocess
+        reuse the same shapes without GPU reallocation).
+      - Q/K/V are scaled by 1/sqrt(head_dim) to keep dot-product magnitudes
+        in a safe fp16 range and avoid misleading NaN output during debug.
+    """
+    skipped: list[str] = []
+    configs: list[KernelConfig] = []
+    multi = len(backends) > 1
 
-        # Bytes (cold-cache lower bound):
-        #   Q: (seq_len, num_qo_heads, head_dim)  — read
-        #   K: (seq_len, num_kv_heads, head_dim)  — read
-        #   V: (seq_len, num_kv_heads, head_dim)  — read
-        #   O: (seq_len, num_qo_heads, head_dim)  — write
-        # Total = fp16 (2 B) × (2×num_qo_heads + 2×num_kv_heads) × seq_len × head_dim
-        theo_bytes = 4 * seq_len * head_dim * (num_qo_heads + num_kv_heads)
+    for backend in backends:
+        if backend == "aiter" and not HAS_AITER:
+            skipped.append("aiter")
+            continue
 
-        causal_str = "causal" if causal else "nc"
-        configs.append(
-            KernelConfig(
-                name=f"s{seq_len}_{causal_str}",
-                run_fn=torch.inference_mode()(
-                    lambda q=q, k=k, v=v, c=causal: (
-                        flashinfer.single_prefill_with_kv_cache_return_lse(
-                            q, k, v, causal=c, backend="fa2"
-                        )
-                    )
-                ),
-                theoretical_flops=flops,
-                theoretical_bytes=theo_bytes,
-                label=f"seq={seq_len:>5d}  {'causal' if causal else 'non-causal'}",
+        for q_len, kv_len, num_qo_heads, num_kv_heads, head_dim, causal in shapes:
+            scale = 1.0 / math.sqrt(head_dim)
+            q = torch.randn(q_len, num_qo_heads, head_dim, dtype=torch.half, device="cuda") * scale
+            k = torch.randn(kv_len, num_kv_heads, head_dim, dtype=torch.half, device="cuda") * scale
+            v = torch.randn(kv_len, num_kv_heads, head_dim, dtype=torch.half, device="cuda") * scale
+
+            # FLOPs: two GEMMs (QK^T and AV), both of shape attended×head_dim.
+            # For causal with q_len ≤ kv_len, each query token i attends to
+            # kv_len-q_len+i+1 key positions → total attended pairs =
+            #   q_len*(kv_len-q_len) + q_len*(q_len+1)//2
+            #   = q_len*kv_len - q_len*(q_len-1)//2
+            # For non-causal every pair is attended.
+            if causal:
+                attended = q_len * kv_len - q_len * (q_len - 1) // 2
+            else:
+                attended = q_len * kv_len
+            flops = attended * num_qo_heads * head_dim * 4  # ×2 matmuls × ×2 mul-add
+
+            # Bytes (cold-cache lower bound, fp16):
+            #   Q: (q_len, num_qo_heads, head_dim) — read
+            #   K: (kv_len, num_kv_heads, head_dim) — read
+            #   V: (kv_len, num_kv_heads, head_dim) — read
+            #   O: (q_len, num_qo_heads, head_dim) — write
+            #   LSE: (q_len, num_qo_heads) × fp32 — write (return_lse variant)
+            theo_bytes = (
+                (2 * q_len * num_qo_heads + 2 * kv_len * num_kv_heads) * head_dim * 2
+                + q_len * num_qo_heads * 4
             )
+
+            causal_str = "causal" if causal else "nc"
+            backend_tag = f"_{backend}" if multi else ""
+            name = f"kv{kv_len}h{head_dim}_{causal_str}{backend_tag}"
+
+            if q_len == kv_len:
+                shape_label = f"seq={q_len:>5d}"
+            else:
+                shape_label = f"q={q_len} kv={kv_len:>5d}"
+            label = f"{shape_label} {'causal':6s} {backend}" if causal else f"{shape_label} {'nc':6s} {backend}"
+
+            configs.append(
+                KernelConfig(
+                    name=name,
+                    run_fn=torch.inference_mode()(
+                        lambda q=q, k=k, v=v, c=causal, b=backend: (
+                            flashinfer.single_prefill_with_kv_cache(
+                                q, k, v, causal=c, backend=b, return_lse=True
+                            )
+                        )
+                    ),
+                    theoretical_flops=flops,
+                    theoretical_bytes=theo_bytes,
+                    label=label,
+                )
+            )
+
+    if skipped:
+        print(
+            f"[bench] WARNING: skipping backends {skipped} — "
+            "not installed (install from https://github.com/ROCm/aiter).",
+            file=sys.stderr,
         )
     return configs
 
@@ -190,8 +294,13 @@ def _make_configs() -> list[KernelConfig]:
 if __name__ == "__main__":
     # Defer GPU tensor allocation: --replot and --list-presets don't need a CUDA device.
     _skip_gpu = "--replot" in sys.argv or "--list-presets" in sys.argv
+    shapes = _SHAPE_SETS[_shape_set]
+
+    # Counter collection via kernel_name_regex matches the FA2/FA3 kernel.
+    # AITER dispatches a different kernel; its dispatches won't appear in the
+    # counter CSV (timing is still accurate for all backends).
     profiler = RocmProfiler(
-        configs=[] if _skip_gpu else _make_configs(),
+        configs=[] if _skip_gpu else _make_configs(shapes, _backends),
         num_warmup=3,
         dry_run_ms=100,
         repeat_ms=1000,

--- a/rocm_profiler/rocm_profiler.py
+++ b/rocm_profiler/rocm_profiler.py
@@ -540,8 +540,7 @@ class RocmProfiler:
                 "tflops": f"{tflops:.3f}",
                 "ai_theory": f"{ai_theory:.2f}",
             }
-            if cfg.num_tokens > 0:
-                row["tput_tok_per_s"] = f"{tput_tok_per_s:.0f}"
+            row["tput_tok_per_s"] = f"{tput_tok_per_s:.0f}" if cfg.num_tokens > 0 else ""
             rows.append(row)
             tput_str = (
                 f"  {tput_tok_per_s / 1e3:7.1f} ktok/s" if cfg.num_tokens > 0 else ""
@@ -553,8 +552,13 @@ class RocmProfiler:
             )
             sys.stdout.flush()
 
+        _timing_fields = [
+            "name", "theoretical_flops", "theoretical_bytes",
+            "n_iters", "min_ms", "p5_ms", "median_ms", "p95_ms", "std_ms",
+            "tflops", "ai_theory", "tput_tok_per_s",
+        ]
         with open(out_path, "w", newline="") as f:
-            writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+            writer = csv.DictWriter(f, fieldnames=_timing_fields)
             writer.writeheader()
             writer.writerows(rows)
 
@@ -1232,7 +1236,15 @@ def _warn_if_regex_unmatched(
     Scan rocprofv3 CSV rows for any Kernel_Name matching `regex`.
     If none match, print a warning so the user knows their regex is stale.
     """
-    pattern = re.compile(regex)
+    try:
+        pattern = re.compile(regex)
+    except re.error as exc:
+        print(
+            f"[rocm_profiler] WARNING: kernel_name_regex '{regex}' is invalid: {exc} "
+            "— skipping regex check.",
+            file=sys.stderr,
+        )
+        return
     kernel_name_candidates = [
         "Kernel_Name",
         "kernel_name",

--- a/rocm_profiler/rocm_profiler.py
+++ b/rocm_profiler/rocm_profiler.py
@@ -15,85 +15,35 @@ limitations under the License.
 
 rocm_profiler.py — Generic ROCm kernel profiler with automated rocprofv3 subprocess.
 
-Provides a library (`RocmProfiler`, `KernelConfig`, `TensorSpec`, `HardwareCeilings`) that
-users import in a thin driver script. Calling `profiler.run()` executes the full pipeline:
-
-  1. Timing mode   — repeated GPU launches → median kernel time
-  2. Profile mode  — rocprofv3 spawned as a subprocess; the script auto-detects when it is
-                     running inside rocprofv3 via the _ROCM_PROFILER_INTERNAL env sentinel
-                     and executes only the warmup + profiled-launch protocol.
-  3. Roofline plot — two-panel log-log plot from timing + hardware counter data.
-
-Usage (driver script):
+Pipeline: timing (repeated GPU launches → median) → rocprofv3 counter collection →
+roofline PNG.  Import in a driver script:
 
     from rocm_profiler import RocmProfiler, KernelConfig
-    import torch, flashinfer
-
-    configs = [
-        KernelConfig(
-            name="s1024_causal",
-            run_fn=lambda: flashinfer.single_prefill_with_kv_cache_return_lse(
-                q, k, v, causal=True
-            ),
-            theoretical_flops=1024 * 1024 * 32 * 128 * 2,
-            theoretical_bytes=8 * 1024 * 32 * 128 * 2,
-            label="seq=1024 causal",
-        ),
-    ]
 
     profiler = RocmProfiler(
-        configs=configs,
-        counters="roofline",            # built-in preset or path to YAML/txt file
+        configs=[KernelConfig(name="s1024", run_fn=lambda: kernel(...),
+                              theoretical_flops=..., theoretical_bytes=...)],
+        counters="roofline",          # preset name or path to rocprofv3 YAML
         kernel_name_regex="SinglePrefill",
         output_dir="benchmarks/rocm_benchmarks",
         label="fa2",
     )
-
     if __name__ == "__main__":
         profiler.run()
 
-CLI flags (passed to the driver script):
+CLI flags accepted by all driver scripts:
+    --timing-only    Skip rocprofv3 and roofline
+    --skip-roofline  Profile but skip plot
+    --replot         Regenerate plot from existing CSVs (no GPU)
+    --list-presets   Print counter preset names and exit
+    --num-warmup N   Warmup launches per config in profile mode
+    --dry-run-ms N   Timing dry-run window (ms)
+    --repeat-ms N    Timing measurement window (ms)
 
-    python my_bench.py                  # full pipeline: timing + profile + roofline
-    python my_bench.py --timing-only    # timing CSV only
-    python my_bench.py --skip-roofline  # timing + profile, no plot
-    python my_bench.py --replot         # regenerate plot from existing CSVs
-    python my_bench.py --list-presets   # show built-in counter presets
-    python my_bench.py --num-warmup N   # override warmup count
-    python my_bench.py --dry-run-ms N   # override timing dry-run window (ms)
-    python my_bench.py --repeat-ms N    # override timing measurement window (ms)
-
-Counter presets:
-
-    "roofline"  2 passes — Pass1: FetchSize+MFMA+TCC_RDREQ; Pass2: WriteSize+LDS+TCC_WRREQ+SQ_VALU_MFMA_BUSY_CYCLES
-    "compute"   1 pass  — MFMA ops and cycle counters
-    "memory"    2 passes — Pass1: FetchSize+VALU+TCC_RD; Pass2: WriteSize+LDS+TCC_WR
-    "basic"     2 passes — FetchSize / WriteSize (separate passes, gfx942 hw limit)
-    "occupancy" 2 passes — SQ_WAVES+SQ_BUSY_CYCLES+SQ_VALU_MFMA_BUSY_CYCLES / SQ_WAIT_INST_ANY+SQ_INSTS_LDS
-    "stall"     2 passes — SQ_INSTS_MFMA+SQ_WAIT_INST_VMEM+SQ_VALU_MFMA_BUSY_CYCLES / SQ_WAIT_INST_LDS+SQ_BUSY_CYCLES
-
-    Note: You can also bypass presets entirely and point to a YAML file on disk:
-    `counters="/path/to/my_counters.yml"`.  The file must use rocprofv3's native
-    job format — one `pmc:` list per hardware pass.  Counters that share the same
-    internal resource on gfx942 (e.g. FetchSize + WriteSize) must be split across
-    separate passes or rocprofv3 will abort with error code 38.  Example:
-
-        # my_counters.yml
-        jobs:
-          - pmc: [SQ_WAVES, SQ_INSTS_MFMA, FetchSize]   # Pass 1
-          - pmc: [SQ_WAIT_INST_ANY, WriteSize]            # Pass 2
-
-    Run `rocprofv3 --list-counters` to enumerate all counters available on your GPU.
-
-rocprofv3 notes:
-
-  - rocprofv3 replays the driver script once per PMC pass. Each replay sees
-    _ROCM_PROFILER_INTERNAL=1 and runs only the profile protocol (JIT warmup +
-    measured launches); timing and subprocess spawning are skipped.
-  - The rocprofv3 CSV is long-form (one row per dispatch × counter). The profiler
-    pivots it to wide-form before writing {label}_counter_collection.csv.
-  - Output discovery: rocprofv3 writes to {tmpdir}/{hostname}/pid_{label}*.csv;
-    the profiler globs for the largest CSV in tmpdir after the subprocess exits.
+rocprofv3 behaviour: replays the driver script once per PMC pass with
+_ROCM_PROFILER_INTERNAL=1; each replay runs only the profile protocol and skips
+timing and subprocess spawning.  rocprofv3 is invoked once per config (not once
+for the whole sweep) to avoid ring-buffer overflow (~8 dispatches retained).
 """
 
 from __future__ import annotations

--- a/rocm_profiler/rocm_profiler.py
+++ b/rocm_profiler/rocm_profiler.py
@@ -267,6 +267,7 @@ class KernelConfig:
     theoretical_bytes: int
     run_fn: Callable[[], Any] | None = None
     label: str = ""
+    num_tokens: int = 0  # when > 0, profiler also reports tokens/sec
     # Called once before each profiling phase to (re-)allocate tensors.
     # run_fn should close over a mutable container that setup_fn refreshes.
     setup_fn: Callable[[], None] | None = None
@@ -523,25 +524,32 @@ class RocmProfiler:
             n_iters = int(len(arr))
             tflops = cfg.theoretical_flops / median_ms / 1e9
             ai_theory = cfg.theoretical_flops / cfg.theoretical_bytes
-            rows.append(
-                {
-                    "name": cfg.name,
-                    "theoretical_flops": cfg.theoretical_flops,
-                    "theoretical_bytes": cfg.theoretical_bytes,
-                    "n_iters": n_iters,
-                    "min_ms": f"{min_ms:.4f}",
-                    "p5_ms": f"{p5_ms:.4f}",
-                    "median_ms": f"{median_ms:.4f}",
-                    "p95_ms": f"{p95_ms:.4f}",
-                    "std_ms": f"{std_ms:.4f}",
-                    "tflops": f"{tflops:.3f}",
-                    "ai_theory": f"{ai_theory:.2f}",
-                }
+            tput_tok_per_s = (
+                cfg.num_tokens / (median_ms * 1e-3) if cfg.num_tokens > 0 else 0
+            )
+            row: dict[str, Any] = {
+                "name": cfg.name,
+                "theoretical_flops": cfg.theoretical_flops,
+                "theoretical_bytes": cfg.theoretical_bytes,
+                "n_iters": n_iters,
+                "min_ms": f"{min_ms:.4f}",
+                "p5_ms": f"{p5_ms:.4f}",
+                "median_ms": f"{median_ms:.4f}",
+                "p95_ms": f"{p95_ms:.4f}",
+                "std_ms": f"{std_ms:.4f}",
+                "tflops": f"{tflops:.3f}",
+                "ai_theory": f"{ai_theory:.2f}",
+            }
+            if cfg.num_tokens > 0:
+                row["tput_tok_per_s"] = f"{tput_tok_per_s:.0f}"
+            rows.append(row)
+            tput_str = (
+                f"  {tput_tok_per_s / 1e3:7.1f} ktok/s" if cfg.num_tokens > 0 else ""
             )
             print(
                 f"  {cfg.label:40s}  {median_ms:8.3f} ms  "
                 f"[p5={p5_ms:.3f} p95={p95_ms:.3f} std={std_ms:.3f}]  "
-                f"{tflops:7.2f} TFLOPS  AI={ai_theory:.1f}"
+                f"{tflops:7.2f} TFLOPS  AI={ai_theory:.1f}{tput_str}"
             )
             sys.stdout.flush()
 

--- a/rocm_profiler/rocm_profiler.py
+++ b/rocm_profiler/rocm_profiler.py
@@ -65,7 +65,7 @@ CLI flags (passed to the driver script):
 
 Counter presets:
 
-    "roofline"  2 passes — Pass1: FetchSize+MFMA+TCC_RDREQ; Pass2: WriteSize+LDS+TCC_WRREQ
+    "roofline"  2 passes — Pass1: FetchSize+MFMA+TCC_RDREQ; Pass2: WriteSize+LDS+TCC_WRREQ+SQ_VALU_MFMA_BUSY_CYCLES
     "compute"   1 pass  — MFMA ops and cycle counters
     "memory"    2 passes — Pass1: FetchSize+VALU+TCC_RD; Pass2: WriteSize+LDS+TCC_WR
     "basic"     2 passes — FetchSize / WriteSize (separate passes, gfx942 hw limit)
@@ -100,6 +100,8 @@ from __future__ import annotations
 
 import argparse
 import csv
+import datetime
+import json
 import os
 import re
 import subprocess
@@ -127,8 +129,8 @@ _COUNTER_PRESETS: dict[str, str] = {
 jobs:
   # Pass 1: L2 read traffic + MFMA throughput + HBM reads
   - pmc: [FetchSize, SQ_INSTS_VALU_MFMA_MOPS_F16, SQ_INSTS_MFMA, TCC_EA0_RDREQ_DRAM_sum]
-  # Pass 2: L2 write traffic + LDS conflicts + HBM writes
-  - pmc: [WriteSize, SQ_LDS_BANK_CONFLICT, TCC_EA0_WRREQ_DRAM_sum]
+  # Pass 2: L2 write traffic + LDS conflicts + HBM writes + MFMA duty-cycle cycles
+  - pmc: [WriteSize, SQ_LDS_BANK_CONFLICT, TCC_EA0_WRREQ_DRAM_sum, SQ_VALU_MFMA_BUSY_CYCLES]
 """,
     # Single-pass MFMA compute counters only
     "compute": """\
@@ -484,8 +486,8 @@ class RocmProfiler:
 
     def _timing_mode(self) -> Path:
         """
-        Repeated GPU launches for each config → median kernel time.
-        Writes {label}_timing.csv and returns its path.
+        Repeated GPU launches for each config → timing statistics.
+        Writes {label}_timing.csv and {label}_meta.json; returns the CSV path.
         """
         from flashinfer.testing.utils import bench_gpu_time
 
@@ -500,12 +502,25 @@ class RocmProfiler:
         for cfg in self.configs:
             if cfg.setup_fn:
                 cfg.setup_fn()
+
+            # One pre-check launch: verify the kernel produces finite output
+            # before entering the measurement loop.
+            result = cfg.run_fn()
+            torch.cuda.synchronize()
+            _check_finite(result, cfg.name)
+
             times_ms = bench_gpu_time(
                 cfg.run_fn,
                 dry_run_time_ms=int(self.dry_run_ms),
                 repeat_time_ms=int(self.repeat_ms),
             )
-            median_ms = float(np.median(times_ms))
+            arr = np.asarray(times_ms, dtype=np.float64)
+            median_ms = float(np.median(arr))
+            min_ms = float(np.min(arr))
+            p5_ms = float(np.percentile(arr, 5))
+            p95_ms = float(np.percentile(arr, 95))
+            std_ms = float(np.std(arr))
+            n_iters = int(len(arr))
             tflops = cfg.theoretical_flops / median_ms / 1e9
             ai_theory = cfg.theoretical_flops / cfg.theoretical_bytes
             rows.append(
@@ -513,13 +528,19 @@ class RocmProfiler:
                     "name": cfg.name,
                     "theoretical_flops": cfg.theoretical_flops,
                     "theoretical_bytes": cfg.theoretical_bytes,
+                    "n_iters": n_iters,
+                    "min_ms": f"{min_ms:.4f}",
+                    "p5_ms": f"{p5_ms:.4f}",
                     "median_ms": f"{median_ms:.4f}",
+                    "p95_ms": f"{p95_ms:.4f}",
+                    "std_ms": f"{std_ms:.4f}",
                     "tflops": f"{tflops:.3f}",
                     "ai_theory": f"{ai_theory:.2f}",
                 }
             )
             print(
-                f"  {cfg.label:36s}  {median_ms:8.3f} ms  "
+                f"  {cfg.label:40s}  {median_ms:8.3f} ms  "
+                f"[p5={p5_ms:.3f} p95={p95_ms:.3f} std={std_ms:.3f}]  "
                 f"{tflops:7.2f} TFLOPS  AI={ai_theory:.1f}"
             )
             sys.stdout.flush()
@@ -530,7 +551,81 @@ class RocmProfiler:
             writer.writerows(rows)
 
         print(f"[rocm_profiler] Timing done → {out_path}\n")
+
+        self._write_meta(out_path)
         return out_path
+
+    def _write_meta(self, timing_csv: Path) -> None:
+        """Write a sidecar JSON with provenance metadata for this bench run."""
+        import platform
+
+        meta: dict[str, Any] = {
+            "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "label": self.label,
+            "timing_csv": str(timing_csv),
+            "num_configs": len(self.configs),
+        }
+
+        # Git provenance
+        try:
+            meta["git_commit"] = subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], text=True, timeout=5
+            ).strip()
+        except Exception:
+            meta["git_commit"] = None
+        try:
+            dirty = subprocess.check_output(
+                ["git", "status", "--porcelain"], text=True, timeout=5
+            ).strip()
+            meta["git_dirty"] = bool(dirty)
+        except Exception:
+            meta["git_dirty"] = None
+
+        # Python / Torch / FlashInfer versions
+        meta["python_version"] = platform.python_version()
+        try:
+            meta["torch_version"] = torch.__version__
+        except Exception:
+            meta["torch_version"] = None
+        try:
+            import flashinfer
+
+            meta["flashinfer_version"] = getattr(flashinfer, "__version__", None)
+        except Exception:
+            meta["flashinfer_version"] = None
+
+        # ROCm version
+        for vpath in ["/opt/rocm/VERSION", "/opt/rocm/.info/version"]:
+            try:
+                meta["rocm_version"] = Path(vpath).read_text().strip()
+                break
+            except Exception:
+                pass
+        else:
+            meta["rocm_version"] = None
+
+        # GPU info
+        if self.hw_ceilings:
+            meta["gpu_name"] = self.hw_ceilings.gpu_name
+            meta["peak_tflops_fp16"] = self.hw_ceilings.peak_tflops_fp16
+            meta["peak_bw_tbs"] = self.hw_ceilings.peak_bw_tbs
+
+        # Relevant env vars
+        meta["env"] = {
+            k: os.environ.get(k)
+            for k in [
+                "FLASHINFER_ROCM_ARCH_LIST",
+                "FLASHINFER_JIT_DEBUG",
+                "FLASHINFER_JIT_VERBOSE",
+                "MAX_JOBS",
+                "ROCR_VISIBLE_DEVICES",
+                "HIP_VISIBLE_DEVICES",
+            ]
+        }
+
+        out = self.output_dir / f"{self.label}_meta.json"
+        out.write_text(json.dumps(meta, indent=2))
+        print(f"[rocm_profiler] Metadata → {out}")
 
     # ── Profile mode (executes inside rocprofv3 subprocess) ───────────────────
 
@@ -761,6 +856,10 @@ class RocmProfiler:
                     )
                     continue
 
+                # Warn if rocprofv3 produced rows but none matched the kernel regex.
+                if self.kernel_name_regex:
+                    _warn_if_regex_unmatched(csv_files, self.kernel_name_regex, cfg.name)
+
                 row = _merge_pass_csvs(csv_files)
                 if row is None:
                     print(
@@ -858,6 +957,7 @@ class RocmProfiler:
 
             mfma_mops = _float(c.get("SQ_INSTS_VALU_MFMA_MOPS_F16", 0))
             actual_flops_mfma = mfma_mops * 512
+            mfma_busy_cycles = _float(c.get("SQ_VALU_MFMA_BUSY_CYCLES", 0))
 
             results.append(
                 dict(
@@ -876,6 +976,7 @@ class RocmProfiler:
                     actual_flops_mfma=actual_flops_mfma,
                     flops_theory=flops,
                     lds_conflict=_float(c.get("SQ_LDS_BANK_CONFLICT", 0)),
+                    mfma_busy_cycles=mfma_busy_cycles,
                     mfma_util_pct=(
                         actual_flops_mfma
                         / (self.hw_ceilings.peak_tflops_fp16 * 1e12 * duration_s)
@@ -1101,6 +1202,64 @@ def _float(v: Any, default: float = 0.0) -> float:
         return default
 
 
+def _check_finite(result: Any, name: str) -> None:
+    """Warn if the kernel returned NaN or Inf in any output tensor."""
+    tensors = result if isinstance(result, (list, tuple)) else (result,)
+    for t in tensors:
+        if not isinstance(t, torch.Tensor) or not t.is_floating_point():
+            continue
+        if not torch.isfinite(t).all():
+            print(
+                f"[rocm_profiler] WARNING: '{name}' produced NaN/Inf output — "
+                "kernel may be incorrectly compiled or have numerical issues.",
+                file=sys.stderr,
+            )
+            return
+
+
+def _warn_if_regex_unmatched(
+    csv_files: list[Path], regex: str, config_name: str
+) -> None:
+    """
+    Scan rocprofv3 CSV rows for any Kernel_Name matching `regex`.
+    If none match, print a warning so the user knows their regex is stale.
+    """
+    pattern = re.compile(regex)
+    kernel_name_candidates = [
+        "Kernel_Name",
+        "kernel_name",
+        "KernelName",
+    ]
+    any_kernel_seen = False
+    any_match = False
+    for csv_file in csv_files:
+        try:
+            with open(csv_file, newline="", encoding="utf-8") as f:
+                reader = csv.DictReader(f)
+                name_col = _find_col(reader.fieldnames or [], kernel_name_candidates)
+                if name_col is None:
+                    continue
+                for row in reader:
+                    kname = row.get(name_col, "").strip()
+                    if kname:
+                        any_kernel_seen = True
+                    if kname and pattern.search(kname):
+                        any_match = True
+                        break
+        except Exception:
+            continue
+        if any_match:
+            break
+
+    if any_kernel_seen and not any_match:
+        print(
+            f"[rocm_profiler] WARNING: kernel_name_regex '{regex}' matched no "
+            f"kernels for config '{config_name}'. The kernel may have been "
+            "renamed. Check rocprofv3 CSV Kernel_Name column.",
+            file=sys.stderr,
+        )
+
+
 def _print_presets() -> None:
     print("Available counter presets:\n")
     for name, content in _COUNTER_PRESETS.items():
@@ -1123,17 +1282,19 @@ def _print_metrics_table(
     header = (
         f"{'Config':>30} | {'ms':>7} | {'TFLOPS':>7} | {'AI_th':>7} | "
         f"{'AI_meas':>8} | {'BW_TB/s':>8} | {'BW_HBM':>8} | "
-        f"{'MFMA_util%':>10} | {'LDS_bank_cf':>11}"
+        f"{'MFMA_util%':>10} | {'MFMA_busy_cy':>12} | {'LDS_bank_cf':>11}"
     )
     print(header)
     print("-" * len(header))
 
     for r in results:
+        mfma_busy = r.get("mfma_busy_cycles", 0)
         print(
             f"{r['label']:>30} | {r['median_ms']:>7.3f} | {r['tflops']:>7.2f} | "
             f"{r['ai_theory']:>7.0f} | {r['ai_measured']:>8.1f} | "
             f"{r['bw_tbs']:>8.3f} | {r['bw_hbm_tbs']:>8.3f} | "
-            f"{r['mfma_util_pct']:>10.1f} | {r['lds_conflict']:>11.0f}"
+            f"{r['mfma_util_pct']:>10.1f} | {mfma_busy:>12.0f} | "
+            f"{r['lds_conflict']:>11.0f}"
         )
 
     print()


### PR DESCRIPTION
## Summary

Improves measurement accuracy and coverage across the ROCm benchmark scripts: fixes an asymmetric-causal FLOPs bug affecting all production shapes, switches batch/paged configs to realistic asymmetric shapes, and extends the profiler with richer statistics, a provenance sidecar, and throughput reporting.

### What changed

#### rocm_profiler.py

- **Richer timing output** — CSV now records `n_iters`, `min_ms`, `p5_ms`, `median_ms`, `p95_ms`, `std_ms` alongside `tflops` and `ai_theory`; variance is visible without re-running.
- **Throughput metric** — `KernelConfig` gains a `num_tokens: int` field; when set, the profiler computes `tput_tok_per_s` (ktok/s) in the console table and CSV.
- **Provenance sidecar** — `{label}_meta.json` written after every timing run, capturing git commit, dirty flag, Python/Torch/FlashInfer/ROCm versions, GPU specs, and key env vars so historical CSVs are unambiguously traceable.
- **NaN/Inf pre-check** — one kernel launch before the measurement loop warns to stderr on bad output, catching silently broken builds before the full timing window.
- **Stale regex warning** — after rocprofv3 counter collection, warns if `kernel_name_regex` matched zero kernels (catches kernel renames); a malformed regex now emits a warning instead of crashing.
- **Fixed CSV fieldnames** — `DictWriter` fieldnames are now an explicit list rather than `rows[0].keys()`, so mixed sweeps (with and without `num_tokens`) produce a consistent header without raising.
- **MFMA duty-cycle counter** — `SQ_VALU_MFMA_BUSY_CYCLES` added to the roofline preset (pass 2) and surfaced in the metrics table as `MFMA_busy_cy`.

#### bench_fa2_prefill.py

- **FLOPs fix** — asymmetric causal attended pairs = `q_len*kv_len - q_len*(q_len-1)//2`; the factor-2 shortcut was wrong for `q_len < kv_len`, underestimating by 33–97% on production shapes.
- **Asymmetric batch/paged configs** — batch-ragged and batch-paged configs now use a fixed `q_len` (default 256) attending to swept `kv_len`, matching real chunked-prefill bursts. The previous symmetric `q=kv=seq_len` shapes caused each batch element to saturate the GPU independently, showing no batching benefit.
- **GQA model presets** (`--model`) — `intensity` (default MHA 32/32 hd=128), `llama3-8b` (GQA 32/8), `llama3-70b` (GQA 64/8), `mistral-7b` (GQA 32/8).
- **New CLI flags** — `--q-len`, `--batch`, `--paged`, `--batch-q-len`, `--page-size` for fine-grained control without editing the script.
- **Scattered page indices** — `torch.randperm(seed=42)` replaces `torch.arange` for paged KV indices to simulate real memory-pool fragmentation.
- **`sys.argv` stripping removed** — `RocmProfiler._parse_args` already uses `parse_known_args`; stripping bench flags from `sys.argv` was breaking the rocprofv3 subprocess (which re-runs with the original argv), causing it to silently fall back to defaults.

#### bench_aiter_prefill.py

- Same FLOPs fix, `num_tokens` wiring, page index scatter, `--batch N` flag (0 disables paged sections), and `sys.argv` fix as above.


🤖 Generated with [Claude Code](https://claude.com/claude-code)