### PR TITLE
fix(hip): address Copilot review comments on PR #210 torch.compile flag

### DIFF
--- a/flashinfer/decode_rocm.py
+++ b/flashinfer/decode_rocm.py
@@ -1199,6 +1199,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
             check_shape_dtype_device(out, q.shape, q.dtype, q.device, "out")
 
         if self.use_tensor_cores:
+            assert self._plan_info is not None, "plan info is not initialized; call plan() first"
             run_args = [
                 self._float_workspace_buffer,
                 self._int_workspace_buffer,

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import contextlib
 import functools
+import warnings
 import math
 import os
 from enum import Enum
@@ -33,18 +34,19 @@ from .jit.spdlog import gen_spdlog_module
 def plan_info_vec_as_tensor(
     plan_info: Union[torch.Tensor, Sequence[int]],
     *,
-    device: torch.device,
+    device: Optional[torch.device] = None,
 ) -> torch.Tensor:
-    """Normalize JIT ``plan`` output to int64 on ``device`` for custom-op boundaries.
+    """Normalize JIT ``plan`` output to a CPU int64 tensor for custom-op boundaries.
 
-    ``plan()`` returns a tensor on HIP/CUDA; some call sites may still use a Python
-    sequence — accept both.
+    The ROCm C++ ops read ``plan_info_vec.data_ptr<int64_t>()`` on the host, so the
+    tensor must stay on CPU regardless of where the workspace lives.  ``device`` is
+    accepted for API compatibility but is intentionally ignored.
     """
     if isinstance(plan_info, torch.Tensor):
-        if plan_info.dtype == torch.int64 and plan_info.device == device:
+        if plan_info.dtype == torch.int64 and plan_info.device.type == "cpu":
             return plan_info
-        return plan_info.to(device=device, dtype=torch.int64)
-    return torch.tensor(list(plan_info), dtype=torch.int64, device=device)
+        return plan_info.to(device="cpu", dtype=torch.int64)
+    return torch.tensor(list(plan_info), dtype=torch.int64)
 
 
 class PosEncodingMode(Enum):
@@ -412,6 +414,13 @@ else:
                 # supported by torch.library.custom_op's schema inference.  Fall
                 # back to the compile guard so torch.compile still raises a
                 # clear error instead of tracing into the extension.
+                warnings.warn(
+                    f"Could not register '{name}' as a torch.library custom op "
+                    "(unsupported parameter type in schema inference); falling back "
+                    "to compile guard. torch.compile will raise a RuntimeError if it "
+                    "traces into this op.",
+                    stacklevel=2,
+                )
                 return _guard_compile(f, name)
 
         if fn is not None:

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -46,7 +46,7 @@ def plan_info_vec_as_tensor(
         if plan_info.dtype == torch.int64 and plan_info.device.type == "cpu":
             return plan_info
         return plan_info.to(device="cpu", dtype=torch.int64)
-    return torch.tensor(list(plan_info), dtype=torch.int64)
+    return torch.tensor(list(plan_info), dtype=torch.int64, device="cpu")
 
 
 class PosEncodingMode(Enum):

--- a/tests/rocm_tests/test_torch_compile_hip.py
+++ b/tests/rocm_tests/test_torch_compile_hip.py
@@ -87,6 +87,11 @@ def test_eager_without_custom_ops():
     assert result.returncode == 0, f"eager (custom ops off) failed:\n{result.stderr}"
 
 
+@pytest.mark.skipif(
+    torch.torch_version.TorchVersion(torch.__version__)
+    < torch.torch_version.TorchVersion("2.4"),
+    reason="torch.compile custom ops require torch >= 2.4",
+)
 def test_eager_with_custom_ops():
     """append_paged_kv_cache works in eager mode with custom ops enabled."""
     snippet = _PREAMBLE + textwrap.dedent(


### PR DESCRIPTION
## Summary

Follow-up to #210 ("Enable torch.compile under a flag"), addressing Copilot and reviewer comments.

- **`plan_info_vec_as_tensor` always returns CPU tensor**: The ROCm C++ ops read `plan_info_vec.data_ptr<int64_t>()` from the host side, so the tensor must stay on CPU regardless of where the workspace buffer lives. The old code moved it to the GPU device, which is semantically wrong even if it happened to work on MI300X's unified memory. The `device` parameter is kept for API compatibility but now ignored.
- **`register_custom_op` warns on schema fallback**: Added `warnings.warn` in the `ValueError`/`TypeError` catch so the fallback to `_guard_compile` is visible. The fallback behavior is kept — `torch.compile` still raises a clear `RuntimeError` if it traces into an op that couldn't be registered as a custom op.
- **`test_eager_with_custom_ops` gets `skipif(torch<2.4)`**: `_USE_TORCH_CUSTOM_OPS` is already gated on `torch >= 2.4`, so asserting it's `True` would fail on older torch. Adds the same skip condition the other compile tests use.
- **Tensor-core decode path gets a None guard**: Added `assert self._plan_info is not None` before building `run_args` in the tensor-core branch of `BatchDecodeWithPagedKVCacheWrapper.forward()`, matching the non-tensor-core branch.

## Test plan

- [x] `pytest tests/rocm_tests/test_torch_compile_hip.py -v` — 4 passed
- [x] `pytest tests/rocm_tests/ -m "not slow"` — full suite in progress