### PR TITLE
fix(test): restrict MLA AITER test to page_size=1 and bfloat16

### DIFF
--- a/tests/rocm_tests/test_mla_aiter_hip.py
+++ b/tests/rocm_tests/test_mla_aiter_hip.py
@@ -105,8 +105,8 @@ def _build_paged_kv(
     not is_aiter_supported(torch.device("cuda:0")),
     reason="AITER backend requires gfx942/gfx950",
 )
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("page_size", [16, 32])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("page_size", [1])
 @pytest.mark.parametrize("num_heads,head_dim_ckv,head_dim_kpe", [(16, 512, 64)])
 @pytest.mark.parametrize(
     "kv_lens",
@@ -195,8 +195,8 @@ def test_mla_decode_out_tensor():
     import math
 
     device = torch.device("cuda:0")
-    dtype = torch.float16
-    batch_size, num_heads, head_dim_ckv, head_dim_kpe, page_size = 2, 16, 512, 64, 16
+    dtype = torch.bfloat16
+    batch_size, num_heads, head_dim_ckv, head_dim_kpe, page_size = 2, 16, 512, 64, 1
     kv_lens = [32, 64]
     sm_scale = 1.0 / math.sqrt(head_dim_ckv + head_dim_kpe)
 


### PR DESCRIPTION
## Summary

Restrict `test_mla_aiter_hip.py` parametrize to `page_size=1` and `dtype=bfloat16` — the only combination that produces correct output through the AITER MLA decode entrypoint (`aiter.mla.mla_decode_fwd`) for the FlashInfer-style call pattern used by `flashinfer.mla_rocm.BatchMLAPagedAttentionWrapper`.

The other failures listed in trunk (sliding-window decode, CUDA-graph batch decode, shared-prefix decode) were already fixed by PR #234; rebasing onto the current `amd-integration` resolves them, so this PR only carries the MLA test fix.

## Why this restriction is correct (not over-restrictive)

### fp16 unsupported — verified at three independent levels

1. `aiter_meta/csrc/py_itfs_cu/asm_mla.cu` (the dispatch the wrapper routes through) only branches on `Q.dtype == BFloat16` and `Q.dtype == Float8_e4m3fnuz/fn`. There is no `Half` branch — fp16 falls through to `TORCH_CHECK(impl_ptr != nullptr, ": unsupport current data type or shape")`, which is exactly the runtime error trunk produces.
2. The alternative dispatch path `aiter_meta/csrc/cpp_itfs/mla/asm_mla_decode_fwd.py:115` has an explicit `raise ValueError("only support dtype == torch.bfloat16 for now")`.
3. The pre-compiled `.co` kernel files in `aiter_meta/hsa/gfx942/mla/` exist only as `bf16` (`a16w16`), `fp8` (`a8w8`), and mixed `a16w8` variants. No fp16 kernels are shipped.

### page_size=1 only — verified empirically and by canonical AITER usage

`page_size` is templated into the kernel as a runtime parameter (`s_log2_plen`), so it is not statically rejected — but in practice the kernel produces silently-wrong output for page_size > 1 through this code path. Evidence:

- AITER's own canonical test `asm_mla_decode_fwd_test.py` hardcodes `block_size = 1` and `kv_last_page_lens = torch.ones(batch_size)`.
- AITER's AOT compilation `aiter/aot/asm_mla_decode_fwd.py` only targets `page_size=1`.
- Empirical sweep through the wrapper (max abs diff vs pure-PyTorch reference):

  | page_size | kv_len=1 | kv_len=5 | kv_len=16 | kv_len=64 |
  |-----------|----------|----------|-----------|-----------|
  | 1         | 0.0000   | 0.0010   | 0.0005    | 0.0002    |
  | 16        | 0.0000   | 0.3182   | 0.3513    | 0.1787    |
  | 32        | 0.0000   | 0.3182   | 0.3513    | 0.2473    |

  (kv_len=1 is a trivial pass: softmax over 1 element is `[1.0]` regardless of the score, so it does not exercise the kernel's per-page masking/indexing.)

This matches the existing project note from PR #232 wiring up `mla_rocm.py` ("page_size=1 only — AITER ASM limitation"). Production frameworks (vLLM, SGLang) use AITER MLA with `page_size > 1` only through different entrypoints (NSA decode path, custom KV-cache repacking) that don't match the FlashInfer `BatchMLAPagedAttentionWrapper` contract.

A future improvement would be to wire up an alternate AITER path that supports larger page sizes, but that is a new wrapper, not a test fix.

## Test plan

- [x] `pytest tests/rocm_tests/test_mla_aiter_hip.py` — 8 passed
- [x] `pytest -n auto --reruns 2 -m "not slow"` — exit 0 (full fast suite)