### PR TITLE
chore(test): align default pytest invocation and drop redundant testpath

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,8 @@
 | Task | Command |
 |------|---------|
 | Install for development | `python -m pip install --no-build-isolation -ve.` |
-| Run tests (fast) | `pytest tests/rocm_tests/ -m "not slow"` |
-| Run all tests | `pytest tests/rocm_tests/` |
-| Run tests in parallel | `pytest tests/rocm_tests/ -n auto` |
+| Run tests (fast) | `pytest -n auto --reruns 2 -m "not slow"` |
+| Run all tests | `pytest -n auto --reruns 2` |
 | Clear JIT cache | `rm -rf ~/.cache/flashinfer/` |
 | Set target arch | `export FLASHINFER_ROCM_ARCH_LIST="gfx942,gfx950"` |
 | Limit parallel build | `export MAX_JOBS=4` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,6 @@ pythonpath = ["tests", "tests/test_helpers"]
 testpaths = [
     "tests/rocm_tests",
     "tests/attention/test_decode_prefill_lse.py",
-    "tests/rocm_tests/test_logits_cap_hip.py",
     "tests/attention/test_non_contiguous_decode.py",
     "tests/attention/test_non_contiguous_prefill.py",
     "tests/attention/test_page.py",


### PR DESCRIPTION
## Summary
- Update `CLAUDE.md` test commands to `pytest -n auto --reruns 2` (with and without `-m "not slow"`), matching the invocation that's actually robust to HSA/HIPBLAS flakiness under parallel execution.
- Drop the duplicate `tests/rocm_tests/test_logits_cap_hip.py` entry from `pyproject.toml` testpaths — `tests/rocm_tests` already covers it.

## Test plan
- [x] `pytest -n auto --reruns 2 -m "not slow"` collects the same set as before (minus the dedup).
- [x] No other docs reference the old `pytest tests/rocm_tests/` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)