### PR TITLE
feat(hip): port POD attention to ROCm

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ kernel for non-attention ops). **AITER** = ROCm AITER backend.
 | **Batch prefill attention (paged + ragged)** | ✅ `fa2` | ✅ | Same auto criteria as single prefill | MHA / GQA / MQA; fp8 WIP. AITER native page sizes: `{16, 1024}` (`{128, 256, 1024}` on `amd-aiter==0.1.10`); other sizes go through a gather on the AITER path |
 | **Cascade attention** | ✅ | — | HIP | Two-level shared-prefix attention; a fused single-kernel HIP variant is gated behind `FLASHINFER_HIP_FUSED_CASCADE=1` |
 | **MLA (Multi-Latent Attention)** | — | ✅ | **AITER** (no HIP fallback) | DeepSeek-style 192/128 head-dim split; bf16 + `page_size=1`; `backend="auto"` (default) resolves to `"aiter"` |
-| **POD attention** | TBD | — | n/a | Code present; **not yet validated on ROCm** |
+| **POD attention** | ✅ `fa2` | — | HIP | MHA / GQA / MQA; single + batch variants (`PODWithPagedKVCacheWrapper`, `BatchPODWithPagedKVCacheWrapper`); JIT-only (excluded from AOT, same as upstream CUDA) |
 | **RoPE (positional encoding)** | ✅ | — | HIP | LLaMA-style + LLaMA 3.1 scaling; fused RoPE + fp8 quant + paged-KV append (E4M3FNUZ, E5M2FNUZ) |
 | **Paged KV-cache append** | ✅ `native` | ✅ | **AITER** when `fp16/bf16` + `NHD` + gfx942/gfx950 + AITER importable; else **HIP `native`** | `append_paged_kv_cache`; fp8 KV-cache supported on the HIP path |
 | **RMSNorm** | ✅ `native` | ✅ | **HIP `native`** (auto stays on HIP — AITER is opt-in via `backend="aiter"`) | AITER path is fp16/bf16, 2-D only; slightly lower precision at `hidden_size >= 1024` |

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -277,6 +277,8 @@ elif IS_HIP:
     from .cascade import merge_state as merge_state
     from .cascade import merge_state_in_place as merge_state_in_place
     from .cascade import merge_states as merge_states
+    from .pod import PODWithPagedKVCacheWrapper as PODWithPagedKVCacheWrapper
+    from .pod import BatchPODWithPagedKVCacheWrapper as BatchPODWithPagedKVCacheWrapper
 
     from .utils import next_positive_power_of_2 as next_positive_power_of_2
     from .utils import use_torch_custom_ops_enabled as use_torch_custom_ops_enabled

--- a/flashinfer/csrc_rocm/batch_pod.cu
+++ b/flashinfer/csrc_rocm/batch_pod.cu
@@ -1,0 +1,296 @@
+// SPDX-FileCopyrightText: 2025 FlashInfer team.
+// SPDX-FileCopyrightText: 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <flashinfer/attention/generic/allocator.h>
+
+#include <flashinfer/attention/generic/pos_enc.cuh>
+#include <flashinfer/attention/generic/scheduler.cuh>
+#include <gpu_iface/dispatch.cuh>
+#include <gpu_iface/enums.hpp>
+#include <gpu_iface/fastdiv.cuh>
+#include <optional>
+
+#include "batch_pod_config.inc"
+#include "pytorch_conversion_utils.h"
+#include "pytorch_extension_utils.h"
+
+namespace flashinfer {
+
+template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, PosEncodingMode POS_ENCODING_MODE,
+          bool USE_FP16_QK_REDUCTION, uint32_t CTA_TILE_Q_P, MaskMode MASK_MODE_P,
+          uint32_t CTA_TILE_Q_D, MaskMode MASK_MODE_D, typename PrefillAttentionVariant,
+          typename DecodeAttentionVariant, typename PrefillParams, typename DecodeParams>
+hipError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
+                                               typename PrefillParams::DTypeO* tmp_v_p,
+                                               float* tmp_s_p, DecodeParams decode_params,
+                                               typename DecodeParams::DTypeO* tmp_v_d,
+                                               float* tmp_s_d, bool enable_pdl, hipStream_t stream,
+                                               int* sm_aware_sched);
+
+}  // namespace flashinfer
+
+using namespace flashinfer;
+
+void batch_pod_with_kv_cache_tensor(
+    // Prefill params
+    at::Tensor float_workspace_buffer_p, at::Tensor int_workspace_buffer_p,
+    at::Tensor plan_info_vec_p, at::Tensor q_p, at::Tensor paged_k_cache_p,
+    at::Tensor paged_v_cache_p, at::Tensor qo_indptr_p, at::Tensor paged_kv_indptr_p,
+    at::Tensor paged_kv_indices_p, at::Tensor paged_kv_last_page_len_p, at::Tensor o_p,
+    std::optional<at::Tensor> maybe_lse_p, int64_t mask_mode_code_p, int64_t layout_p,
+    int64_t window_left_p, std::optional<at::Tensor> maybe_custom_mask_p,
+    std::optional<at::Tensor> maybe_mask_indptr_p, std::optional<at::Tensor> maybe_alibi_slopes_p,
+    double logits_soft_cap_p, double sm_scale_p, double rope_rcp_scale_p, double rope_rcp_theta_p,
+    // Decode params
+    at::Tensor float_workspace_buffer_d, at::Tensor int_workspace_buffer_d,
+    at::Tensor plan_info_vec_d, at::Tensor q_d, at::Tensor paged_k_cache_d,
+    at::Tensor paged_v_cache_d, at::Tensor qo_indptr_d, at::Tensor paged_kv_indptr_d,
+    at::Tensor paged_kv_indices_d, at::Tensor paged_kv_last_page_len_d, at::Tensor o_d,
+    std::optional<at::Tensor> maybe_lse_d, int64_t mask_mode_code_d, int64_t layout_d,
+    int64_t window_left_d, std::optional<at::Tensor> maybe_custom_mask_d,
+    std::optional<at::Tensor> maybe_mask_indptr_d, std::optional<at::Tensor> maybe_alibi_slopes_d,
+    double logits_soft_cap_d, double sm_scale_d, double rope_rcp_scale_d, double rope_rcp_theta_d,
+    bool enable_pdl, at::Tensor sm_aware_sched) {
+  // Prefill setup
+  PrefillPlanInfo plan_info_p;
+  plan_info_p.FromVector(tensor_to_vec(plan_info_vec_p));
+  TORCH_CHECK(!plan_info_p.enable_cuda_graph,
+              "CUDA graph mode is not supported with BatchPOD on ROCm");
+  QKVLayout kv_layout_p = static_cast<QKVLayout>(layout_p);
+  int64_t batch_size_p = paged_kv_indptr_p.size(0) - 1;
+  int64_t num_qo_heads = q_p.size(1);
+
+  int64_t num_kv_heads_p, page_size_p;
+  if (kv_layout_p == QKVLayout::kHND) {
+    num_kv_heads_p = paged_k_cache_p.size(1);
+    page_size_p = paged_k_cache_p.size(2);
+  } else {
+    page_size_p = paged_k_cache_p.size(1);
+    num_kv_heads_p = paged_k_cache_p.size(2);
+  }
+
+  void* float_buffer_ptr_p = float_workspace_buffer_p.data_ptr();
+  void* int_buffer_ptr_p = int_workspace_buffer_p.data_ptr();
+
+  const MaskMode mask_mode_p = static_cast<MaskMode>(mask_mode_code_p);
+  const auto q_stride_n_p = q_p.stride(0);
+  const auto q_stride_h_p = q_p.stride(1);
+
+  auto k_strides_p = paged_k_cache_p.strides();
+  auto v_strides_p = paged_v_cache_p.strides();
+  TORCH_CHECK(k_strides_p == v_strides_p, "prefill k/v strides must be identical");
+  const int64_t* kv_cache_strides_p = k_strides_p.data();
+
+  // Decode setup
+  PrefillPlanInfo plan_info_d;
+  plan_info_d.FromVector(tensor_to_vec(plan_info_vec_d));
+  TORCH_CHECK(!plan_info_d.enable_cuda_graph,
+              "CUDA graph mode is not supported with BatchPOD on ROCm");
+  QKVLayout kv_layout_d = static_cast<QKVLayout>(layout_d);
+  int64_t batch_size_d = paged_kv_indptr_d.size(0) - 1;
+  int64_t num_qo_heads_d = q_d.size(1);
+
+  TORCH_CHECK(num_qo_heads == num_qo_heads_d, "BatchPOD: prefill/decode QO heads must match");
+
+  int64_t num_kv_heads_d, page_size_d;
+  if (kv_layout_d == QKVLayout::kHND) {
+    num_kv_heads_d = paged_k_cache_d.size(1);
+    page_size_d = paged_k_cache_d.size(2);
+  } else {
+    page_size_d = paged_k_cache_d.size(1);
+    num_kv_heads_d = paged_k_cache_d.size(2);
+  }
+
+  TORCH_CHECK(num_kv_heads_p == num_kv_heads_d,
+              "BatchPOD: prefill/decode KV heads must match; prefill: ", num_kv_heads_p,
+              ", decode: ", num_kv_heads_d);
+
+  void* float_buffer_ptr_d = float_workspace_buffer_d.data_ptr();
+  void* int_buffer_ptr_d = int_workspace_buffer_d.data_ptr();
+
+  const MaskMode mask_mode_d = static_cast<MaskMode>(mask_mode_code_d);
+  const auto q_stride_n_d = q_d.stride(0);
+  const auto q_stride_h_d = q_d.stride(1);
+
+  auto k_strides_d = paged_k_cache_d.strides();
+  auto v_strides_d = paged_v_cache_d.strides();
+  TORCH_CHECK(k_strides_d == v_strides_d, "decode k/v strides must be identical");
+  const int64_t* kv_cache_strides_d = k_strides_d.data();
+
+  const c10::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(
+      float_workspace_buffer_p.device());
+  const hipStream_t stream = c10::hip::getCurrentHIPStream();
+
+  DISPATCH_context(
+      MASK_MODE_P, MASK_MODE_D, DTypeQ, DTypeKV, HEAD_DIM_QK, USE_SLIDING_WINDOW_P,
+      USE_SLIDING_WINDOW_D, USE_LOGITS_SOFT_CAP, [&] {
+        PrefillParams prefill_params;
+        DTypeO* tmp_v_p = nullptr;
+        float* tmp_s_p = nullptr;
+        {
+          PrefillParams& params = prefill_params;
+          params.q = static_cast<DTypeQ*>(q_p.data_ptr());
+          paged_kv_t<DTypeKV, IdType> paged_kv(
+              num_kv_heads_p, page_size_p, HEAD_DIM_VO, batch_size_p, kv_layout_p,
+              static_cast<DTypeKV*>(paged_k_cache_p.data_ptr()),
+              static_cast<DTypeKV*>(paged_v_cache_p.data_ptr()), kv_cache_strides_p,
+              static_cast<IdType*>(paged_kv_indices_p.data_ptr()),
+              static_cast<IdType*>(paged_kv_indptr_p.data_ptr()),
+              static_cast<IdType*>(paged_kv_last_page_len_p.data_ptr()));
+          params.paged_kv = paged_kv;
+          params.q_indptr = static_cast<IdType*>(qo_indptr_p.data_ptr());
+          params.o = static_cast<DTypeO*>(o_p.data_ptr());
+          params.lse = maybe_lse_p ? static_cast<float*>(maybe_lse_p->data_ptr()) : nullptr;
+          params.num_qo_heads = num_qo_heads;
+          params.group_size = uint_fastdiv(num_qo_heads / static_cast<uint32_t>(num_kv_heads_p));
+          params.q_stride_n = q_stride_n_p;
+          params.q_stride_h = q_stride_h_p;
+          params.window_left = window_left_p;
+
+          params.request_indices = nullptr;
+          params.qo_tile_indices = nullptr;
+          params.kv_tile_indices = nullptr;
+          params.merge_indptr = nullptr;
+          params.o_indptr = nullptr;
+          params.kv_chunk_size_ptr = nullptr;
+          params.block_valid_mask = nullptr;
+          params.total_num_rows = nullptr;
+          params.max_total_num_rows = 0;
+          params.padded_batch_size = 0;
+          params.partition_kv = false;
+
+          params.maybe_custom_mask = maybe_custom_mask_p
+                                         ? static_cast<uint8_t*>(maybe_custom_mask_p->data_ptr())
+                                         : nullptr;
+          params.maybe_mask_indptr =
+              maybe_mask_indptr_p ? static_cast<IdType*>(maybe_mask_indptr_p->data_ptr()) : nullptr;
+          params.maybe_alibi_slopes = maybe_alibi_slopes_p
+                                          ? static_cast<float*>(maybe_alibi_slopes_p->data_ptr())
+                                          : nullptr;
+          params.logits_soft_cap = static_cast<float>(logits_soft_cap_p);
+          params.sm_scale = static_cast<float>(sm_scale_p);
+          params.rope_rcp_scale = static_cast<float>(rope_rcp_scale_p);
+          params.rope_rcp_theta = static_cast<float>(rope_rcp_theta_p);
+
+          params.request_indices =
+              GetPtrFromBaseOffset<IdType>(int_buffer_ptr_p, plan_info_p.request_indices_offset);
+          params.qo_tile_indices =
+              GetPtrFromBaseOffset<IdType>(int_buffer_ptr_p, plan_info_p.qo_tile_indices_offset);
+          params.kv_tile_indices =
+              GetPtrFromBaseOffset<IdType>(int_buffer_ptr_p, plan_info_p.kv_tile_indices_offset);
+          params.o_indptr =
+              GetPtrFromBaseOffset<IdType>(int_buffer_ptr_p, plan_info_p.o_indptr_offset);
+          params.kv_chunk_size_ptr =
+              GetPtrFromBaseOffset<IdType>(int_buffer_ptr_p, plan_info_p.kv_chunk_size_ptr_offset);
+          if (plan_info_p.split_kv) {
+            params.merge_indptr =
+                GetPtrFromBaseOffset<IdType>(int_buffer_ptr_p, plan_info_p.merge_indptr_offset);
+            tmp_v_p = GetPtrFromBaseOffset<DTypeO>(float_buffer_ptr_p, plan_info_p.v_offset);
+            tmp_s_p = GetPtrFromBaseOffset<float>(float_buffer_ptr_p, plan_info_p.s_offset);
+            if (plan_info_p.enable_cuda_graph) {
+              params.block_valid_mask =
+                  GetPtrFromBaseOffset<bool>(int_buffer_ptr_p, plan_info_p.block_valid_mask_offset);
+            }
+          }
+          params.padded_batch_size = plan_info_p.padded_batch_size;
+          params.max_total_num_rows = plan_info_p.total_num_rows;
+          if (plan_info_p.enable_cuda_graph) {
+            params.total_num_rows =
+                GetPtrFromBaseOffset<uint32_t>(int_buffer_ptr_p, plan_info_p.total_num_rows_offset);
+          }
+        }
+
+        DecodeParams decode_params;
+        DTypeO* tmp_v_d = nullptr;
+        float* tmp_s_d = nullptr;
+        {
+          DecodeParams& params = decode_params;
+          params.q = static_cast<DTypeQ*>(q_d.data_ptr());
+          paged_kv_t<DTypeKV, IdType> paged_kv(
+              num_kv_heads_d, page_size_d, HEAD_DIM_VO, batch_size_d, kv_layout_d,
+              static_cast<DTypeKV*>(paged_k_cache_d.data_ptr()),
+              static_cast<DTypeKV*>(paged_v_cache_d.data_ptr()), kv_cache_strides_d,
+              static_cast<IdType*>(paged_kv_indices_d.data_ptr()),
+              static_cast<IdType*>(paged_kv_indptr_d.data_ptr()),
+              static_cast<IdType*>(paged_kv_last_page_len_d.data_ptr()));
+          params.paged_kv = paged_kv;
+          params.q_indptr = static_cast<IdType*>(qo_indptr_d.data_ptr());
+          params.o = static_cast<DTypeO*>(o_d.data_ptr());
+          params.lse = maybe_lse_d ? static_cast<float*>(maybe_lse_d->data_ptr()) : nullptr;
+          params.num_qo_heads = num_qo_heads;
+          params.group_size = uint_fastdiv(num_qo_heads / static_cast<uint32_t>(num_kv_heads_d));
+          params.q_stride_n = q_stride_n_d;
+          params.q_stride_h = q_stride_h_d;
+          params.window_left = window_left_d;
+
+          params.request_indices = nullptr;
+          params.qo_tile_indices = nullptr;
+          params.kv_tile_indices = nullptr;
+          params.merge_indptr = nullptr;
+          params.o_indptr = nullptr;
+          params.kv_chunk_size_ptr = nullptr;
+          params.block_valid_mask = nullptr;
+          params.total_num_rows = nullptr;
+          params.max_total_num_rows = 0;
+          params.padded_batch_size = 0;
+          params.partition_kv = false;
+
+          params.maybe_custom_mask = maybe_custom_mask_d
+                                         ? static_cast<uint8_t*>(maybe_custom_mask_d->data_ptr())
+                                         : nullptr;
+          params.maybe_mask_indptr =
+              maybe_mask_indptr_d ? static_cast<IdType*>(maybe_mask_indptr_d->data_ptr()) : nullptr;
+          params.maybe_alibi_slopes = maybe_alibi_slopes_d
+                                          ? static_cast<float*>(maybe_alibi_slopes_d->data_ptr())
+                                          : nullptr;
+          params.logits_soft_cap = static_cast<float>(logits_soft_cap_d);
+          params.sm_scale = static_cast<float>(sm_scale_d);
+          params.rope_rcp_scale = static_cast<float>(rope_rcp_scale_d);
+          params.rope_rcp_theta = static_cast<float>(rope_rcp_theta_d);
+
+          params.request_indices =
+              GetPtrFromBaseOffset<IdType>(int_buffer_ptr_d, plan_info_d.request_indices_offset);
+          params.qo_tile_indices =
+              GetPtrFromBaseOffset<IdType>(int_buffer_ptr_d, plan_info_d.qo_tile_indices_offset);
+          params.kv_tile_indices =
+              GetPtrFromBaseOffset<IdType>(int_buffer_ptr_d, plan_info_d.kv_tile_indices_offset);
+          params.o_indptr =
+              GetPtrFromBaseOffset<IdType>(int_buffer_ptr_d, plan_info_d.o_indptr_offset);
+          params.kv_chunk_size_ptr =
+              GetPtrFromBaseOffset<IdType>(int_buffer_ptr_d, plan_info_d.kv_chunk_size_ptr_offset);
+          if (plan_info_d.split_kv) {
+            params.merge_indptr =
+                GetPtrFromBaseOffset<IdType>(int_buffer_ptr_d, plan_info_d.merge_indptr_offset);
+            tmp_v_d = GetPtrFromBaseOffset<DTypeO>(float_buffer_ptr_d, plan_info_d.v_offset);
+            tmp_s_d = GetPtrFromBaseOffset<float>(float_buffer_ptr_d, plan_info_d.s_offset);
+            if (plan_info_d.enable_cuda_graph) {
+              params.block_valid_mask =
+                  GetPtrFromBaseOffset<bool>(int_buffer_ptr_d, plan_info_d.block_valid_mask_offset);
+            }
+          }
+          params.padded_batch_size = plan_info_d.padded_batch_size;
+          params.max_total_num_rows = plan_info_d.total_num_rows;
+          if (plan_info_d.enable_cuda_graph) {
+            params.total_num_rows =
+                GetPtrFromBaseOffset<uint32_t>(int_buffer_ptr_d, plan_info_d.total_num_rows_offset);
+          }
+        }
+
+        hipError_t status = hipSuccess;
+        DISPATCH_CTA_TILE_Q(plan_info_p.cta_tile_q, CTA_TILE_Q_P, {
+          constexpr size_t CTA_TILE_Q_D = 16;
+          status = flashinfer::BatchPODWithKVCacheTensorDispatched<
+              HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE, USE_FP16_QK_REDUCTION, CTA_TILE_Q_P,
+              MASK_MODE_P, CTA_TILE_Q_D, MASK_MODE_D, PrefillAttentionVariant,
+              DecodeAttentionVariant>(prefill_params, tmp_v_p, tmp_s_p, decode_params, tmp_v_d,
+                                      tmp_s_d, enable_pdl, stream,
+                                      static_cast<int*>(sm_aware_sched.data_ptr()));
+        });
+
+        TORCH_CHECK(status == hipSuccess,
+                    "BatchPODWithKVCache kernel launch failed, error: ", hipGetErrorString(status));
+        return true;
+      });
+}

--- a/flashinfer/csrc_rocm/batch_pod_customize_config.jinja
+++ b/flashinfer/csrc_rocm/batch_pod_customize_config.jinja
@@ -1,0 +1,44 @@
+#pragma once
+#include <gpu_iface/math_ops.hpp>
+#include <gpu_iface/layout.cuh>
+#include <gpu_iface/utils.cuh>
+#include <gpu_iface/fastdiv.cuh>
+
+#include <flashinfer/attention/generic/page.cuh>
+#include <flashinfer/attention/generic/pos_enc.cuh>
+#include <flashinfer/attention/generic/variant_helper.cuh>
+#include <flashinfer/attention/generic/variants.cuh>
+#include <flashinfer/attention/generic/default_prefill_params.cuh>
+
+using namespace flashinfer;
+
+using DTypeQ = {{ dtype_q }};
+using DTypeKV = {{ dtype_kv }};
+using DTypeO = {{ dtype_o }};
+using IdType = {{ idtype }};
+constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
+constexpr int HEAD_DIM_VO = {{ head_dim_vo }};
+constexpr bool USE_FP16_QK_REDUCTION = {{ use_fp16_qk_reduction }};
+constexpr auto USE_LOGITS_SOFT_CAP_P = {{ use_logits_soft_cap_p }};
+constexpr auto POS_ENCODING_MODE_P = {{ pos_encoding_mode_p }};
+constexpr auto USE_SLIDING_WINDOW_P = {{ use_sliding_window_p }};
+constexpr auto USE_LOGITS_SOFT_CAP_D = {{ use_logits_soft_cap_d }};
+constexpr auto POS_ENCODING_MODE_D = {{ pos_encoding_mode_d }};
+constexpr auto USE_SLIDING_WINDOW_D = {{ use_sliding_window_d }};
+constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;
+constexpr bool USE_LOGITS_SOFT_CAP = false;
+
+using PrefillParams = BatchPrefillPagedParams<DTypeQ, DTypeKV, DTypeO, IdType>;
+using DecodeParams = BatchPrefillPagedParams<DTypeQ, DTypeKV, DTypeO, IdType>;
+
+#define DISPATCH_context(MASK_MODE_P, MASK_MODE_D, DTypeQ, DTypeKV, HEAD_DIM_QK,     \
+                         USE_SLIDING_WINDOW_P, USE_SLIDING_WINDOW_D, USE_LOGITS_SOFT_CAP, ...) \
+  DISPATCH_MASK_MODE(mask_mode_p, MASK_MODE_P, {                                       \
+    DISPATCH_MASK_MODE(mask_mode_d, MASK_MODE_D, {                                     \
+      constexpr bool use_custom_mask_p = MASK_MODE_P == MaskMode::kCustom;             \
+      constexpr bool use_custom_mask_d = MASK_MODE_D == MaskMode::kCustom;             \
+      using PrefillAttentionVariant = {{ variant_name_p }};                            \
+      using DecodeAttentionVariant = {{ variant_name_d }};                             \
+      __VA_ARGS__();                                                                    \
+    });                                                                                \
+  })

--- a/flashinfer/csrc_rocm/batch_pod_jit_pybind.cu
+++ b/flashinfer/csrc_rocm/batch_pod_jit_pybind.cu
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "batch_pod_config.inc"
+#include "pytorch_extension_utils.h"
+
+void batch_pod_with_kv_cache_tensor(
+    at::Tensor float_workspace_buffer_p, at::Tensor int_workspace_buffer_p,
+    at::Tensor plan_info_vec_p, at::Tensor q_p, at::Tensor paged_k_cache_p,
+    at::Tensor paged_v_cache_p, at::Tensor qo_indptr_p, at::Tensor paged_kv_indptr_p,
+    at::Tensor paged_kv_indices_p, at::Tensor paged_kv_last_page_len_p, at::Tensor o_p,
+    std::optional<at::Tensor> maybe_lse_p, int64_t mask_mode_code_p, int64_t layout_p,
+    int64_t window_left_p, std::optional<at::Tensor> maybe_custom_mask_p,
+    std::optional<at::Tensor> maybe_mask_indptr_p, std::optional<at::Tensor> maybe_alibi_slopes_p,
+    double logits_soft_cap_p, double sm_scale_p, double rope_rcp_scale_p, double rope_rcp_theta_p,
+    at::Tensor float_workspace_buffer_d, at::Tensor int_workspace_buffer_d,
+    at::Tensor plan_info_vec_d, at::Tensor q_d, at::Tensor paged_k_cache_d,
+    at::Tensor paged_v_cache_d, at::Tensor qo_indptr_d, at::Tensor paged_kv_indptr_d,
+    at::Tensor paged_kv_indices_d, at::Tensor paged_kv_last_page_len_d, at::Tensor o_d,
+    std::optional<at::Tensor> maybe_lse_d, int64_t mask_mode_code_d, int64_t layout_d,
+    int64_t window_left_d, std::optional<at::Tensor> maybe_custom_mask_d,
+    std::optional<at::Tensor> maybe_mask_indptr_d, std::optional<at::Tensor> maybe_alibi_slopes_d,
+    double logits_soft_cap_d, double sm_scale_d, double rope_rcp_scale_d, double rope_rcp_theta_d,
+    bool enable_pdl, at::Tensor sm_aware_sched);
+
+TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
+  m.def("batch_pod_with_kv_cache_tensor", batch_pod_with_kv_cache_tensor);
+}

--- a/flashinfer/csrc_rocm/batch_pod_kernel_inst.jinja
+++ b/flashinfer/csrc_rocm/batch_pod_kernel_inst.jinja
@@ -1,0 +1,26 @@
+#include <flashinfer/attention/generic/batch_pod.cuh>
+#include <flashinfer/attention/generic/default_prefill_params.cuh>
+#include "batch_pod_config.inc"
+
+using namespace flashinfer;
+
+namespace flashinfer {
+
+constexpr auto use_custom_mask_p = {{ mask_mode_p }} == MaskMode::kCustom;
+constexpr auto use_custom_mask_d = {{ mask_mode_d }} == MaskMode::kCustom;
+
+using PrefillAttentionVariant = {{ variant_name_p }};
+using DecodeAttentionVariant = {{ variant_name_d }};
+
+{% for cta_tile_q in [16, 64, 128] %}
+template hipError_t BatchPODWithKVCacheTensorDispatched<
+    {{ head_dim_qk }}, {{ head_dim_vo }}, POS_ENCODING_MODE,
+    {{ use_fp16_qk_reduction }}, /*CTA_TILE_Q_P=*/{{ cta_tile_q }}, {{ mask_mode_p }},
+    /*CTA_TILE_Q_D=*/16, {{ mask_mode_d }}, PrefillAttentionVariant, DecodeAttentionVariant,
+    PrefillParams, DecodeParams>(
+        PrefillParams prefill_params, {{ dtype_o }}* tmp_v_p, float* tmp_s_p,
+        DecodeParams decode_params, {{ dtype_o }}* tmp_v_d, float* tmp_s_d,
+        bool enable_pdl, hipStream_t stream, int* sm_aware_sched);
+{% endfor %}
+
+}  // namespace flashinfer

--- a/flashinfer/csrc_rocm/pod.cu
+++ b/flashinfer/csrc_rocm/pod.cu
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: 2025 FlashInfer team.
+// SPDX-FileCopyrightText: 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <flashinfer/attention/generic/allocator.h>
+
+#include <flashinfer/attention/generic/pos_enc.cuh>
+#include <flashinfer/attention/generic/scheduler.cuh>
+#include <gpu_iface/enums.hpp>
+#include <gpu_iface/fastdiv.cuh>
+#include <optional>
+
+#include "pod_config.inc"
+#include "pytorch_conversion_utils.h"
+#include "pytorch_extension_utils.h"
+
+namespace flashinfer {
+
+template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, PosEncodingMode POS_ENCODING_MODE,
+          bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE_P, uint32_t CTA_TILE_Q_D,
+          MaskMode MASK_MODE_D, typename PrefillAttentionVariant, typename DecodeAttentionVariant,
+          typename PrefillParams, typename DecodeParams>
+hipError_t PODWithKVCacheTensorDispatched(PrefillParams prefill_params,
+                                          typename PrefillParams::DTypeO* tmp,
+                                          DecodeParams decode_params,
+                                          typename DecodeParams::DTypeO* tmp_v, float* tmp_s,
+                                          bool enable_pdl, hipStream_t stream);
+
+}  // namespace flashinfer
+
+using namespace flashinfer;
+
+void pod_with_kv_cache_tensor(
+    // Prefill params
+    at::Tensor q_p, at::Tensor k_p, at::Tensor v_p, at::Tensor tmp_p, at::Tensor o_p,
+    std::optional<at::Tensor> maybe_lse_p, int64_t mask_mode_code_p, int64_t layout_p,
+    int64_t window_left_p, std::optional<at::Tensor> maybe_custom_mask_p,
+    std::optional<at::Tensor> maybe_alibi_slopes_p, double logits_soft_cap_p, double sm_scale_p,
+    double rope_rcp_scale_p, double rope_rcp_theta_p,
+    // Decode params
+    at::Tensor float_workspace_buffer_d, at::Tensor int_workspace_buffer_d,
+    at::Tensor plan_info_vec, at::Tensor q_d, at::Tensor paged_k_cache_d,
+    at::Tensor paged_v_cache_d, at::Tensor qo_indptr_d, at::Tensor paged_kv_indptr_d,
+    at::Tensor paged_kv_indices_d, at::Tensor paged_kv_last_page_len_d, at::Tensor o_d,
+    std::optional<at::Tensor> maybe_lse_d, int64_t mask_mode_code_d, int64_t layout_d,
+    int64_t window_left_d, std::optional<at::Tensor> maybe_custom_mask_d,
+    std::optional<at::Tensor> maybe_mask_indptr_d, std::optional<at::Tensor> maybe_alibi_slopes_d,
+    double logits_soft_cap_d, double sm_scale_d, double rope_rcp_scale_d, double rope_rcp_theta_d,
+    bool enable_pdl) {
+  QKVLayout kv_layout_p = static_cast<QKVLayout>(layout_p);
+  uint32_t qo_len_p = q_p.size(0);
+  uint32_t num_qo_heads = q_p.size(1);
+  uint32_t kv_len_p, num_kv_heads;
+  uint32_t q_stride_n_p = q_p.stride(0), q_stride_h_p = q_p.stride(1);
+  uint32_t k_stride_n_p, k_stride_h_p, v_stride_n_p, v_stride_h_p;
+  if (kv_layout_p == QKVLayout::kNHD) {
+    kv_len_p = k_p.size(0);
+    num_kv_heads = k_p.size(1);
+    k_stride_n_p = k_p.stride(0);
+    k_stride_h_p = k_p.stride(1);
+    v_stride_n_p = v_p.stride(0);
+    v_stride_h_p = v_p.stride(1);
+  } else {
+    kv_len_p = k_p.size(1);
+    num_kv_heads = k_p.size(0);
+    k_stride_h_p = k_p.stride(0);
+    k_stride_n_p = k_p.stride(1);
+    v_stride_h_p = v_p.stride(0);
+    v_stride_n_p = v_p.stride(1);
+  }
+
+  const MaskMode mask_mode_p = static_cast<MaskMode>(mask_mode_code_p);
+
+  PrefillPlanInfo plan_info;
+  plan_info.FromVector(tensor_to_vec(plan_info_vec));
+  TORCH_CHECK(!plan_info.enable_cuda_graph, "CUDA graph mode is not supported with POD on ROCm");
+  QKVLayout kv_layout_d = static_cast<QKVLayout>(layout_d);
+  int64_t batch_size = paged_kv_indptr_d.size(0) - 1;
+  int64_t num_kv_heads_d, page_size_d;
+  if (kv_layout_d == QKVLayout::kHND) {
+    num_kv_heads_d = paged_k_cache_d.size(1);
+    page_size_d = paged_k_cache_d.size(2);
+  } else {
+    page_size_d = paged_k_cache_d.size(1);
+    num_kv_heads_d = paged_k_cache_d.size(2);
+  }
+  TORCH_CHECK(num_qo_heads == (uint32_t)q_d.size(1), "POD: prefill/decode QO heads must match");
+  TORCH_CHECK(num_kv_heads == (uint32_t)num_kv_heads_d, "POD: prefill/decode KV heads must match");
+
+  void* float_buffer_ptr = float_workspace_buffer_d.data_ptr();
+  void* int_buffer_ptr = int_workspace_buffer_d.data_ptr();
+
+  const MaskMode mask_mode_d = static_cast<MaskMode>(mask_mode_code_d);
+  const auto q_stride_n_d = q_d.stride(0);
+  const auto q_stride_h_d = q_d.stride(1);
+
+  auto k_strides_d = paged_k_cache_d.strides();
+  auto v_strides_d = paged_v_cache_d.strides();
+  TORCH_CHECK(k_strides_d == v_strides_d, "k/v strides must be identical");
+  const int64_t* kv_cache_strides_d = k_strides_d.data();
+
+  const c10::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(
+      float_workspace_buffer_d.device());
+  const hipStream_t stream = c10::hip::getCurrentHIPStream();
+
+  DISPATCH_context(
+      MASK_MODE_P, MASK_MODE_D, DTypeQ, DTypeKV, HEAD_DIM_QK, USE_SLIDING_WINDOW_P,
+      USE_SLIDING_WINDOW_D, USE_LOGITS_SOFT_CAP, [&] {
+        PrefillParams prefill_params;
+        {
+          PrefillParams& params = prefill_params;
+          params.q = static_cast<DTypeQ*>(q_p.data_ptr());
+          params.k = static_cast<DTypeKV*>(k_p.data_ptr());
+          params.v = static_cast<DTypeKV*>(v_p.data_ptr());
+          params.o = static_cast<DTypeO*>(o_p.data_ptr());
+          params.lse = maybe_lse_p ? static_cast<float*>(maybe_lse_p->data_ptr()) : nullptr;
+          params.num_qo_heads = num_qo_heads;
+          params.num_kv_heads = num_kv_heads;
+          params.group_size = uint_fastdiv(num_qo_heads / num_kv_heads);
+          params.qo_len = qo_len_p;
+          params.kv_len = kv_len_p;
+          params.q_stride_n = q_stride_n_p;
+          params.q_stride_h = q_stride_h_p;
+          params.k_stride_n = k_stride_n_p;
+          params.k_stride_h = k_stride_h_p;
+          params.v_stride_n = v_stride_n_p;
+          params.v_stride_h = v_stride_h_p;
+          params.window_left = window_left_p;
+          params.partition_kv = false;
+          params.maybe_custom_mask = maybe_custom_mask_p
+                                         ? static_cast<uint8_t*>(maybe_custom_mask_p->data_ptr())
+                                         : nullptr;
+          params.maybe_alibi_slopes = maybe_alibi_slopes_p
+                                          ? static_cast<float*>(maybe_alibi_slopes_p->data_ptr())
+                                          : nullptr;
+          params.logits_soft_cap = static_cast<float>(logits_soft_cap_p);
+          params.sm_scale = static_cast<float>(sm_scale_p);
+          params.rope_rcp_scale = static_cast<float>(rope_rcp_scale_p);
+          params.rope_rcp_theta = static_cast<float>(rope_rcp_theta_p);
+        }
+
+        DecodeParams decode_params;
+        DTypeO* tmp_v = nullptr;
+        float* tmp_s = nullptr;
+        {
+          DecodeParams& params = decode_params;
+          params.q = static_cast<DTypeQ*>(q_d.data_ptr());
+          paged_kv_t<DTypeKV, IdType> paged_kv(
+              num_kv_heads_d, page_size_d, HEAD_DIM_VO, batch_size, kv_layout_d,
+              static_cast<DTypeKV*>(paged_k_cache_d.data_ptr()),
+              static_cast<DTypeKV*>(paged_v_cache_d.data_ptr()), kv_cache_strides_d,
+              static_cast<IdType*>(paged_kv_indices_d.data_ptr()),
+              static_cast<IdType*>(paged_kv_indptr_d.data_ptr()),
+              static_cast<IdType*>(paged_kv_last_page_len_d.data_ptr()));
+          params.paged_kv = paged_kv;
+          params.q_indptr = static_cast<IdType*>(qo_indptr_d.data_ptr());
+          params.o = static_cast<DTypeO*>(o_d.data_ptr());
+          params.lse = maybe_lse_d ? static_cast<float*>(maybe_lse_d->data_ptr()) : nullptr;
+          params.num_qo_heads = num_qo_heads;
+          params.group_size = uint_fastdiv(num_qo_heads / static_cast<uint32_t>(num_kv_heads_d));
+          params.q_stride_n = q_stride_n_d;
+          params.q_stride_h = q_stride_h_d;
+          params.window_left = window_left_d;
+          params.request_indices = nullptr;
+          params.qo_tile_indices = nullptr;
+          params.kv_tile_indices = nullptr;
+          params.merge_indptr = nullptr;
+          params.o_indptr = nullptr;
+          params.kv_chunk_size_ptr = nullptr;
+          params.block_valid_mask = nullptr;
+          params.total_num_rows = nullptr;
+          params.max_total_num_rows = 0;
+          params.padded_batch_size = 0;
+          params.partition_kv = false;
+          params.maybe_custom_mask = maybe_custom_mask_d
+                                         ? static_cast<uint8_t*>(maybe_custom_mask_d->data_ptr())
+                                         : nullptr;
+          params.maybe_mask_indptr =
+              maybe_mask_indptr_d ? static_cast<IdType*>(maybe_mask_indptr_d->data_ptr()) : nullptr;
+          params.maybe_alibi_slopes = maybe_alibi_slopes_d
+                                          ? static_cast<float*>(maybe_alibi_slopes_d->data_ptr())
+                                          : nullptr;
+          params.logits_soft_cap = static_cast<float>(logits_soft_cap_d);
+          params.sm_scale = static_cast<float>(sm_scale_d);
+          params.rope_rcp_scale = static_cast<float>(rope_rcp_scale_d);
+          params.rope_rcp_theta = static_cast<float>(rope_rcp_theta_d);
+
+          params.request_indices =
+              GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.request_indices_offset);
+          params.qo_tile_indices =
+              GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.qo_tile_indices_offset);
+          params.kv_tile_indices =
+              GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_tile_indices_offset);
+          params.o_indptr = GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.o_indptr_offset);
+          params.kv_chunk_size_ptr =
+              GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.kv_chunk_size_ptr_offset);
+          if (plan_info.split_kv) {
+            params.merge_indptr =
+                GetPtrFromBaseOffset<IdType>(int_buffer_ptr, plan_info.merge_indptr_offset);
+            tmp_v = GetPtrFromBaseOffset<DTypeO>(float_buffer_ptr, plan_info.v_offset);
+            tmp_s = GetPtrFromBaseOffset<float>(float_buffer_ptr, plan_info.s_offset);
+            if (plan_info.enable_cuda_graph) {
+              params.block_valid_mask =
+                  GetPtrFromBaseOffset<bool>(int_buffer_ptr, plan_info.block_valid_mask_offset);
+            }
+          }
+          params.padded_batch_size = plan_info.padded_batch_size;
+          params.max_total_num_rows = plan_info.total_num_rows;
+          if (plan_info.enable_cuda_graph) {
+            params.total_num_rows =
+                GetPtrFromBaseOffset<uint32_t>(int_buffer_ptr, plan_info.total_num_rows_offset);
+          }
+        }
+
+        constexpr size_t CTA_TILE_Q_D = 16;
+        hipError_t status = flashinfer::PODWithKVCacheTensorDispatched<
+            HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE, USE_FP16_QK_REDUCTION, MASK_MODE_P,
+            CTA_TILE_Q_D, MASK_MODE_D, PrefillAttentionVariant, DecodeAttentionVariant>(
+            prefill_params, static_cast<DTypeO*>(tmp_p.data_ptr()), decode_params, tmp_v, tmp_s,
+            enable_pdl, stream);
+        TORCH_CHECK(status == hipSuccess,
+                    "PODWithKVCache kernel launch failed, error: ", hipGetErrorString(status));
+        return true;
+      });
+}

--- a/flashinfer/csrc_rocm/pod_customize_config.jinja
+++ b/flashinfer/csrc_rocm/pod_customize_config.jinja
@@ -1,0 +1,44 @@
+#pragma once
+#include <gpu_iface/math_ops.hpp>
+#include <gpu_iface/layout.cuh>
+#include <gpu_iface/utils.cuh>
+#include <gpu_iface/fastdiv.cuh>
+
+#include <flashinfer/attention/generic/page.cuh>
+#include <flashinfer/attention/generic/pos_enc.cuh>
+#include <flashinfer/attention/generic/variant_helper.cuh>
+#include <flashinfer/attention/generic/variants.cuh>
+#include <flashinfer/attention/generic/default_prefill_params.cuh>
+
+using namespace flashinfer;
+
+using DTypeQ = {{ dtype_q }};
+using DTypeKV = {{ dtype_kv }};
+using DTypeO = {{ dtype_o }};
+using IdType = {{ idtype }};
+constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
+constexpr int HEAD_DIM_VO = {{ head_dim_vo }};
+constexpr bool USE_FP16_QK_REDUCTION = {{ use_fp16_qk_reduction }};
+constexpr auto USE_LOGITS_SOFT_CAP_P = {{ use_logits_soft_cap_p }};
+constexpr auto POS_ENCODING_MODE_P = {{ pos_encoding_mode_p }};
+constexpr auto USE_SLIDING_WINDOW_P = {{ use_sliding_window_p }};
+constexpr auto USE_LOGITS_SOFT_CAP_D = {{ use_logits_soft_cap_d }};
+constexpr auto POS_ENCODING_MODE_D = {{ pos_encoding_mode_d }};
+constexpr auto USE_SLIDING_WINDOW_D = {{ use_sliding_window_d }};
+constexpr auto POS_ENCODING_MODE = PosEncodingMode::kNone;
+constexpr bool USE_LOGITS_SOFT_CAP = false;
+
+using PrefillParams = SinglePrefillParams<DTypeQ, DTypeKV, DTypeO>;
+using DecodeParams = BatchPrefillPagedParams<DTypeQ, DTypeKV, DTypeO, IdType>;
+
+#define DISPATCH_context(MASK_MODE_P, MASK_MODE_D, DTypeQ, DTypeKV, HEAD_DIM_QK,     \
+                         USE_SLIDING_WINDOW_P, USE_SLIDING_WINDOW_D, USE_LOGITS_SOFT_CAP, ...) \
+  DISPATCH_MASK_MODE(mask_mode_p, MASK_MODE_P, {                                       \
+    DISPATCH_MASK_MODE(mask_mode_d, MASK_MODE_D, {                                     \
+      constexpr bool use_custom_mask_p = MASK_MODE_P == MaskMode::kCustom;             \
+      constexpr bool use_custom_mask_d = MASK_MODE_D == MaskMode::kCustom;             \
+      using PrefillAttentionVariant = {{ variant_name_p }};                            \
+      using DecodeAttentionVariant = {{ variant_name_d }};                             \
+      __VA_ARGS__();                                                                    \
+    });                                                                                \
+  })

--- a/flashinfer/csrc_rocm/pod_jit_pybind.cu
+++ b/flashinfer/csrc_rocm/pod_jit_pybind.cu
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pod_config.inc"
+#include "pytorch_extension_utils.h"
+
+void pod_with_kv_cache_tensor(
+    at::Tensor q_p, at::Tensor k_p, at::Tensor v_p, at::Tensor tmp_p, at::Tensor o_p,
+    std::optional<at::Tensor> maybe_lse_p, int64_t mask_mode_code_p, int64_t layout_p,
+    int64_t window_left_p, std::optional<at::Tensor> maybe_custom_mask_p,
+    std::optional<at::Tensor> maybe_alibi_slopes_p, double logits_soft_cap_p, double sm_scale_p,
+    double rope_rcp_scale_p, double rope_rcp_theta_p, at::Tensor float_workspace_buffer_d,
+    at::Tensor int_workspace_buffer_d, at::Tensor plan_info_vec, at::Tensor q_d,
+    at::Tensor paged_k_cache_d, at::Tensor paged_v_cache_d, at::Tensor qo_indptr_d,
+    at::Tensor paged_kv_indptr_d, at::Tensor paged_kv_indices_d,
+    at::Tensor paged_kv_last_page_len_d, at::Tensor o_d, std::optional<at::Tensor> maybe_lse_d,
+    int64_t mask_mode_code_d, int64_t layout_d, int64_t window_left_d,
+    std::optional<at::Tensor> maybe_custom_mask_d, std::optional<at::Tensor> maybe_mask_indptr_d,
+    std::optional<at::Tensor> maybe_alibi_slopes_d, double logits_soft_cap_d, double sm_scale_d,
+    double rope_rcp_scale_d, double rope_rcp_theta_d, bool enable_pdl);
+
+TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
+  m.def("pod_with_kv_cache_tensor", pod_with_kv_cache_tensor);
+}

--- a/flashinfer/csrc_rocm/pod_kernel_inst.jinja
+++ b/flashinfer/csrc_rocm/pod_kernel_inst.jinja
@@ -1,0 +1,24 @@
+#include <flashinfer/attention/generic/pod.cuh>
+#include <flashinfer/attention/generic/default_prefill_params.cuh>
+#include "pod_config.inc"
+
+using namespace flashinfer;
+
+namespace flashinfer {
+
+constexpr auto use_custom_mask_p = {{ mask_mode_p }} == MaskMode::kCustom;
+constexpr auto use_custom_mask_d = {{ mask_mode_d }} == MaskMode::kCustom;
+
+using PrefillAttentionVariant = {{ variant_name_p }};
+using DecodeAttentionVariant = {{ variant_name_d }};
+
+template hipError_t PODWithKVCacheTensorDispatched<
+    {{ head_dim_qk }}, {{ head_dim_vo }}, POS_ENCODING_MODE,
+    {{ use_fp16_qk_reduction }}, {{ mask_mode_p }}, /*CTA_TILE_Q_D=*/16,
+    {{ mask_mode_d }}, PrefillAttentionVariant, DecodeAttentionVariant,
+    PrefillParams, DecodeParams>(
+        PrefillParams prefill_params, {{ dtype_o }}* tmp,
+        DecodeParams decode_params, {{ dtype_o }}* tmp_v,
+        float* tmp_s, bool enable_pdl, hipStream_t stream);
+
+}  // namespace flashinfer

--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -131,10 +131,14 @@ elif IS_HIP:
     from .attention import (
         gen_single_prefill_module as gen_single_prefill_module,
     )
+    from .attention import gen_pod_module as gen_pod_module
+    from .attention import gen_batch_pod_module as gen_batch_pod_module
     from .attention import get_batch_decode_uri as get_batch_decode_uri
     from .attention import get_batch_prefill_uri as get_batch_prefill_uri
     from .attention import get_single_decode_uri as get_single_decode_uri
     from .attention import get_single_prefill_uri as get_single_prefill_uri
+    from .attention import get_pod_uri as get_pod_uri
+    from .attention import get_batch_pod_uri as get_batch_pod_uri
     from .core import JitSpec as JitSpec
     from .core import JitSpecStatus as JitSpecStatus
     from .core import JitSpecRegistry as JitSpecRegistry

--- a/flashinfer/jit/attention/__init__.py
+++ b/flashinfer/jit/attention/__init__.py
@@ -82,3 +82,7 @@ elif IS_HIP:
     from .modules_hip import get_batch_prefill_uri as get_batch_prefill_uri
     from .modules_hip import get_single_decode_uri as get_single_decode_uri
     from .modules_hip import get_single_prefill_uri as get_single_prefill_uri
+    from .modules_hip import gen_pod_module as gen_pod_module
+    from .modules_hip import gen_batch_pod_module as gen_batch_pod_module
+    from .modules_hip import get_pod_uri as get_pod_uri
+    from .modules_hip import get_batch_pod_uri as get_batch_pod_uri

--- a/flashinfer/jit/attention/modules_hip.py
+++ b/flashinfer/jit/attention/modules_hip.py
@@ -1169,7 +1169,8 @@ def gen_batch_pod_module(
     )
 
 
-def gen_customize_pod_module(
+def _gen_customize_pod_like_module(
+    prefix: str,
     uri: str,
     dtype_q: torch.dtype,
     dtype_kv: torch.dtype,
@@ -1178,14 +1179,15 @@ def gen_customize_pod_module(
     head_dim: int,
     variant_name_p: str,
     variant_name_d: str,
-    pos_encoding_mode_p: int = 0,
-    use_sliding_window_p: bool = False,
-    use_logits_soft_cap_p: bool = False,
-    pos_encoding_mode_d: int = 0,
-    use_sliding_window_d: bool = False,
-    use_logits_soft_cap_d: bool = False,
-    use_fp16_qk_reduction: bool = False,
+    pos_encoding_mode_p: int,
+    use_sliding_window_p: bool,
+    use_logits_soft_cap_p: bool,
+    pos_encoding_mode_d: int,
+    use_sliding_window_d: bool,
+    use_logits_soft_cap_d: bool,
+    use_fp16_qk_reduction: bool,
 ) -> JitSpec:
+    """Shared body for single (prefix="pod") and batch (prefix="batch_pod") POD JIT modules."""
     gen_directory = FLASHINFER_GEN_SRC_DIR / uri
 
     kwargs = {
@@ -1206,40 +1208,77 @@ def gen_customize_pod_module(
         "use_fp16_qk_reduction": str(use_fp16_qk_reduction).lower(),
     }
 
-    with open(FLASHINFER_CSRC_DIR / "pod_customize_config.jinja") as f:
+    with open(FLASHINFER_CSRC_DIR / f"{prefix}_customize_config.jinja") as f:
         config_templ = jinja2.Template(f.read())
-
-    with open(FLASHINFER_CSRC_DIR / "pod_kernel_inst.jinja") as f:
+    with open(FLASHINFER_CSRC_DIR / f"{prefix}_kernel_inst.jinja") as f:
         kernel_inst_templ = jinja2.Template(f.read())
 
-    generated_inc_str = config_templ.render(**kwargs)
     os.makedirs(gen_directory, exist_ok=True)
-    generated_config_path = gen_directory / "pod_config.inc"
-    write_if_different(generated_config_path, generated_inc_str)
+    write_if_different(
+        gen_directory / f"{prefix}_config.inc", config_templ.render(**kwargs)
+    )
 
     source_paths = []
-
     for mask_mode_p in [0, 1, 2]:
         for mask_mode_d in [0, 1, 2]:
-            filename = f"pod_kernel_mask_{mask_mode_p}p_{mask_mode_d}d.cu"
-            dest_path = gen_directory / filename
-            source_paths.append(dest_path)
-            source = kernel_inst_templ.render(
-                mask_mode_p=mask_mode_literal[mask_mode_p],
-                mask_mode_d=mask_mode_literal[mask_mode_d],
-                **kwargs,
+            dest_path = (
+                gen_directory / f"{prefix}_kernel_mask_{mask_mode_p}p_{mask_mode_d}d.cu"
             )
-            write_if_different(dest_path, source)
+            source_paths.append(dest_path)
+            write_if_different(
+                dest_path,
+                kernel_inst_templ.render(
+                    mask_mode_p=mask_mode_literal[mask_mode_p],
+                    mask_mode_d=mask_mode_literal[mask_mode_d],
+                    **kwargs,
+                ),
+            )
 
-    for filename in ["pod.cu", "pod_jit_pybind.cu"]:
+    for filename in [f"{prefix}.cu", f"{prefix}_jit_pybind.cu"]:
         src_path = FLASHINFER_CSRC_DIR / filename
         dest_path = gen_directory / filename
         source_paths.append(dest_path)
         with open(src_path, "r") as f:
-            source = f.read()
-        write_if_different(dest_path, source)
+            write_if_different(dest_path, f.read())
 
     return gen_jit_spec(uri, source_paths)
+
+
+def gen_customize_pod_module(
+    uri: str,
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+    dtype_o: torch.dtype,
+    dtype_idx: torch.dtype,
+    head_dim: int,
+    variant_name_p: str,
+    variant_name_d: str,
+    pos_encoding_mode_p: int = 0,
+    use_sliding_window_p: bool = False,
+    use_logits_soft_cap_p: bool = False,
+    pos_encoding_mode_d: int = 0,
+    use_sliding_window_d: bool = False,
+    use_logits_soft_cap_d: bool = False,
+    use_fp16_qk_reduction: bool = False,
+) -> JitSpec:
+    return _gen_customize_pod_like_module(
+        "pod",
+        uri,
+        dtype_q,
+        dtype_kv,
+        dtype_o,
+        dtype_idx,
+        head_dim,
+        variant_name_p,
+        variant_name_d,
+        pos_encoding_mode_p,
+        use_sliding_window_p,
+        use_logits_soft_cap_p,
+        pos_encoding_mode_d,
+        use_sliding_window_d,
+        use_logits_soft_cap_d,
+        use_fp16_qk_reduction,
+    )
 
 
 def gen_customize_batch_pod_module(
@@ -1259,57 +1298,21 @@ def gen_customize_batch_pod_module(
     use_logits_soft_cap_d: bool = False,
     use_fp16_qk_reduction: bool = False,
 ) -> JitSpec:
-    gen_directory = FLASHINFER_GEN_SRC_DIR / uri
-
-    kwargs = {
-        "variant_name_p": variant_name_p,
-        "variant_name_d": variant_name_d,
-        "dtype_q": dtype_map_hip[dtype_q],
-        "dtype_kv": dtype_map_hip[dtype_kv],
-        "dtype_o": dtype_map_hip[dtype_o],
-        "idtype": dtype_map_hip[dtype_idx],
-        "head_dim_qk": head_dim,
-        "head_dim_vo": head_dim,
-        "pos_encoding_mode_p": pos_encoding_mode_literal[pos_encoding_mode_p],
-        "pos_encoding_mode_d": pos_encoding_mode_literal[pos_encoding_mode_d],
-        "use_sliding_window_p": str(use_sliding_window_p).lower(),
-        "use_logits_soft_cap_p": str(use_logits_soft_cap_p).lower(),
-        "use_sliding_window_d": str(use_sliding_window_d).lower(),
-        "use_logits_soft_cap_d": str(use_logits_soft_cap_d).lower(),
-        "use_fp16_qk_reduction": str(use_fp16_qk_reduction).lower(),
-    }
-
-    with open(FLASHINFER_CSRC_DIR / "batch_pod_customize_config.jinja") as f:
-        config_templ = jinja2.Template(f.read())
-
-    with open(FLASHINFER_CSRC_DIR / "batch_pod_kernel_inst.jinja") as f:
-        kernel_inst_templ = jinja2.Template(f.read())
-
-    generated_inc_str = config_templ.render(**kwargs)
-    os.makedirs(gen_directory, exist_ok=True)
-    generated_config_path = gen_directory / "batch_pod_config.inc"
-    write_if_different(generated_config_path, generated_inc_str)
-
-    source_paths = []
-
-    for mask_mode_p in [0, 1, 2]:
-        for mask_mode_d in [0, 1, 2]:
-            filename = f"batch_pod_kernel_mask_{mask_mode_p}p_{mask_mode_d}d.cu"
-            dest_path = gen_directory / filename
-            source_paths.append(dest_path)
-            source = kernel_inst_templ.render(
-                mask_mode_p=mask_mode_literal[mask_mode_p],
-                mask_mode_d=mask_mode_literal[mask_mode_d],
-                **kwargs,
-            )
-            write_if_different(dest_path, source)
-
-    for filename in ["batch_pod.cu", "batch_pod_jit_pybind.cu"]:
-        src_path = FLASHINFER_CSRC_DIR / filename
-        dest_path = gen_directory / filename
-        source_paths.append(dest_path)
-        with open(src_path, "r") as f:
-            source = f.read()
-        write_if_different(dest_path, source)
-
-    return gen_jit_spec(uri, source_paths)
+    return _gen_customize_pod_like_module(
+        "batch_pod",
+        uri,
+        dtype_q,
+        dtype_kv,
+        dtype_o,
+        dtype_idx,
+        head_dim,
+        variant_name_p,
+        variant_name_d,
+        pos_encoding_mode_p,
+        use_sliding_window_p,
+        use_logits_soft_cap_p,
+        pos_encoding_mode_d,
+        use_sliding_window_d,
+        use_logits_soft_cap_d,
+        use_fp16_qk_reduction,
+    )

--- a/flashinfer/jit/attention/modules_hip.py
+++ b/flashinfer/jit/attention/modules_hip.py
@@ -1009,3 +1009,307 @@ def gen_customize_batch_prefill_module(
         raise ValueError("FA3 backend not currently supported for ROCm")
     else:
         raise ValueError(f"Invalid backend: {backend}")
+
+
+def get_pod_uri(
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+    dtype_o: torch.dtype,
+    head_dim: int,
+    pos_encoding_mode_p: int,
+    use_sliding_window_p: bool,
+    use_logits_soft_cap_p: bool,
+    use_fp16_qk_reduction: bool,
+    dtype_idx: torch.dtype,
+    pos_encoding_mode_d: int,
+    use_sliding_window_d: bool,
+    use_logits_soft_cap_d: bool,
+) -> str:
+    return (
+        f"pod_with_kv_cache_dtype_q_{filename_safe_dtype_map[dtype_q]}_"
+        f"dtype_kv_{filename_safe_dtype_map[dtype_kv]}_"
+        f"dtype_o_{filename_safe_dtype_map[dtype_o]}_"
+        f"head_dim_{head_dim}_"
+        f"posenc_p_{pos_encoding_mode_p}_"
+        f"use_swa_p_{use_sliding_window_p}_"
+        f"use_logits_cap_p_{use_logits_soft_cap_p}_"
+        f"posenc_d_{pos_encoding_mode_d}_"
+        f"use_swa_d_{use_sliding_window_d}_"
+        f"use_logits_cap_d_{use_logits_soft_cap_d}_"
+        f"dtype_idx_{filename_safe_dtype_map[dtype_idx]}_"
+        f"f16qk_{use_fp16_qk_reduction}"
+    )
+
+
+def get_batch_pod_uri(
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+    dtype_o: torch.dtype,
+    head_dim: int,
+    pos_encoding_mode_p: int,
+    use_sliding_window_p: bool,
+    use_logits_soft_cap_p: bool,
+    use_fp16_qk_reduction: bool,
+    dtype_idx: torch.dtype,
+    pos_encoding_mode_d: int,
+    use_sliding_window_d: bool,
+    use_logits_soft_cap_d: bool,
+) -> str:
+    return "batch_" + get_pod_uri(
+        dtype_q,
+        dtype_kv,
+        dtype_o,
+        head_dim,
+        pos_encoding_mode_p,
+        use_sliding_window_p,
+        use_logits_soft_cap_p,
+        use_fp16_qk_reduction,
+        dtype_idx,
+        pos_encoding_mode_d,
+        use_sliding_window_d,
+        use_logits_soft_cap_d,
+    )
+
+
+def gen_pod_module(
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+    dtype_o: torch.dtype,
+    head_dim: int,
+    pos_encoding_mode_p: int,
+    use_sliding_window_p: bool,
+    use_logits_soft_cap_p: bool,
+    use_fp16_qk_reduction: bool,
+    dtype_idx: torch.dtype,
+    pos_encoding_mode_d: int,
+    use_sliding_window_d: bool,
+    use_logits_soft_cap_d: bool,
+) -> JitSpec:
+    uri = get_pod_uri(
+        dtype_q,
+        dtype_kv,
+        dtype_o,
+        head_dim,
+        pos_encoding_mode_p,
+        use_sliding_window_p,
+        use_logits_soft_cap_p,
+        use_fp16_qk_reduction,
+        dtype_idx,
+        pos_encoding_mode_d,
+        use_sliding_window_d,
+        use_logits_soft_cap_d,
+    )
+    variant_name_p = f"DefaultAttention<use_custom_mask_p, {str(use_sliding_window_p).lower()}, {str(use_logits_soft_cap_p).lower()}, {str(pos_encoding_mode_p == 2).lower()}>"
+    variant_name_d = f"DefaultAttention<use_custom_mask_d, {str(use_sliding_window_d).lower()}, {str(use_logits_soft_cap_d).lower()}, {str(pos_encoding_mode_d == 2).lower()}>"
+    return gen_customize_pod_module(
+        uri,
+        dtype_q,
+        dtype_kv,
+        dtype_o,
+        dtype_idx,
+        head_dim,
+        variant_name_p,
+        variant_name_d,
+        pos_encoding_mode_p=pos_encoding_mode_p,
+        use_sliding_window_p=use_sliding_window_p,
+        use_logits_soft_cap_p=use_logits_soft_cap_p,
+        pos_encoding_mode_d=pos_encoding_mode_d,
+        use_sliding_window_d=use_sliding_window_d,
+        use_logits_soft_cap_d=use_logits_soft_cap_d,
+        use_fp16_qk_reduction=use_fp16_qk_reduction,
+    )
+
+
+def gen_batch_pod_module(
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+    dtype_o: torch.dtype,
+    head_dim: int,
+    pos_encoding_mode_p: int,
+    use_sliding_window_p: bool,
+    use_logits_soft_cap_p: bool,
+    use_fp16_qk_reduction: bool,
+    dtype_idx: torch.dtype,
+    pos_encoding_mode_d: int,
+    use_sliding_window_d: bool,
+    use_logits_soft_cap_d: bool,
+) -> JitSpec:
+    uri = get_batch_pod_uri(
+        dtype_q,
+        dtype_kv,
+        dtype_o,
+        head_dim,
+        pos_encoding_mode_p,
+        use_sliding_window_p,
+        use_logits_soft_cap_p,
+        use_fp16_qk_reduction,
+        dtype_idx,
+        pos_encoding_mode_d,
+        use_sliding_window_d,
+        use_logits_soft_cap_d,
+    )
+    variant_name_p = f"DefaultAttention<use_custom_mask_p, {str(use_sliding_window_p).lower()}, {str(use_logits_soft_cap_p).lower()}, {str(pos_encoding_mode_p == 2).lower()}>"
+    variant_name_d = f"DefaultAttention<use_custom_mask_d, {str(use_sliding_window_d).lower()}, {str(use_logits_soft_cap_d).lower()}, {str(pos_encoding_mode_d == 2).lower()}>"
+    return gen_customize_batch_pod_module(
+        uri,
+        dtype_q,
+        dtype_kv,
+        dtype_o,
+        dtype_idx,
+        head_dim,
+        variant_name_p,
+        variant_name_d,
+        pos_encoding_mode_p=pos_encoding_mode_p,
+        use_sliding_window_p=use_sliding_window_p,
+        use_logits_soft_cap_p=use_logits_soft_cap_p,
+        pos_encoding_mode_d=pos_encoding_mode_d,
+        use_sliding_window_d=use_sliding_window_d,
+        use_logits_soft_cap_d=use_logits_soft_cap_d,
+        use_fp16_qk_reduction=use_fp16_qk_reduction,
+    )
+
+
+def gen_customize_pod_module(
+    uri: str,
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+    dtype_o: torch.dtype,
+    dtype_idx: torch.dtype,
+    head_dim: int,
+    variant_name_p: str,
+    variant_name_d: str,
+    pos_encoding_mode_p: int = 0,
+    use_sliding_window_p: bool = False,
+    use_logits_soft_cap_p: bool = False,
+    pos_encoding_mode_d: int = 0,
+    use_sliding_window_d: bool = False,
+    use_logits_soft_cap_d: bool = False,
+    use_fp16_qk_reduction: bool = False,
+) -> JitSpec:
+    gen_directory = FLASHINFER_GEN_SRC_DIR / uri
+
+    kwargs = {
+        "variant_name_p": variant_name_p,
+        "variant_name_d": variant_name_d,
+        "dtype_q": dtype_map_hip[dtype_q],
+        "dtype_kv": dtype_map_hip[dtype_kv],
+        "dtype_o": dtype_map_hip[dtype_o],
+        "idtype": dtype_map_hip[dtype_idx],
+        "head_dim_qk": head_dim,
+        "head_dim_vo": head_dim,
+        "pos_encoding_mode_p": pos_encoding_mode_literal[pos_encoding_mode_p],
+        "pos_encoding_mode_d": pos_encoding_mode_literal[pos_encoding_mode_d],
+        "use_sliding_window_p": str(use_sliding_window_p).lower(),
+        "use_logits_soft_cap_p": str(use_logits_soft_cap_p).lower(),
+        "use_sliding_window_d": str(use_sliding_window_d).lower(),
+        "use_logits_soft_cap_d": str(use_logits_soft_cap_d).lower(),
+        "use_fp16_qk_reduction": str(use_fp16_qk_reduction).lower(),
+    }
+
+    with open(FLASHINFER_CSRC_DIR / "pod_customize_config.jinja") as f:
+        config_templ = jinja2.Template(f.read())
+
+    with open(FLASHINFER_CSRC_DIR / "pod_kernel_inst.jinja") as f:
+        kernel_inst_templ = jinja2.Template(f.read())
+
+    generated_inc_str = config_templ.render(**kwargs)
+    os.makedirs(gen_directory, exist_ok=True)
+    generated_config_path = gen_directory / "pod_config.inc"
+    write_if_different(generated_config_path, generated_inc_str)
+
+    source_paths = []
+
+    for mask_mode_p in [0, 1, 2]:
+        for mask_mode_d in [0, 1, 2]:
+            filename = f"pod_kernel_mask_{mask_mode_p}p_{mask_mode_d}d.cu"
+            dest_path = gen_directory / filename
+            source_paths.append(dest_path)
+            source = kernel_inst_templ.render(
+                mask_mode_p=mask_mode_literal[mask_mode_p],
+                mask_mode_d=mask_mode_literal[mask_mode_d],
+                **kwargs,
+            )
+            write_if_different(dest_path, source)
+
+    for filename in ["pod.cu", "pod_jit_pybind.cu"]:
+        src_path = FLASHINFER_CSRC_DIR / filename
+        dest_path = gen_directory / filename
+        source_paths.append(dest_path)
+        with open(src_path, "r") as f:
+            source = f.read()
+        write_if_different(dest_path, source)
+
+    return gen_jit_spec(uri, source_paths)
+
+
+def gen_customize_batch_pod_module(
+    uri: str,
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+    dtype_o: torch.dtype,
+    dtype_idx: torch.dtype,
+    head_dim: int,
+    variant_name_p: str,
+    variant_name_d: str,
+    pos_encoding_mode_p: int = 0,
+    use_sliding_window_p: bool = False,
+    use_logits_soft_cap_p: bool = False,
+    pos_encoding_mode_d: int = 0,
+    use_sliding_window_d: bool = False,
+    use_logits_soft_cap_d: bool = False,
+    use_fp16_qk_reduction: bool = False,
+) -> JitSpec:
+    gen_directory = FLASHINFER_GEN_SRC_DIR / uri
+
+    kwargs = {
+        "variant_name_p": variant_name_p,
+        "variant_name_d": variant_name_d,
+        "dtype_q": dtype_map_hip[dtype_q],
+        "dtype_kv": dtype_map_hip[dtype_kv],
+        "dtype_o": dtype_map_hip[dtype_o],
+        "idtype": dtype_map_hip[dtype_idx],
+        "head_dim_qk": head_dim,
+        "head_dim_vo": head_dim,
+        "pos_encoding_mode_p": pos_encoding_mode_literal[pos_encoding_mode_p],
+        "pos_encoding_mode_d": pos_encoding_mode_literal[pos_encoding_mode_d],
+        "use_sliding_window_p": str(use_sliding_window_p).lower(),
+        "use_logits_soft_cap_p": str(use_logits_soft_cap_p).lower(),
+        "use_sliding_window_d": str(use_sliding_window_d).lower(),
+        "use_logits_soft_cap_d": str(use_logits_soft_cap_d).lower(),
+        "use_fp16_qk_reduction": str(use_fp16_qk_reduction).lower(),
+    }
+
+    with open(FLASHINFER_CSRC_DIR / "batch_pod_customize_config.jinja") as f:
+        config_templ = jinja2.Template(f.read())
+
+    with open(FLASHINFER_CSRC_DIR / "batch_pod_kernel_inst.jinja") as f:
+        kernel_inst_templ = jinja2.Template(f.read())
+
+    generated_inc_str = config_templ.render(**kwargs)
+    os.makedirs(gen_directory, exist_ok=True)
+    generated_config_path = gen_directory / "batch_pod_config.inc"
+    write_if_different(generated_config_path, generated_inc_str)
+
+    source_paths = []
+
+    for mask_mode_p in [0, 1, 2]:
+        for mask_mode_d in [0, 1, 2]:
+            filename = f"batch_pod_kernel_mask_{mask_mode_p}p_{mask_mode_d}d.cu"
+            dest_path = gen_directory / filename
+            source_paths.append(dest_path)
+            source = kernel_inst_templ.render(
+                mask_mode_p=mask_mode_literal[mask_mode_p],
+                mask_mode_d=mask_mode_literal[mask_mode_d],
+                **kwargs,
+            )
+            write_if_different(dest_path, source)
+
+    for filename in ["batch_pod.cu", "batch_pod_jit_pybind.cu"]:
+        src_path = FLASHINFER_CSRC_DIR / filename
+        dest_path = gen_directory / filename
+        source_paths.append(dest_path)
+        with open(src_path, "r") as f:
+            source = f.read()
+        write_if_different(dest_path, source)
+
+    return gen_jit_spec(uri, source_paths)

--- a/flashinfer/pod.py
+++ b/flashinfer/pod.py
@@ -21,6 +21,7 @@ from typing import Any, List, Optional, Tuple, Union
 
 import torch
 
+from .device_utils import IS_HIP
 from .jit import gen_pod_module, gen_batch_pod_module
 from .page import get_seq_lens
 from .prefill import get_batch_prefill_module
@@ -29,6 +30,7 @@ from .utils import (
     MaskMode,
     PosEncodingMode,
     TensorLayout,
+    plan_info_vec_as_tensor,
     _check_cached_qkv_data_type,
     _check_kv_layout,
     _check_pos_encoding_mode,
@@ -400,7 +402,7 @@ class PODWithPagedKVCacheWrapper:
                 False,  # use_fp16_qk_reduction
             )
 
-        self._plan_info = self._cached_module.plan(
+        _plan_args = [
             self._float_workspace_buffer,
             self._int_workspace_buffer,
             self._pin_memory_int_workspace_buffer,
@@ -416,11 +418,15 @@ class PODWithPagedKVCacheWrapper:
             head_dim,
             head_dim,
             False,  # causal
-            window_left,
-            -1,  # fixed_split_size
-            False,  # disable_split_kv
-            0,  # num_colocated_ctas
-        )
+        ]
+        if IS_HIP:
+            self._plan_info = plan_info_vec_as_tensor(
+                self._cached_module.plan(*_plan_args),
+                device=self._float_workspace_buffer.device,
+            )
+        else:
+            _plan_args += [window_left, -1, False, 0]
+            self._plan_info = self._cached_module.plan(*_plan_args)
 
         self._indptr_type = indptr.dtype
         self._pos_encoding_mode = pos_encoding_mode
@@ -952,7 +958,7 @@ class BatchPODWithPagedKVCacheWrapper:
             kv_indptr_host_d, last_page_len_host_d, page_size
         )
 
-        self._plan_info_d = self._cached_module.plan(
+        _plan_args_d = [
             self._float_workspace_buffer_d,
             self._int_workspace_buffer_d,
             self._pin_memory_int_workspace_buffer_d,
@@ -968,17 +974,22 @@ class BatchPODWithPagedKVCacheWrapper:
             head_dim,
             head_dim,
             False,  # causal
-            window_left,
-            -1,  # fixed_split_size
-            False,  # disable_split_kv
-            0,  # num_colocated_ctas
-        )
+        ]
+        if IS_HIP:
+            self._plan_info_d = plan_info_vec_as_tensor(
+                self._cached_module.plan(*_plan_args_d),
+                device=self._float_workspace_buffer_d.device,
+            )
+            num_colocated_ctas = 0  # colocated-CTA scheduling is CUDA-only
+        else:
+            _plan_args_d += [window_left, -1, False, 0]
+            self._plan_info_d = self._cached_module.plan(*_plan_args_d)
+            num_colocated_ctas = self._plan_info_d[0]
 
-        num_colocated_ctas = self._plan_info_d[0]
-        # Splitting small prefill causes unecessary bandwidth contention
+        # Splitting small prefill causes unnecessary bandwidth contention
         if total_num_rows_p > 1536:
             num_colocated_ctas = 0
-        self._plan_info_p = self._cached_module.plan(
+        _plan_args_p = [
             self._float_workspace_buffer_p,
             self._int_workspace_buffer_p,
             self._pin_memory_int_workspace_buffer_p,
@@ -994,11 +1005,15 @@ class BatchPODWithPagedKVCacheWrapper:
             head_dim,
             head_dim,
             False,  # causal
-            window_left,
-            -1,  # fixed_split_size
-            False,  # disable_split_kv
-            num_colocated_ctas,
-        )
+        ]
+        if IS_HIP:
+            self._plan_info_p = plan_info_vec_as_tensor(
+                self._cached_module.plan(*_plan_args_p),
+                device=self._float_workspace_buffer_p.device,
+            )
+        else:
+            _plan_args_p += [window_left, -1, False, num_colocated_ctas]
+            self._plan_info_p = self._cached_module.plan(*_plan_args_p)
         self._indptr_type = kv_indptr_p.dtype
         self._pos_encoding_mode = pos_encoding_mode
         self._window_left = window_left

--- a/include/flashinfer/attention/batch_pod.cuh
+++ b/include/flashinfer/attention/batch_pod.cuh
@@ -74,7 +74,13 @@ __global__ __launch_bounds__(std::max(
     const int prefill_slots = (prefill_blocks + blk_factor_p - 1) / blk_factor_p;
     const int decode_slots = (decode_blocks + blk_factor_d - 1) / blk_factor_d;
 
-    if (prefill_slots <= decode_slots) {
+    if (prefill_slots == 0) {
+      op = DECODE;
+      linear_bid = atomicAdd(&sm_aware_sched[num_SMs + op], 1);
+    } else if (decode_slots == 0) {
+      op = PREFILL;
+      linear_bid = atomicAdd(&sm_aware_sched[num_SMs + op], 1);
+    } else if (prefill_slots <= decode_slots) {
       // Total tags = (decode + prefill) / min(decode, prefill)
       // = 1 + decode / prefill; when prefill < decode
       const int total_tags = decode_slots / prefill_slots + 1;
@@ -82,6 +88,16 @@ __global__ __launch_bounds__(std::max(
       op = (atomicAdd(&sm_aware_sched[linear_bid], 1) % total_tags);
       if (op > 0) {
         op = 1;
+      }
+      // Get the next blockId for that operation
+      linear_bid = atomicAdd(&sm_aware_sched[num_SMs + op], 1);
+      // If the blockId obtained exceeds the max blockIds for that op, switch to the other op
+      if (op == 0 && linear_bid >= prefill_slots) {
+        linear_bid = atomicAdd(&sm_aware_sched[num_SMs + 1], 1);
+        op = !op;
+      } else if (op == 1 && linear_bid >= decode_slots) {
+        op = !op;
+        linear_bid = atomicAdd(&sm_aware_sched[num_SMs + 0], 1);
       }
     } else {
       // Total tags = (decode + prefill) / min(decode, prefill)
@@ -95,17 +111,16 @@ __global__ __launch_bounds__(std::max(
       } else {
         op = 1;
       }
-    }
-
-    // Get the next blockId for that operation
-    linear_bid = atomicAdd(&sm_aware_sched[num_SMs + op], 1);
-    // If the blockId obtained exceeds the max blockIds for that op, switch to the other op
-    if (op == 0 && linear_bid >= prefill_slots) {
-      linear_bid = atomicAdd(&sm_aware_sched[num_SMs + 1], 1);
-      op = !op;
-    } else if (op == 1 && linear_bid >= decode_slots) {
-      op = !op;
-      linear_bid = atomicAdd(&sm_aware_sched[num_SMs + 0], 1);
+      // Get the next blockId for that operation
+      linear_bid = atomicAdd(&sm_aware_sched[num_SMs + op], 1);
+      // If the blockId obtained exceeds the max blockIds for that op, switch to the other op
+      if (op == 0 && linear_bid >= prefill_slots) {
+        linear_bid = atomicAdd(&sm_aware_sched[num_SMs + 1], 1);
+        op = !op;
+      } else if (op == 1 && linear_bid >= decode_slots) {
+        op = !op;
+        linear_bid = atomicAdd(&sm_aware_sched[num_SMs + 0], 1);
+      }
     }
     // Write the blockId and operation to shared memory
     ((int*)smem)[0] = linear_bid;
@@ -175,6 +190,13 @@ cudaError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
   // Ensure heads match
   assert(prefill_params.paged_kv.num_heads == decode_params.paged_kv.num_heads);
   assert(prefill_params.num_qo_heads == decode_params.num_qo_heads);
+
+  const uint32_t padded_batch_size_p = prefill_params.padded_batch_size;
+  const uint32_t padded_batch_size_d = decode_params.padded_batch_size;
+  if (padded_batch_size_p == 0 && padded_batch_size_d == 0) {
+    return cudaSuccess;
+  }
+
   // Common variables for both prefill and decode
   const uint32_t num_qo_heads = prefill_params.num_qo_heads;
   const uint32_t num_kv_heads = prefill_params.paged_kv.num_heads;
@@ -189,7 +211,6 @@ cudaError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
   using DTypeQ_P = typename PrefillParams::DTypeQ;
   using DTypeKV_P = typename PrefillParams::DTypeKV;
   using DTypeO_P = typename PrefillParams::DTypeO;
-  const uint32_t padded_batch_size_p = prefill_params.padded_batch_size;
   constexpr uint32_t NUM_MMA_Q_P = get_num_mma_q(CTA_TILE_Q_P);
   constexpr uint32_t NUM_WARPS_Q_P = get_num_warps_q(CTA_TILE_Q_P);
   constexpr uint32_t NUM_WARPS_KV_P = get_num_warps_kv(CTA_TILE_Q_P);
@@ -207,7 +228,6 @@ cudaError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
   using DTypeQ_D = typename DecodeParams::DTypeQ;
   using DTypeKV_D = typename DecodeParams::DTypeKV;
   using DTypeO_D = typename DecodeParams::DTypeO;
-  const uint32_t padded_batch_size_d = decode_params.padded_batch_size;
   constexpr uint32_t NUM_MMA_Q_D = get_num_mma_q(CTA_TILE_Q_D);
   constexpr uint32_t NUM_WARPS_Q_D = get_num_warps_q(CTA_TILE_Q_D);
   constexpr uint32_t NUM_WARPS_KV_D = get_num_warps_kv(CTA_TILE_Q_D);

--- a/include/flashinfer/attention/generic/batch_pod.cuh
+++ b/include/flashinfer/attention/generic/batch_pod.cuh
@@ -50,11 +50,26 @@ __global__ __launch_bounds__(std::max(
     const int prefill_slots = (prefill_blocks + blk_factor_p - 1) / blk_factor_p;
     const int decode_slots = (decode_blocks + blk_factor_d - 1) / blk_factor_d;
 
-    if (prefill_slots <= decode_slots) {
+    if (prefill_slots == 0) {
+      op = BATCH_POD_DECODE;
+      linear_bid = atomicAdd(&sm_aware_sched[num_SMs + op], 1);
+    } else if (decode_slots == 0) {
+      op = BATCH_POD_PREFILL;
+      linear_bid = atomicAdd(&sm_aware_sched[num_SMs + op], 1);
+    } else if (prefill_slots <= decode_slots) {
       const int total_tags = decode_slots / prefill_slots + 1;
       op = (atomicAdd(&sm_aware_sched[linear_bid], 1) % total_tags);
       if (op > 0) {
         op = 1;
+      }
+      linear_bid = atomicAdd(&sm_aware_sched[num_SMs + op], 1);
+      // If this CU has exhausted its quota for the chosen op, steal work from the other op.
+      if (op == 0 && linear_bid >= prefill_slots) {
+        linear_bid = atomicAdd(&sm_aware_sched[num_SMs + 1], 1);
+        op = !op;
+      } else if (op == 1 && linear_bid >= decode_slots) {
+        op = !op;
+        linear_bid = atomicAdd(&sm_aware_sched[num_SMs + 0], 1);
       }
     } else {
       const int pref_tags = prefill_slots / decode_slots;
@@ -64,15 +79,15 @@ __global__ __launch_bounds__(std::max(
       } else {
         op = 1;
       }
-    }
-
-    linear_bid = atomicAdd(&sm_aware_sched[num_SMs + op], 1);
-    if (op == 0 && linear_bid >= prefill_slots) {
-      linear_bid = atomicAdd(&sm_aware_sched[num_SMs + 1], 1);
-      op = !op;
-    } else if (op == 1 && linear_bid >= decode_slots) {
-      op = !op;
-      linear_bid = atomicAdd(&sm_aware_sched[num_SMs + 0], 1);
+      linear_bid = atomicAdd(&sm_aware_sched[num_SMs + op], 1);
+      // If this CU has exhausted its quota for the chosen op, steal work from the other op.
+      if (op == 0 && linear_bid >= prefill_slots) {
+        linear_bid = atomicAdd(&sm_aware_sched[num_SMs + 1], 1);
+        op = !op;
+      } else if (op == 1 && linear_bid >= decode_slots) {
+        op = !op;
+        linear_bid = atomicAdd(&sm_aware_sched[num_SMs + 0], 1);
+      }
     }
     ((int*)smem)[0] = linear_bid;
     ((int*)smem)[1] = op;
@@ -97,7 +112,7 @@ __global__ __launch_bounds__(std::max(
 
     BatchPrefillWithPagedKVCacheDevice<KTraits_P>(prefill_params, smem_storage, tid, bx,
                                                   kv_head_idx, num_kv_heads_p);
-  } else /* OP == DECODE */ {
+  } else {  // BATCH_POD_DECODE
     auto& smem_storage = reinterpret_cast<typename KTraits_D::SharedStorage&>(smem);
     if (linear_bid >= decode_blocks) return;
 
@@ -132,6 +147,12 @@ gpuError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
   assert(prefill_params.paged_kv.num_heads == decode_params.paged_kv.num_heads);
   assert(prefill_params.num_qo_heads == decode_params.num_qo_heads);
 
+  const uint32_t padded_batch_size_p = prefill_params.padded_batch_size;
+  const uint32_t padded_batch_size_d = decode_params.padded_batch_size;
+  if (padded_batch_size_p == 0 && padded_batch_size_d == 0) {
+    return gpuSuccess;
+  }
+
   const uint32_t num_qo_heads = prefill_params.num_qo_heads;
   const uint32_t num_kv_heads = prefill_params.paged_kv.num_heads;
 
@@ -142,7 +163,6 @@ gpuError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
   using DTypeQ_P = typename PrefillParams::DTypeQ;
   using DTypeKV_P = typename PrefillParams::DTypeKV;
   using DTypeO_P = typename PrefillParams::DTypeO;
-  const uint32_t padded_batch_size_p = prefill_params.padded_batch_size;
   constexpr uint32_t NUM_MMA_Q_P = get_num_mma_q(CTA_TILE_Q_P);
   constexpr uint32_t NUM_WARPS_Q_P = get_num_warps_q(CTA_TILE_Q_P);
   constexpr uint32_t NUM_WARPS_KV_P = get_num_warps_kv(CTA_TILE_Q_P);
@@ -158,7 +178,6 @@ gpuError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
   using DTypeQ_D = typename DecodeParams::DTypeQ;
   using DTypeKV_D = typename DecodeParams::DTypeKV;
   using DTypeO_D = typename DecodeParams::DTypeO;
-  const uint32_t padded_batch_size_d = decode_params.padded_batch_size;
   constexpr uint32_t NUM_MMA_Q_D = get_num_mma_q(CTA_TILE_Q_D);
   constexpr uint32_t NUM_WARPS_Q_D = get_num_warps_q(CTA_TILE_Q_D);
   constexpr uint32_t NUM_WARPS_KV_D = get_num_warps_kv(CTA_TILE_Q_D);
@@ -238,11 +257,11 @@ gpuError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
             decode_params.lse = tmp_s_d;
           }
 
-          int nblks_p(padded_batch_size_p * 1 * num_kv_heads);
-          int nthrs_p(KTraits_P::NUM_THREADS);
+          int nblks_p = padded_batch_size_p * num_kv_heads;
+          int nthrs_p = KTraits_P::NUM_THREADS;
 
-          int nblks_d(padded_batch_size_d * 1 * num_kv_heads);
-          int nthrs_d(KTraits_D::NUM_THREADS);
+          int nblks_d = padded_batch_size_d * num_kv_heads;
+          int nthrs_d = KTraits_D::NUM_THREADS;
 
           size_t smem_size = max(smem_size_p, smem_size_d);
           int nblks = nblks_p + nblks_d;

--- a/include/flashinfer/attention/generic/batch_pod.cuh
+++ b/include/flashinfer/attention/generic/batch_pod.cuh
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: 2025 FlashInfer team.
+// SPDX-FileCopyrightText: 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "cascade.cuh"
+#include "dispatch.cuh"
+#include "gpu_iface/gpu_runtime_compat.hpp"
+#include "gpu_iface/math_ops.hpp"
+#include "gpu_iface/platform.hpp"
+#include "gpu_iface/sm_id.hpp"
+#include "gpu_iface/utils.cuh"
+#include "prefill.cuh"
+#include "variants.cuh"
+
+namespace flashinfer {
+
+enum BatchPODOperation {
+  BATCH_POD_PREFILL = 0,
+  BATCH_POD_DECODE = 1,
+};
+
+template <typename KTraits_P, typename KTraits_D, typename PrefillParams, typename DecodeParams>
+__global__ __launch_bounds__(std::max(
+    KTraits_P::NUM_THREADS,
+    KTraits_D::NUM_THREADS)) void BatchPODWithKVCacheTensorKernel(const __grid_constant__
+                                                                      PrefillParams prefill_params,
+                                                                  const __grid_constant__
+                                                                      DecodeParams decode_params,
+                                                                  int* sm_aware_sched,
+                                                                  int num_SMs) {
+  extern __shared__ uint8_t smem[];
+  const uint32_t padded_bsize_p = prefill_params.padded_batch_size;
+  const uint32_t num_kv_heads_p = prefill_params.paged_kv.num_heads;
+
+  const uint32_t padded_bsize_d = decode_params.padded_batch_size;
+  const uint32_t num_kv_heads_d = decode_params.paged_kv.num_heads;
+
+  const uint32_t prefill_blocks = padded_bsize_p * num_kv_heads_p;
+  const uint32_t decode_blocks = padded_bsize_d * num_kv_heads_d;
+
+  int op;
+  int linear_bid;
+  if (threadIdx.x == 0) {
+    constexpr int blk_factor_p = 1;
+    constexpr int blk_factor_d = 1;
+
+    linear_bid = static_cast<int>(gpu_iface::get_processor_id() % static_cast<uint32_t>(num_SMs));
+    const int prefill_slots = (prefill_blocks + blk_factor_p - 1) / blk_factor_p;
+    const int decode_slots = (decode_blocks + blk_factor_d - 1) / blk_factor_d;
+
+    if (prefill_slots <= decode_slots) {
+      const int total_tags = decode_slots / prefill_slots + 1;
+      op = (atomicAdd(&sm_aware_sched[linear_bid], 1) % total_tags);
+      if (op > 0) {
+        op = 1;
+      }
+    } else {
+      const int pref_tags = prefill_slots / decode_slots;
+      op = (atomicAdd(&sm_aware_sched[linear_bid], 1) % (pref_tags + 1));
+      if (op < pref_tags) {
+        op = 0;
+      } else {
+        op = 1;
+      }
+    }
+
+    linear_bid = atomicAdd(&sm_aware_sched[num_SMs + op], 1);
+    if (op == 0 && linear_bid >= prefill_slots) {
+      linear_bid = atomicAdd(&sm_aware_sched[num_SMs + 1], 1);
+      op = !op;
+    } else if (op == 1 && linear_bid >= decode_slots) {
+      op = !op;
+      linear_bid = atomicAdd(&sm_aware_sched[num_SMs + 0], 1);
+    }
+    ((int*)smem)[0] = linear_bid;
+    ((int*)smem)[1] = op;
+  }
+  __syncthreads();
+  linear_bid = ((int*)smem)[0];
+  op = ((int*)smem)[1];
+  __syncthreads();
+
+  if (op == BATCH_POD_PREFILL) {
+    auto& smem_storage = reinterpret_cast<typename KTraits_P::SharedStorage&>(smem);
+    if (linear_bid >= prefill_blocks) return;
+
+    const uint32_t bx = linear_bid % padded_bsize_p;
+    const uint32_t kv_head_idx = linear_bid / padded_bsize_p;
+
+    const uint32_t linear_tid = threadIdx.x;
+    if (linear_tid >= WARP_SIZE * KTraits_P::NUM_WARPS_Q * KTraits_P::NUM_WARPS_KV) return;
+
+    const dim3 tid = dim3(linear_tid % WARP_SIZE, (linear_tid / WARP_SIZE) % KTraits_P::NUM_WARPS_Q,
+                          (linear_tid / WARP_SIZE) / KTraits_P::NUM_WARPS_Q);
+
+    BatchPrefillWithPagedKVCacheDevice<KTraits_P>(prefill_params, smem_storage, tid, bx,
+                                                  kv_head_idx, num_kv_heads_p);
+  } else /* OP == DECODE */ {
+    auto& smem_storage = reinterpret_cast<typename KTraits_D::SharedStorage&>(smem);
+    if (linear_bid >= decode_blocks) return;
+
+    const uint32_t bx = linear_bid % padded_bsize_d;
+    const uint32_t kv_head_idx = linear_bid / padded_bsize_d;
+
+    const uint32_t linear_tid = threadIdx.x;
+    if (linear_tid >= WARP_SIZE * KTraits_D::NUM_WARPS_Q * KTraits_D::NUM_WARPS_KV) return;
+
+    const dim3 tid = dim3(linear_tid % WARP_SIZE, (linear_tid / WARP_SIZE) % KTraits_D::NUM_WARPS_Q,
+                          (linear_tid / WARP_SIZE) / KTraits_D::NUM_WARPS_Q);
+
+    BatchPrefillWithPagedKVCacheDevice<KTraits_D>(decode_params, smem_storage, tid, bx, kv_head_idx,
+                                                  num_kv_heads_d);
+  }
+}
+
+template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, PosEncodingMode POS_ENCODING_MODE,
+          bool USE_FP16_QK_REDUCTION, uint32_t CTA_TILE_Q_P, MaskMode MASK_MODE_P,
+          uint32_t CTA_TILE_Q_D, MaskMode MASK_MODE_D, typename PrefillAttentionVariant,
+          typename DecodeAttentionVariant, typename PrefillParams, typename DecodeParams>
+gpuError_t BatchPODWithKVCacheTensorDispatched(PrefillParams prefill_params,
+                                               typename PrefillParams::DTypeO* tmp_v_p,
+                                               float* tmp_s_p, DecodeParams decode_params,
+                                               typename DecodeParams::DTypeO* tmp_v_d,
+                                               float* tmp_s_d, bool /*enable_pdl*/,
+                                               gpuStream_t stream, int* sm_aware_sched) {
+  static_assert(std::is_same<typename PrefillParams::DTypeQ, typename DecodeParams::DTypeQ>::value);
+  static_assert(
+      std::is_same<typename PrefillParams::DTypeKV, typename DecodeParams::DTypeKV>::value);
+  static_assert(std::is_same<typename PrefillParams::DTypeO, typename DecodeParams::DTypeO>::value);
+  assert(prefill_params.paged_kv.num_heads == decode_params.paged_kv.num_heads);
+  assert(prefill_params.num_qo_heads == decode_params.num_qo_heads);
+
+  const uint32_t num_qo_heads = prefill_params.num_qo_heads;
+  const uint32_t num_kv_heads = prefill_params.paged_kv.num_heads;
+
+  int dev_id = 0;
+  FI_GPU_CALL(gpuGetDevice(&dev_id));
+  int max_smem_per_sm = getMaxSharedMemPerMultiprocessor(dev_id);
+
+  using DTypeQ_P = typename PrefillParams::DTypeQ;
+  using DTypeKV_P = typename PrefillParams::DTypeKV;
+  using DTypeO_P = typename PrefillParams::DTypeO;
+  const uint32_t padded_batch_size_p = prefill_params.padded_batch_size;
+  constexpr uint32_t NUM_MMA_Q_P = get_num_mma_q(CTA_TILE_Q_P);
+  constexpr uint32_t NUM_WARPS_Q_P = get_num_warps_q(CTA_TILE_Q_P);
+  constexpr uint32_t NUM_WARPS_KV_P = get_num_warps_kv(CTA_TILE_Q_P);
+
+  using DTypeQKAccum_P =
+      typename std::conditional<USE_FP16_QK_REDUCTION && std::is_same_v<DTypeQ_P, half>, half,
+                                float>::type;
+
+  const uint32_t group_size = num_qo_heads / num_kv_heads;
+  constexpr uint32_t NUM_MMA_D_QK = HEAD_DIM_QK / 16;
+  constexpr uint32_t NUM_MMA_D_VO = HEAD_DIM_VO / 16;
+
+  using DTypeQ_D = typename DecodeParams::DTypeQ;
+  using DTypeKV_D = typename DecodeParams::DTypeKV;
+  using DTypeO_D = typename DecodeParams::DTypeO;
+  const uint32_t padded_batch_size_d = decode_params.padded_batch_size;
+  constexpr uint32_t NUM_MMA_Q_D = get_num_mma_q(CTA_TILE_Q_D);
+  constexpr uint32_t NUM_WARPS_Q_D = get_num_warps_q(CTA_TILE_Q_D);
+  constexpr uint32_t NUM_WARPS_KV_D = get_num_warps_kv(CTA_TILE_Q_D);
+
+  using DTypeQKAccum_D =
+      typename std::conditional<USE_FP16_QK_REDUCTION && std::is_same_v<DTypeQ_D, half>, half,
+                                float>::type;
+
+  const int num_ctas_per_sm = max_smem_per_sm > (16 * HEAD_DIM_QK * sizeof(DTypeQ_D) * 16) ? 2 : 1;
+  const int max_smem_per_threadblock = max_smem_per_sm / num_ctas_per_sm;
+
+  constexpr uint32_t max_num_mma_kv_reg_p =
+      (HEAD_DIM_VO >= 128 && NUM_MMA_Q_P == 2 && POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
+       !USE_FP16_QK_REDUCTION)
+          ? 2
+          : (8 / NUM_MMA_Q_P);
+  const uint32_t max_num_mma_kv_smem_p =
+      (max_smem_per_threadblock / (16 * HEAD_DIM_QK * sizeof(DTypeQ_P)) -
+       NUM_MMA_Q_P * NUM_WARPS_Q_P) /
+      (2 * NUM_WARPS_KV_P);
+
+  constexpr uint32_t max_num_mma_kv_reg_d =
+      (HEAD_DIM_VO >= 128 && NUM_MMA_Q_D == 2 && POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
+       !USE_FP16_QK_REDUCTION)
+          ? 2
+          : (8 / NUM_MMA_Q_D);
+  const uint32_t max_num_mma_kv_smem_d =
+      (max_smem_per_threadblock / (16 * HEAD_DIM_QK * sizeof(DTypeQ_D)) -
+       NUM_MMA_Q_D * NUM_WARPS_Q_D) /
+      (2 * NUM_WARPS_KV_D);
+
+  DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem_p, max_num_mma_kv_reg_p), NUM_MMA_KV_P, {
+    using KTraits_P = KernelTraits<MASK_MODE_P, CTA_TILE_Q_P, NUM_MMA_Q_P, NUM_MMA_KV_P,
+                                   NUM_MMA_D_QK, NUM_MMA_D_VO, NUM_WARPS_Q_P, NUM_WARPS_KV_P,
+                                   POS_ENCODING_MODE, DTypeQ_P, DTypeKV_P, DTypeO_P, DTypeQKAccum_P,
+                                   typename PrefillParams::IdType, PrefillAttentionVariant>;
+
+    if constexpr (KTraits_P::IsInvalid()) {
+      std::ostringstream err_msg;
+      err_msg << "FlashInfer Internal Error: Invalid batch prefill configuration";
+      FLASHINFER_ERROR(err_msg.str());
+    } else {
+      DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem_d, max_num_mma_kv_reg_d), NUM_MMA_KV_D, {
+        using KTraits_D =
+            KernelTraits<MASK_MODE_D, CTA_TILE_Q_D, NUM_MMA_Q_D, NUM_MMA_KV_D, NUM_MMA_D_QK,
+                         NUM_MMA_D_VO, NUM_WARPS_Q_D, NUM_WARPS_KV_D, POS_ENCODING_MODE, DTypeQ_D,
+                         DTypeKV_D, DTypeO_D, DTypeQKAccum_D, typename DecodeParams::IdType,
+                         DecodeAttentionVariant>;
+        if constexpr (KTraits_D::IsInvalid()) {
+          std::ostringstream err_msg;
+          err_msg << "FlashInfer Internal Error: Invalid batch decode configuration";
+          FLASHINFER_ERROR(err_msg.str());
+        } else {
+          size_t smem_size_p = sizeof(typename KTraits_P::SharedStorage);
+          size_t smem_size_d = sizeof(typename KTraits_D::SharedStorage);
+
+          auto kernel =
+              BatchPODWithKVCacheTensorKernel<KTraits_P, KTraits_D, PrefillParams, DecodeParams>;
+
+          auto o_p = prefill_params.o;
+          auto lse_p = prefill_params.lse;
+          if (tmp_v_p == nullptr) {
+            prefill_params.partition_kv = false;
+          } else {
+            prefill_params.partition_kv = true;
+            prefill_params.o = tmp_v_p;
+            prefill_params.lse = tmp_s_p;
+          }
+
+          auto o_d = decode_params.o;
+          auto lse_d = decode_params.lse;
+          if (tmp_v_d == nullptr) {
+            decode_params.partition_kv = false;
+          } else {
+            decode_params.partition_kv = true;
+            decode_params.o = tmp_v_d;
+            decode_params.lse = tmp_s_d;
+          }
+
+          int nblks_p(padded_batch_size_p * 1 * num_kv_heads);
+          int nthrs_p(KTraits_P::NUM_THREADS);
+
+          int nblks_d(padded_batch_size_d * 1 * num_kv_heads);
+          int nthrs_d(KTraits_D::NUM_THREADS);
+
+          size_t smem_size = max(smem_size_p, smem_size_d);
+          int nblks = nblks_p + nblks_d;
+          int nthrs = max(nthrs_p, nthrs_d);
+
+          int num_sm = 0;
+          FI_GPU_CALL(gpuDeviceGetAttribute(&num_sm, gpuDevAttrMultiProcessorCount, dev_id));
+          FI_GPU_CALL(gpuMemset(sm_aware_sched, 0, sizeof(int) * (num_sm + 2)));
+
+          FI_GPU_CALL(
+              gpuFuncSetAttribute(kernel, gpuFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+
+          void* args[] = {(void*)&prefill_params, (void*)&decode_params, (void*)&sm_aware_sched,
+                          (void*)&num_sm};
+          FI_GPU_CALL(gpuLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+
+          if (tmp_v_p != nullptr) {
+            if constexpr (PrefillAttentionVariant::use_softmax) {
+              FI_GPU_CALL(VariableLengthMergeStates(tmp_v_p, tmp_s_p, prefill_params.merge_indptr,
+                                                    o_p, lse_p, prefill_params.max_total_num_rows,
+                                                    prefill_params.total_num_rows, num_qo_heads,
+                                                    HEAD_DIM_VO, stream));
+            } else {
+              FI_GPU_CALL(VariableLengthAttentionSum(
+                  tmp_v_p, prefill_params.merge_indptr, o_p, prefill_params.max_total_num_rows,
+                  prefill_params.total_num_rows, num_qo_heads, HEAD_DIM_VO, stream));
+            }
+          }
+          if (tmp_v_d != nullptr) {
+            if constexpr (DecodeAttentionVariant::use_softmax) {
+              FI_GPU_CALL(VariableLengthMergeStates(tmp_v_d, tmp_s_d, decode_params.merge_indptr,
+                                                    o_d, lse_d, decode_params.max_total_num_rows,
+                                                    decode_params.total_num_rows, num_qo_heads,
+                                                    HEAD_DIM_VO, stream));
+            } else {
+              FI_GPU_CALL(VariableLengthAttentionSum(
+                  tmp_v_d, decode_params.merge_indptr, o_d, decode_params.max_total_num_rows,
+                  decode_params.total_num_rows, num_qo_heads, HEAD_DIM_VO, stream));
+            }
+          }
+        }
+      });
+    }
+  });
+  return gpuSuccess;
+}
+
+}  // namespace flashinfer

--- a/include/flashinfer/attention/generic/pod.cuh
+++ b/include/flashinfer/attention/generic/pod.cuh
@@ -44,21 +44,34 @@ __global__ __launch_bounds__(std::max(
 
   int op;
   int linear_bid;
-  // SM-aware CTA scheduler
   if (threadIdx.x == 0) {
     constexpr int blk_factor_p = 1;
     constexpr int blk_factor_d = 1;
 
-    // Find out which CU this threadblock is scheduled on
     linear_bid = static_cast<int>(gpu_iface::get_processor_id() % static_cast<uint32_t>(num_SMs));
     const int prefill_slots = (prefill_blocks + blk_factor_p - 1) / blk_factor_p;
     const int decode_slots = (decode_blocks + blk_factor_d - 1) / blk_factor_d;
 
-    if (prefill_slots <= decode_slots) {
+    if (prefill_slots == 0) {
+      op = POD_DECODE;
+      linear_bid = atomicAdd(&tbAssign[num_SMs + op], 1);
+    } else if (decode_slots == 0) {
+      op = POD_PREFILL;
+      linear_bid = atomicAdd(&tbAssign[num_SMs + op], 1);
+    } else if (prefill_slots <= decode_slots) {
       const int total_tags = decode_slots / prefill_slots + 1;
       op = (atomicAdd(&tbAssign[linear_bid], 1) % total_tags);
       if (op > 0) {
         op = 1;
+      }
+      linear_bid = atomicAdd(&tbAssign[num_SMs + op], 1);
+      // If this CU has exhausted its quota for the chosen op, steal work from the other op.
+      if (op == 0 && linear_bid >= prefill_slots) {
+        linear_bid = atomicAdd(&tbAssign[num_SMs + 1], 1);
+        op = !op;
+      } else if (op == 1 && linear_bid >= decode_slots) {
+        op = !op;
+        linear_bid = atomicAdd(&tbAssign[num_SMs + 0], 1);
       }
     } else {
       const int pref_tags = prefill_slots / decode_slots;
@@ -68,19 +81,16 @@ __global__ __launch_bounds__(std::max(
       } else {
         op = 1;
       }
+      linear_bid = atomicAdd(&tbAssign[num_SMs + op], 1);
+      // If this CU has exhausted its quota for the chosen op, steal work from the other op.
+      if (op == 0 && linear_bid >= prefill_slots) {
+        linear_bid = atomicAdd(&tbAssign[num_SMs + 1], 1);
+        op = !op;
+      } else if (op == 1 && linear_bid >= decode_slots) {
+        op = !op;
+        linear_bid = atomicAdd(&tbAssign[num_SMs + 0], 1);
+      }
     }
-
-    // Get the next blockId for that operation
-    linear_bid = atomicAdd(&tbAssign[num_SMs + op], 1);
-    // If the blockId obtained exceeds the max blockIds for that op, switch to the other op
-    if (op == 0 && linear_bid >= prefill_slots) {
-      linear_bid = atomicAdd(&tbAssign[num_SMs + 1], 1);
-      op = !op;
-    } else if (op == 1 && linear_bid >= decode_slots) {
-      op = !op;
-      linear_bid = atomicAdd(&tbAssign[num_SMs + 0], 1);
-    }
-    // Write the blockId and operation to shared memory
     ((int*)smem)[0] = linear_bid;
     ((int*)smem)[1] = op;
   }
@@ -110,7 +120,7 @@ __global__ __launch_bounds__(std::max(
       SinglePrefillWithKVCacheDevice<KTraits_P>(prefill_params, smem_storage, tid, bx, chunk_idx,
                                                 kv_head_idx, num_chunks, num_kv_heads_p);
     }
-  } else /* OP == DECODE */ {
+  } else {  // POD_DECODE
     auto& smem_storage = reinterpret_cast<typename KTraits_D::SharedStorage&>(smem);
     if (linear_bid >= decode_blocks) return;
 
@@ -310,7 +320,6 @@ gpuError_t PODWithKVCacheTensorDispatched(PrefillParams prefill_params,
             FI_GPU_CALL(
                 gpuFuncSetAttribute(kernel, gpuFuncAttributeMaxDynamicSharedMemorySize, smem_size));
 
-            // Launch kernel (no PDL on HIP)
             void* args[] = {(void*)&xsize, (void*)&prefill_params, (void*)&decode_params,
                             (void*)&tbAssign, (void*)&num_sm};
             FI_GPU_CALL(gpuLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));

--- a/include/flashinfer/attention/generic/pod.cuh
+++ b/include/flashinfer/attention/generic/pod.cuh
@@ -1,0 +1,347 @@
+// SPDX-FileCopyrightText: 2025 FlashInfer team.
+// SPDX-FileCopyrightText: 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "cascade.cuh"
+#include "dispatch.cuh"
+#include "gpu_iface/gpu_runtime_compat.hpp"
+#include "gpu_iface/math_ops.hpp"
+#include "gpu_iface/platform.hpp"
+#include "gpu_iface/sm_id.hpp"
+#include "gpu_iface/utils.cuh"
+#include "prefill.cuh"
+#include "variants.cuh"
+
+namespace flashinfer {
+
+enum PODOperation {
+  POD_PREFILL = 0,
+  POD_DECODE = 1,
+};
+
+template <typename KTraits_P, typename KTraits_D, bool PartitionKV_P, typename PrefillParams,
+          typename DecodeParams>
+__global__ __launch_bounds__(std::max(
+    KTraits_P::NUM_THREADS,
+    KTraits_D::NUM_THREADS)) void PODWithKVCacheTensorKernel(const uint32_t xsize,
+                                                             const __grid_constant__ PrefillParams
+                                                                 prefill_params,
+                                                             const __grid_constant__ DecodeParams
+                                                                 decode_params,
+                                                             int* tbAssign, int num_SMs) {
+  extern __shared__ uint8_t smem[];
+  const uint32_t num_kv_heads_p = prefill_params.num_kv_heads;
+  const uint32_t num_chunks = prefill_params.partition_kv;
+  const uint32_t qo_len = prefill_params.qo_len;
+
+  const uint32_t padded_bsize = decode_params.padded_batch_size;
+  const uint32_t num_kv_heads_d = decode_params.paged_kv.num_heads;
+
+  const uint32_t prefill_blocks = num_kv_heads_p * xsize * (PartitionKV_P ? num_chunks : 1);
+  const uint32_t decode_blocks = padded_bsize * num_kv_heads_d;
+
+  int op;
+  int linear_bid;
+  // SM-aware CTA scheduler
+  if (threadIdx.x == 0) {
+    constexpr int blk_factor_p = 1;
+    constexpr int blk_factor_d = 1;
+
+    // Find out which CU this threadblock is scheduled on
+    linear_bid = static_cast<int>(gpu_iface::get_processor_id() % static_cast<uint32_t>(num_SMs));
+    const int prefill_slots = (prefill_blocks + blk_factor_p - 1) / blk_factor_p;
+    const int decode_slots = (decode_blocks + blk_factor_d - 1) / blk_factor_d;
+
+    if (prefill_slots <= decode_slots) {
+      const int total_tags = decode_slots / prefill_slots + 1;
+      op = (atomicAdd(&tbAssign[linear_bid], 1) % total_tags);
+      if (op > 0) {
+        op = 1;
+      }
+    } else {
+      const int pref_tags = prefill_slots / decode_slots;
+      op = (atomicAdd(&tbAssign[linear_bid], 1) % (pref_tags + 1));
+      if (op < pref_tags) {
+        op = 0;
+      } else {
+        op = 1;
+      }
+    }
+
+    // Get the next blockId for that operation
+    linear_bid = atomicAdd(&tbAssign[num_SMs + op], 1);
+    // If the blockId obtained exceeds the max blockIds for that op, switch to the other op
+    if (op == 0 && linear_bid >= prefill_slots) {
+      linear_bid = atomicAdd(&tbAssign[num_SMs + 1], 1);
+      op = !op;
+    } else if (op == 1 && linear_bid >= decode_slots) {
+      op = !op;
+      linear_bid = atomicAdd(&tbAssign[num_SMs + 0], 1);
+    }
+    // Write the blockId and operation to shared memory
+    ((int*)smem)[0] = linear_bid;
+    ((int*)smem)[1] = op;
+  }
+  __syncthreads();
+  linear_bid = ((int*)smem)[0];
+  op = ((int*)smem)[1];
+  __syncthreads();
+
+  if (op == POD_PREFILL) {
+    const uint32_t linear_tid = threadIdx.x;
+    if (linear_tid >= WARP_SIZE * KTraits_P::NUM_WARPS_Q * KTraits_P::NUM_WARPS_KV) return;
+
+    const dim3 tid = dim3(linear_tid % WARP_SIZE, (linear_tid / WARP_SIZE) % KTraits_P::NUM_WARPS_Q,
+                          (linear_tid / WARP_SIZE) / KTraits_P::NUM_WARPS_Q);
+    if (linear_bid >= prefill_blocks) return;
+
+    const uint32_t bx = linear_bid % xsize;
+    auto& smem_storage = reinterpret_cast<typename KTraits_P::SharedStorage&>(smem);
+    if constexpr (!PartitionKV_P) {
+      const uint32_t chunk_idx = 0;
+      const uint32_t kv_head_idx = linear_bid / xsize;
+      SinglePrefillWithKVCacheDevice<KTraits_P>(prefill_params, smem_storage, tid, bx, chunk_idx,
+                                                kv_head_idx, 1, num_kv_heads_p);
+    } else {
+      const uint32_t chunk_idx = (linear_bid / xsize) % num_chunks;
+      const uint32_t kv_head_idx = linear_bid / (xsize * num_chunks);
+      SinglePrefillWithKVCacheDevice<KTraits_P>(prefill_params, smem_storage, tid, bx, chunk_idx,
+                                                kv_head_idx, num_chunks, num_kv_heads_p);
+    }
+  } else /* OP == DECODE */ {
+    auto& smem_storage = reinterpret_cast<typename KTraits_D::SharedStorage&>(smem);
+    if (linear_bid >= decode_blocks) return;
+
+    const uint32_t bx = linear_bid % padded_bsize;
+    const uint32_t kv_head_idx = linear_bid / padded_bsize;
+
+    const uint32_t linear_tid = threadIdx.x;
+    if (linear_tid >= WARP_SIZE * KTraits_D::NUM_WARPS_Q * KTraits_D::NUM_WARPS_KV) return;
+
+    const dim3 tid = dim3(linear_tid % WARP_SIZE, (linear_tid / WARP_SIZE) % KTraits_D::NUM_WARPS_Q,
+                          (linear_tid / WARP_SIZE) / KTraits_D::NUM_WARPS_Q);
+
+    BatchPrefillWithPagedKVCacheDevice<KTraits_D>(decode_params, smem_storage, tid, bx, kv_head_idx,
+                                                  num_kv_heads_d);
+  }
+}
+
+template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, PosEncodingMode POS_ENCODING_MODE,
+          bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE_P, uint32_t CTA_TILE_Q_D,
+          MaskMode MASK_MODE_D, typename PrefillAttentionVariant, typename DecodeAttentionVariant,
+          typename PrefillParams, typename DecodeParams>
+gpuError_t PODWithKVCacheTensorDispatched(PrefillParams prefill_params,
+                                          typename PrefillParams::DTypeO* tmp_p,
+                                          DecodeParams decode_params,
+                                          typename DecodeParams::DTypeO* tmp_v, float* tmp_s,
+                                          bool /*enable_pdl*/, gpuStream_t stream) {
+  static_assert(std::is_same<typename PrefillParams::DTypeQ, typename DecodeParams::DTypeQ>::value);
+  static_assert(
+      std::is_same<typename PrefillParams::DTypeKV, typename DecodeParams::DTypeKV>::value);
+  static_assert(std::is_same<typename PrefillParams::DTypeO, typename DecodeParams::DTypeO>::value);
+  assert(prefill_params.num_kv_heads == decode_params.paged_kv.num_heads);
+  assert(prefill_params.num_qo_heads == decode_params.num_qo_heads);
+
+  using DTypeQ_P = typename PrefillParams::DTypeQ;
+  using DTypeKV_P = typename PrefillParams::DTypeKV;
+  using DTypeO_P = typename PrefillParams::DTypeO;
+  const uint32_t num_qo_heads = prefill_params.num_qo_heads;
+  const uint32_t num_kv_heads = prefill_params.num_kv_heads;
+  const uint32_t qo_len = prefill_params.qo_len;
+  const uint32_t kv_len = prefill_params.kv_len;
+  if (kv_len < qo_len && MASK_MODE_P == MaskMode::kCausal) {
+    std::ostringstream err_msg;
+    err_msg << "When mask_mode is set to MaskMode::kCausal, kv_len must be >= qo_len, got kv_len="
+            << kv_len << " qo_len=" << qo_len;
+    FLASHINFER_ERROR(err_msg.str());
+  }
+
+  const uint32_t group_size = num_qo_heads / num_kv_heads;
+  const uint_fastdiv group_size_fastdiv(group_size);
+  constexpr uint32_t NUM_MMA_D_QK = HEAD_DIM_QK / 16;
+  constexpr uint32_t NUM_MMA_D_VO = HEAD_DIM_VO / 16;
+
+  int64_t unpacked_qo_len = static_cast<int64_t>(qo_len) * group_size;
+  uint32_t cta_tile_q_p = FA2DetermineCtaTileQ(unpacked_qo_len, HEAD_DIM_QK);
+
+  using DTypeQ_D = typename DecodeParams::DTypeQ;
+  using DTypeKV_D = typename DecodeParams::DTypeKV;
+  using DTypeO_D = typename DecodeParams::DTypeO;
+  const uint32_t padded_batch_size_d = decode_params.padded_batch_size;
+  constexpr uint32_t NUM_MMA_Q_D = get_num_mma_q(CTA_TILE_Q_D);
+  constexpr uint32_t NUM_WARPS_Q_D = get_num_warps_q(CTA_TILE_Q_D);
+  constexpr uint32_t NUM_WARPS_KV_D = get_num_warps_kv(CTA_TILE_Q_D);
+
+  if (padded_batch_size_d == 0) {
+    return gpuSuccess;
+  }
+
+  using DTypeQKAccum_D =
+      typename std::conditional<USE_FP16_QK_REDUCTION && std::is_same_v<DTypeQ_D, half>, half,
+                                float>::type;
+
+  int dev_id = 0;
+  FI_GPU_CALL(gpuGetDevice(&dev_id));
+  int max_smem_per_sm = getMaxSharedMemPerMultiprocessor(dev_id);
+  const int num_ctas_per_sm = max_smem_per_sm > (16 * HEAD_DIM_QK * sizeof(DTypeQ_D) * 16) ? 2 : 1;
+  const int max_smem_per_threadblock = max_smem_per_sm / num_ctas_per_sm;
+
+  constexpr uint32_t max_num_mma_kv_reg_d =
+      (HEAD_DIM_VO >= 128 && NUM_MMA_Q_D == 2 && POS_ENCODING_MODE == PosEncodingMode::kRoPELlama &&
+       !USE_FP16_QK_REDUCTION)
+          ? 2
+          : (8 / NUM_MMA_Q_D);
+  const uint32_t max_num_mma_kv_smem_d =
+      (max_smem_per_threadblock / (16 * HEAD_DIM_QK * sizeof(DTypeQ_D)) -
+       NUM_MMA_Q_D * NUM_WARPS_Q_D) /
+      (2 * NUM_WARPS_KV_D);
+
+  DISPATCH_CTA_TILE_Q(cta_tile_q_p, CTA_TILE_Q_P, {
+    constexpr uint32_t NUM_WARPS_Q_P = get_num_warps_q(CTA_TILE_Q_P);
+    constexpr uint32_t NUM_WARPS_KV_P = get_num_warps_kv(CTA_TILE_Q_P);
+    constexpr uint32_t NUM_MMA_Q_P = get_num_mma_q(CTA_TILE_Q_P);
+
+    using DTypeQKAccum_P =
+        typename std::conditional<USE_FP16_QK_REDUCTION && std::is_same_v<DTypeQ_P, half>, half,
+                                  float>::type;
+
+    const int num_ctas_per_sm_p =
+        max_smem_per_sm > (16 * HEAD_DIM_QK * sizeof(DTypeQ_P) * 16) ? 2 : 1;
+    const int max_smem_per_threadblock_p = max_smem_per_sm / num_ctas_per_sm_p;
+
+    constexpr uint32_t max_num_mma_kv_reg_p =
+        (HEAD_DIM_VO >= 128 && NUM_MMA_Q_P == 2 &&
+         POS_ENCODING_MODE == PosEncodingMode::kRoPELlama && !USE_FP16_QK_REDUCTION)
+            ? 2
+            : (8 / NUM_MMA_Q_P);
+    const uint32_t max_num_mma_kv_smem_p =
+        (max_smem_per_threadblock_p / (16 * HEAD_DIM_QK * sizeof(DTypeQ_P)) -
+         NUM_MMA_Q_P * NUM_WARPS_Q_P) /
+        (2 * NUM_WARPS_KV_P);
+
+    DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem_p, max_num_mma_kv_reg_p), NUM_MMA_KV_P, {
+      using KTraits_P =
+          KernelTraits<MASK_MODE_P, CTA_TILE_Q_P, NUM_MMA_Q_P, NUM_MMA_KV_P, NUM_MMA_D_QK,
+                       NUM_MMA_D_VO, NUM_WARPS_Q_P, NUM_WARPS_KV_P, POS_ENCODING_MODE, DTypeQ_P,
+                       DTypeKV_P, DTypeO_P, DTypeQKAccum_P, typename PrefillParams::IdType,
+                       PrefillAttentionVariant>;
+
+      if constexpr (KTraits_P::IsInvalid()) {
+        std::ostringstream err_msg;
+        err_msg << "FlashInfer Internal Error: Invalid prefill configuration";
+        FLASHINFER_ERROR(err_msg.str());
+      } else {
+        DISPATCH_NUM_MMA_KV(min(max_num_mma_kv_smem_d, max_num_mma_kv_reg_d), NUM_MMA_KV_D, {
+          using KTraits_D =
+              KernelTraits<MASK_MODE_D, CTA_TILE_Q_D, NUM_MMA_Q_D, NUM_MMA_KV_D, NUM_MMA_D_QK,
+                           NUM_MMA_D_VO, NUM_WARPS_Q_D, NUM_WARPS_KV_D, POS_ENCODING_MODE, DTypeQ_D,
+                           DTypeKV_D, DTypeO_D, DTypeQKAccum_D, typename DecodeParams::IdType,
+                           DecodeAttentionVariant>;
+          if constexpr (KTraits_D::IsInvalid()) {
+            std::ostringstream err_msg;
+            err_msg << "FlashInfer Internal Error: Invalid decode configuration";
+            FLASHINFER_ERROR(err_msg.str());
+          } else {
+            constexpr uint32_t num_threads_p = KTraits_P::NUM_THREADS;
+            size_t smem_size_p = sizeof(typename KTraits_P::SharedStorage);
+            size_t smem_size_d = sizeof(typename KTraits_D::SharedStorage);
+
+            auto kernel =
+                PODWithKVCacheTensorKernel<KTraits_P, KTraits_D, true, PrefillParams, DecodeParams>;
+
+            int num_blocks_per_sm = 0;
+            int num_sm = 0;
+            FI_GPU_CALL(gpuDeviceGetAttribute(&num_sm, gpuDevAttrMultiProcessorCount, dev_id));
+            num_blocks_per_sm = std::max(
+                1, std::min((int)(max_smem_per_sm / smem_size_p), (int)(256 / num_threads_p)));
+            uint32_t max_num_kv_chunks =
+                (num_blocks_per_sm * num_sm) /
+                (num_kv_heads * ceil_div(qo_len * group_size, KTraits_P::CTA_TILE_Q));
+            uint32_t num_chunks;
+            if (max_num_kv_chunks > 0) {
+              uint32_t chunk_size = max(ceil_div(kv_len, max_num_kv_chunks), 256u);
+              num_chunks = ceil_div(kv_len, chunk_size);
+            } else {
+              num_chunks = 0;
+            }
+
+            auto o_p = prefill_params.o;
+            auto lse_p = prefill_params.lse;
+            float* tmp_lse = (float*)(tmp_p + num_chunks * qo_len * num_qo_heads * HEAD_DIM_VO);
+            if (num_chunks <= 1 || tmp_p == nullptr) {
+              prefill_params.partition_kv = 0;
+              kernel = PODWithKVCacheTensorKernel<KTraits_P, KTraits_D, false, PrefillParams,
+                                                  DecodeParams>;
+            } else {
+              prefill_params.partition_kv = num_chunks;
+              prefill_params.o = tmp_p;
+              prefill_params.lse = tmp_lse;
+              kernel = PODWithKVCacheTensorKernel<KTraits_P, KTraits_D, true, PrefillParams,
+                                                  DecodeParams>;
+            }
+
+            auto o_d = decode_params.o;
+            auto lse_d = decode_params.lse;
+            if (tmp_v == nullptr) {
+              decode_params.partition_kv = false;
+            } else {
+              decode_params.partition_kv = true;
+              decode_params.o = tmp_v;
+              decode_params.lse = tmp_s;
+            }
+            uint32_t xsize = ceil_div(qo_len * group_size, KTraits_P::CTA_TILE_Q);
+            int nblks_p(xsize * (prefill_params.partition_kv ? prefill_params.partition_kv : 1) *
+                        num_kv_heads);
+            int nthrs_p(KTraits_P::NUM_THREADS);
+
+            int nblks_d = padded_batch_size_d * num_kv_heads;
+            int nthrs_d(KTraits_D::NUM_THREADS);
+
+            size_t smem_size = max(smem_size_p, smem_size_d);
+            int nblks = nblks_p + nblks_d;
+            int nthrs = max(nthrs_p, nthrs_d);
+
+            static int* tbAssign = nullptr;
+            if (tbAssign == nullptr) FI_GPU_CALL(gpuMalloc(&tbAssign, sizeof(int) * (num_sm + 2)));
+            FI_GPU_CALL(gpuMemset(tbAssign, 0, sizeof(int) * (num_sm + 2)));
+
+            FI_GPU_CALL(
+                gpuFuncSetAttribute(kernel, gpuFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+
+            // Launch kernel (no PDL on HIP)
+            void* args[] = {(void*)&xsize, (void*)&prefill_params, (void*)&decode_params,
+                            (void*)&tbAssign, (void*)&num_sm};
+            FI_GPU_CALL(gpuLaunchKernel((void*)kernel, nblks, nthrs, args, smem_size, stream));
+
+            if (!(num_chunks <= 1 || tmp_p == nullptr)) {
+              if constexpr (PrefillAttentionVariant::use_softmax) {
+                FI_GPU_CALL(MergeStates(tmp_p, tmp_lse, o_p, lse_p, num_chunks, qo_len,
+                                        num_qo_heads, HEAD_DIM_VO, stream));
+              } else {
+                FI_GPU_CALL(AttentionSum(tmp_p, o_p, num_chunks, qo_len, num_qo_heads, HEAD_DIM_VO,
+                                         stream));
+              }
+            }
+            if (tmp_v != nullptr) {
+              if constexpr (DecodeAttentionVariant::use_softmax) {
+                FI_GPU_CALL(VariableLengthMergeStates(tmp_v, tmp_s, decode_params.merge_indptr, o_d,
+                                                      lse_d, decode_params.max_total_num_rows,
+                                                      decode_params.total_num_rows, num_qo_heads,
+                                                      HEAD_DIM_VO, stream));
+              } else {
+                FI_GPU_CALL(VariableLengthAttentionSum(
+                    tmp_v, decode_params.merge_indptr, o_d, decode_params.max_total_num_rows,
+                    decode_params.total_num_rows, num_qo_heads, HEAD_DIM_VO, stream));
+              }
+            }
+          }
+        });
+      }
+    });
+  });
+  return gpuSuccess;
+}
+
+}  // namespace flashinfer

--- a/include/flashinfer/attention/generic/prefill.cuh
+++ b/include/flashinfer/attention/generic/prefill.cuh
@@ -958,7 +958,7 @@ __device__ __forceinline__ void compute_sfm_v(
     uint32_t* v_smem_offset_r,
     typename KTraits::DTypeQKAccum (*s_frag)[KTraits::NUM_MMA_KV][KTraits::HALF_ELEMS_PER_THREAD],
     float (*o_frag)[KTraits::NUM_MMA_D_VO][KTraits::HALF_ELEMS_PER_THREAD],
-    float (*d)[KTraits::NUM_ACCUM_ROWS_PER_THREAD]) {
+    float (*d)[KTraits::NUM_ACCUM_ROWS_PER_THREAD], const dim3 tid = threadIdx) {
   constexpr uint32_t UPCAST_STRIDE_V = KTraits::UPCAST_STRIDE_V;
   constexpr uint32_t HALF_ELEMS_PER_THREAD = KTraits::HALF_ELEMS_PER_THREAD;
   constexpr uint32_t INT32_ELEMS_PER_THREAD = KTraits::INT32_ELEMS_PER_THREAD;
@@ -1004,9 +1004,9 @@ __device__ __forceinline__ void compute_sfm_v(
 #pragma unroll
   for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
     // v_col_idx: current column j of *v_smem_offset_r before each advance_offset_by_column.
-    // Reset per KV row: each row's V fragment starts at column threadIdx.x / WARP_THREAD_COLS.
+    // Reset per KV row: each row's V fragment starts at column tid.x / WARP_THREAD_COLS.
     // Needed by k128B_16Row; ignored by k128B.
-    uint32_t v_col_idx = threadIdx.x / KTraits::WARP_THREAD_COLS;
+    uint32_t v_col_idx = tid.x / KTraits::WARP_THREAD_COLS;
 #pragma unroll
     for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_VO; ++mma_d) {
       uint32_t b_frag[INT32_ELEMS_PER_THREAD];
@@ -1541,7 +1541,7 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
       block.sync();
     }
     // compute attention score
-    compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag);
+    compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag, tid);
     // logits transformation
     logits_transform<KTraits>(
         params, variant, /*batch_idx=*/0, qo_packed_idx_base,
@@ -1564,7 +1564,7 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
     block.sync();
 
     // compute sfm*v
-    compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r, s_frag, o_frag, d);
+    compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r, s_frag, o_frag, d, tid);
     block.sync();
     produce_kv<true, SharedMemFillMode::kFillZero, KTraits>(
         v_smem, &v_smem_offset_w, &v_ptr, v_stride_n, (iter + 1) * CTA_TILE_KV, chunk_size, tid);
@@ -2278,7 +2278,7 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
     }
 
     // compute attention score
-    compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag);
+    compute_qk<KTraits>(&qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r, s_frag, tid);
 
     logits_transform<KTraits>(
         params, variant, /*batch_idx=*/request_idx, qo_packed_idx_base,
@@ -2304,7 +2304,7 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
     block.sync();
 
     // compute sfm*v
-    compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r, s_frag, o_frag, d);
+    compute_sfm_v<KTraits>(&v_smem, &v_smem_offset_r, s_frag, o_frag, d, tid);
 
     block.sync();
     page_produce_kv<true, KTraits>(v_smem, &v_smem_offset_w, paged_kv, (iter + 1) * CTA_TILE_KV,

--- a/include/flashinfer/attention/pod.cuh
+++ b/include/flashinfer/attention/pod.cuh
@@ -77,7 +77,13 @@ __global__ __launch_bounds__(std::max(
     const int prefill_slots = (prefill_blocks + blk_factor_p - 1) / blk_factor_p;
     const int decode_slots = (decode_blocks + blk_factor_d - 1) / blk_factor_d;
 
-    if (prefill_slots <= decode_slots) {
+    if (prefill_slots == 0) {
+      op = DECODE;
+      linear_bid = atomicAdd(&tbAssign[num_SMs + op], 1);
+    } else if (decode_slots == 0) {
+      op = PREFILL;
+      linear_bid = atomicAdd(&tbAssign[num_SMs + op], 1);
+    } else if (prefill_slots <= decode_slots) {
       // Total tags = (decode + prefill) / min(decode, prefill)
       // = 1 + decode / prefill; when prefill < decode
       const int total_tags = decode_slots / prefill_slots + 1;
@@ -85,6 +91,16 @@ __global__ __launch_bounds__(std::max(
       op = (atomicAdd(&tbAssign[linear_bid], 1) % total_tags);
       if (op > 0) {
         op = 1;
+      }
+      // Get the next blockId for that operation
+      linear_bid = atomicAdd(&tbAssign[num_SMs + op], 1);
+      // If the blockId obtained exceeds the max blockIds for that op, switch to the other op
+      if (op == 0 && linear_bid >= prefill_slots) {
+        linear_bid = atomicAdd(&tbAssign[num_SMs + 1], 1);
+        op = !op;
+      } else if (op == 1 && linear_bid >= decode_slots) {
+        op = !op;
+        linear_bid = atomicAdd(&tbAssign[num_SMs + 0], 1);
       }
     } else {
       // Total tags = (decode + prefill) / min(decode, prefill)
@@ -98,17 +114,16 @@ __global__ __launch_bounds__(std::max(
       } else {
         op = 1;
       }
-    }
-
-    // Get the next blockId for that operation
-    linear_bid = atomicAdd(&tbAssign[num_SMs + op], 1);
-    // If the blockId obtained exceeds the max blockIds for that op, switch to the other op
-    if (op == 0 && linear_bid >= prefill_slots) {
-      linear_bid = atomicAdd(&tbAssign[num_SMs + 1], 1);
-      op = !op;
-    } else if (op == 1 && linear_bid >= decode_slots) {
-      op = !op;
-      linear_bid = atomicAdd(&tbAssign[num_SMs + 0], 1);
+      // Get the next blockId for that operation
+      linear_bid = atomicAdd(&tbAssign[num_SMs + op], 1);
+      // If the blockId obtained exceeds the max blockIds for that op, switch to the other op
+      if (op == 0 && linear_bid >= prefill_slots) {
+        linear_bid = atomicAdd(&tbAssign[num_SMs + 1], 1);
+        op = !op;
+      } else if (op == 1 && linear_bid >= decode_slots) {
+        op = !op;
+        linear_bid = atomicAdd(&tbAssign[num_SMs + 0], 1);
+      }
     }
     // Write the blockId and operation to shared memory
     ((int*)smem)[0] = linear_bid;

--- a/include/gpu_iface/sm_id.hpp
+++ b/include/gpu_iface/sm_id.hpp
@@ -13,10 +13,11 @@ __device__ __forceinline__ uint32_t get_processor_id() {
   asm volatile("mov.u32 %0, %smid;" : "=r"(smid));
   return smid;
 #elif defined(PLATFORM_HIP_DEVICE)
-  // HW_ID register bits [15:8]: SE_ID[15:14] | SH_ID[13:12] | CU_ID[11:8].
-  // Together these 8 bits uniquely identify a CU across the chip.
-  // The caller passes num_SMs and we modulo for safety.
-  uint32_t hw_id = __builtin_amdgcn_s_getreg((4 | (0 << 6) | (31 << 11)));
+  // Read HW_ID (id=4, offset=0, size=32) and extract bits [15:8], which pack
+  // CU_ID | SH_ID | SE_ID into 8 bits that uniquely identify a CU across the chip.
+  // Encoding of s_getreg arg: (reg_id | (offset << 6) | ((size - 1) << 11)).
+  constexpr uint32_t HW_REG_HW_ID = 4;
+  uint32_t hw_id = __builtin_amdgcn_s_getreg(HW_REG_HW_ID | (0 << 6) | (31 << 11));
   return (hw_id >> 8) & 0xFF;
 #else
   return 0;

--- a/include/gpu_iface/sm_id.hpp
+++ b/include/gpu_iface/sm_id.hpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
+
 #include "macros.hpp"
 
 namespace flashinfer {

--- a/include/gpu_iface/sm_id.hpp
+++ b/include/gpu_iface/sm_id.hpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "macros.hpp"
+
+namespace flashinfer {
+namespace gpu_iface {
+
+__device__ __forceinline__ uint32_t get_processor_id() {
+#if defined(PLATFORM_CUDA_DEVICE)
+  uint32_t smid;
+  asm volatile("mov.u32 %0, %smid;" : "=r"(smid));
+  return smid;
+#elif defined(PLATFORM_HIP_DEVICE)
+  // HW_ID register bits [15:8]: SE_ID[15:14] | SH_ID[13:12] | CU_ID[11:8].
+  // Together these 8 bits uniquely identify a CU across the chip.
+  // The caller passes num_SMs and we modulo for safety.
+  uint32_t hw_id = __builtin_amdgcn_s_getreg((4 | (0 << 6) | (31 << 11)));
+  return (hw_id >> 8) & 0xFF;
+#else
+  return 0;
+#endif
+}
+
+}  // namespace gpu_iface
+}  // namespace flashinfer

--- a/tests/rocm_tests/test_batch_pod_hip.py
+++ b/tests/rocm_tests/test_batch_pod_hip.py
@@ -225,7 +225,7 @@ def test_batch_pod_bf16(q_dtype):
 
     float_buf = torch.empty(64 * 1024 * 1024, device=device, dtype=torch.uint8)
     prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-        float_buf, kv_layout
+        float_buf, kv_layout, backend="fa2"
     )
     prefill_wrapper.plan(
         qo_indptr_p,
@@ -245,7 +245,7 @@ def test_batch_pod_bf16(q_dtype):
 
     float_buf_d = torch.empty(64 * 1024 * 1024, device=device, dtype=torch.uint8)
     decode_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-        float_buf_d, kv_layout
+        float_buf_d, kv_layout, backend="fa2"
     )
     decode_wrapper.plan(
         qo_indptr_d,

--- a/tests/rocm_tests/test_batch_pod_hip.py
+++ b/tests/rocm_tests/test_batch_pod_hip.py
@@ -8,6 +8,15 @@ from jit_utils import gen_prefill_attention_modules
 import flashinfer
 from flashinfer.jit.attention import gen_batch_pod_module
 
+DEVICE = "cuda:0"
+HEAD_DIM = 128
+NUM_KV_HEADS = 8
+PAGE_SIZE = 16
+KV_LAYOUT = "NHD"
+POS_ENCODING_MODE = "NONE"
+REF_WORKSPACE_BYTES = 64 * 1024 * 1024
+POD_WORKSPACE_BYTES = 128 * 1024 * 1024
+
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
@@ -15,7 +24,7 @@ def warmup_jit():
         gen_prefill_attention_modules(
             [torch.float16],
             [torch.float16],
-            [128],
+            [HEAD_DIM],
             [0],
             [False],
             [False],
@@ -23,18 +32,18 @@ def warmup_jit():
         )
         + [
             gen_batch_pod_module(
-                torch.float16,  # dtype_q
-                torch.float16,  # dtype_kv
-                torch.float16,  # dtype_o
-                128,  # head_dim
-                0,  # pos_encoding_mode_p (NONE)
-                False,  # use_sliding_window_p
-                False,  # use_logits_soft_cap_p
-                False,  # use_fp16_qk_reduction
-                torch.int32,  # dtype_idx
-                0,  # pos_encoding_mode_d (NONE)
-                False,  # use_sliding_window_d
-                False,  # use_logits_soft_cap_d
+                torch.float16,
+                torch.float16,
+                torch.float16,
+                HEAD_DIM,
+                0,
+                False,
+                False,
+                False,
+                torch.int32,
+                0,
+                False,
+                False,
             )
         ],
         verbose=False,
@@ -42,9 +51,22 @@ def warmup_jit():
     yield
 
 
-def _make_paged_kv(
-    batch_size, kv_len, page_size, num_kv_heads, head_dim, dtype, device
-):
+@pytest.fixture(scope="module")
+def pod_workspace():
+    return torch.empty(POD_WORKSPACE_BYTES, device=DEVICE, dtype=torch.uint8)
+
+
+@pytest.fixture(scope="module")
+def ref_workspace_p():
+    return torch.empty(REF_WORKSPACE_BYTES, device=DEVICE, dtype=torch.uint8)
+
+
+@pytest.fixture(scope="module")
+def ref_workspace_d():
+    return torch.empty(REF_WORKSPACE_BYTES, device=DEVICE, dtype=torch.uint8)
+
+
+def _make_paged_kv(batch_size, kv_len, page_size, num_kv_heads, head_dim, dtype):
     num_pages_per_seq = (kv_len + page_size - 1) // page_size
     total_pages = num_pages_per_seq * batch_size
     kv_data = torch.randn(
@@ -53,117 +75,95 @@ def _make_paged_kv(
         page_size,
         num_kv_heads,
         head_dim,
-        device=device,
+        device=DEVICE,
         dtype=dtype,
     )
     kv_indptr = (
-        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32)
+        torch.arange(0, batch_size + 1, device=DEVICE, dtype=torch.int32)
         * num_pages_per_seq
     )
-    kv_indices = torch.arange(0, total_pages, device=device, dtype=torch.int32)
+    kv_indices = torch.arange(0, total_pages, device=DEVICE, dtype=torch.int32)
     last_page_len = torch.full(
         (batch_size,),
         (kv_len - 1) % page_size + 1,
-        device=device,
+        device=DEVICE,
         dtype=torch.int32,
     )
     return kv_data, kv_indptr, kv_indices, last_page_len
 
 
-@pytest.mark.parametrize("batch_size_p", [2, 4])
-@pytest.mark.parametrize("qo_len_p", [64, 256])
-@pytest.mark.parametrize("kv_len_p", [128, 512])
-@pytest.mark.parametrize("batch_size_d", [4, 16])
-@pytest.mark.parametrize("kv_len_d", [256, 1024])
-@pytest.mark.parametrize("page_size", [16])
-@pytest.mark.parametrize("num_qo_heads", [8, 32])
-@pytest.mark.parametrize("num_kv_heads", [8])
-@pytest.mark.parametrize("head_dim", [128])
-@pytest.mark.parametrize("q_dtype", [torch.float16])
-def test_batch_pod_with_paged_kv_cache(
-    batch_size_p,
-    qo_len_p,
-    kv_len_p,
-    batch_size_d,
-    kv_len_d,
-    page_size,
+def _make_prefill_inputs(batch_size, qo_len, kv_len, num_qo_heads, dtype):
+    total_qo = batch_size * qo_len
+    q = torch.randn(total_qo, num_qo_heads, HEAD_DIM, device=DEVICE, dtype=dtype)
+    kv_data, kv_indptr, kv_indices, last_page_len = _make_paged_kv(
+        batch_size, kv_len, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype
+    )
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, device=DEVICE, dtype=torch.int32) * qo_len
+    )
+    return q, kv_data, qo_indptr, kv_indptr, kv_indices, last_page_len
+
+
+def _make_decode_inputs(batch_size, kv_len, num_qo_heads, dtype):
+    q = torch.randn(batch_size, num_qo_heads, HEAD_DIM, device=DEVICE, dtype=dtype)
+    kv_data, kv_indptr, kv_indices, last_page_len = _make_paged_kv(
+        batch_size, kv_len, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype
+    )
+    qo_indptr = torch.arange(0, batch_size + 1, device=DEVICE, dtype=torch.int32)
+    return q, kv_data, qo_indptr, kv_indptr, kv_indices, last_page_len
+
+
+def _plan_ref_prefill(
+    workspace,
+    qo_indptr,
+    kv_indptr,
+    kv_indices,
+    last_page_len,
     num_qo_heads,
-    num_kv_heads,
-    head_dim,
-    q_dtype,
+    dtype,
+    causal,
+    backend="auto",
 ):
-    device = "cuda:0"
-    kv_dtype = q_dtype
-    kv_layout = "NHD"
-    pos_encoding_mode = "NONE"
-
-    # Prefill: each request has qo_len_p tokens attending to kv_len_p tokens
-    total_qo_p = batch_size_p * qo_len_p
-    q_p = torch.randn(total_qo_p, num_qo_heads, head_dim, device=device, dtype=q_dtype)
-    kv_data_p, kv_indptr_p, kv_indices_p, last_page_len_p = _make_paged_kv(
-        batch_size_p, kv_len_p, page_size, num_kv_heads, head_dim, kv_dtype, device
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        workspace, KV_LAYOUT, backend=backend
     )
-    qo_indptr_p = (
-        torch.arange(0, batch_size_p + 1, device=device, dtype=torch.int32) * qo_len_p
-    )
-
-    # Decode: each request has 1 token
-    q_d = torch.randn(
-        batch_size_d, num_qo_heads, head_dim, device=device, dtype=q_dtype
-    )
-    kv_data_d, kv_indptr_d, kv_indices_d, last_page_len_d = _make_paged_kv(
-        batch_size_d, kv_len_d, page_size, num_kv_heads, head_dim, kv_dtype, device
-    )
-    qo_indptr_d = torch.arange(0, batch_size_d + 1, device=device, dtype=torch.int32)
-
-    # Reference: batch prefill for the prefill arm
-    float_buf_ref = torch.empty(64 * 1024 * 1024, device=device, dtype=torch.uint8)
-    prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-        float_buf_ref, kv_layout
-    )
-    prefill_wrapper.plan(
-        qo_indptr_p,
-        kv_indptr_p,
-        kv_indices_p,
-        last_page_len_p,
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        last_page_len,
         num_qo_heads,
-        num_kv_heads,
-        head_dim,
-        page_size,
-        causal=False,
-        pos_encoding_mode=pos_encoding_mode,
-        kv_data_type=kv_dtype,
-        q_data_type=q_dtype,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        PAGE_SIZE,
+        causal=causal,
+        pos_encoding_mode=POS_ENCODING_MODE,
+        kv_data_type=dtype,
+        q_data_type=dtype,
     )
-    o_ref_p = prefill_wrapper.run(q_p, kv_data_p)
+    return wrapper
 
-    # Reference: batch prefill for the decode arm (1 token per seq)
-    float_buf_ref_d = torch.empty(64 * 1024 * 1024, device=device, dtype=torch.uint8)
-    decode_prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-        float_buf_ref_d, kv_layout
-    )
-    decode_prefill_wrapper.plan(
-        qo_indptr_d,
-        kv_indptr_d,
-        kv_indices_d,
-        last_page_len_d,
-        num_qo_heads,
-        num_kv_heads,
-        head_dim,
-        page_size,
-        causal=False,
-        pos_encoding_mode=pos_encoding_mode,
-        kv_data_type=kv_dtype,
-        q_data_type=q_dtype,
-    )
-    o_ref_d = decode_prefill_wrapper.run(q_d, kv_data_d)
 
-    # BatchPOD wrapper
-    workspace_buffer = torch.empty(128 * 1024 * 1024, device=device, dtype=torch.uint8)
-    batch_pod_wrapper = flashinfer.BatchPODWithPagedKVCacheWrapper(
-        workspace_buffer, kv_layout
-    )
-    batch_pod_wrapper.plan(
+def _run_batch_pod(
+    workspace,
+    qo_indptr_p,
+    kv_indptr_p,
+    kv_indices_p,
+    last_page_len_p,
+    qo_indptr_d,
+    kv_indptr_d,
+    kv_indices_d,
+    last_page_len_d,
+    q_p,
+    kv_data_p,
+    q_d,
+    kv_data_d,
+    num_qo_heads,
+    dtype,
+    causal_p,
+):
+    wrapper = flashinfer.BatchPODWithPagedKVCacheWrapper(workspace, KV_LAYOUT)
+    wrapper.plan(
         qo_indptr_p,
         kv_indptr_p,
         kv_indices_p,
@@ -173,18 +173,82 @@ def test_batch_pod_with_paged_kv_cache(
         kv_indices_d,
         last_page_len_d,
         num_qo_heads=num_qo_heads,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-        page_size=page_size,
-        pos_encoding_mode=pos_encoding_mode,
-        q_data_type=q_dtype,
-        kv_data_type=kv_dtype,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        page_size=PAGE_SIZE,
+        pos_encoding_mode=POS_ENCODING_MODE,
+        q_data_type=dtype,
+        kv_data_type=dtype,
     )
-    o_p, o_d = batch_pod_wrapper.run(
+    return wrapper.run(q_p, kv_data_p, q_d, kv_data_d, causal_p=causal_p)
+
+
+@pytest.mark.parametrize("batch_size_p", [2, 4])
+@pytest.mark.parametrize("qo_len_p", [64, 256])
+@pytest.mark.parametrize("kv_len_p", [128, 512])
+@pytest.mark.parametrize("batch_size_d", [4, 16])
+@pytest.mark.parametrize("kv_len_d", [256, 1024])
+@pytest.mark.parametrize("num_qo_heads", [8, 32])
+@pytest.mark.parametrize("q_dtype", [torch.float16])
+def test_batch_pod_with_paged_kv_cache(
+    batch_size_p,
+    qo_len_p,
+    kv_len_p,
+    batch_size_d,
+    kv_len_d,
+    num_qo_heads,
+    q_dtype,
+    pod_workspace,
+    ref_workspace_p,
+    ref_workspace_d,
+):
+    q_p, kv_data_p, qo_indptr_p, kv_indptr_p, kv_indices_p, last_page_len_p = (
+        _make_prefill_inputs(batch_size_p, qo_len_p, kv_len_p, num_qo_heads, q_dtype)
+    )
+    q_d, kv_data_d, qo_indptr_d, kv_indptr_d, kv_indices_d, last_page_len_d = (
+        _make_decode_inputs(batch_size_d, kv_len_d, num_qo_heads, q_dtype)
+    )
+
+    ref_p = _plan_ref_prefill(
+        ref_workspace_p,
+        qo_indptr_p,
+        kv_indptr_p,
+        kv_indices_p,
+        last_page_len_p,
+        num_qo_heads,
+        q_dtype,
+        causal=False,
+    )
+    o_ref_p = ref_p.run(q_p, kv_data_p)
+
+    ref_d = _plan_ref_prefill(
+        ref_workspace_d,
+        qo_indptr_d,
+        kv_indptr_d,
+        kv_indices_d,
+        last_page_len_d,
+        num_qo_heads,
+        q_dtype,
+        causal=False,
+    )
+    o_ref_d = ref_d.run(q_d, kv_data_d)
+
+    o_p, o_d = _run_batch_pod(
+        pod_workspace,
+        qo_indptr_p,
+        kv_indptr_p,
+        kv_indices_p,
+        last_page_len_p,
+        qo_indptr_d,
+        kv_indptr_d,
+        kv_indices_d,
+        last_page_len_d,
         q_p,
         kv_data_p,
         q_d,
         kv_data_d,
+        num_qo_heads,
+        q_dtype,
         causal_p=False,
     )
 
@@ -196,78 +260,48 @@ def test_batch_pod_with_paged_kv_cache(
     )
 
 
-@pytest.mark.parametrize("q_dtype", [torch.bfloat16])
-def test_batch_pod_bf16(q_dtype):
-    device = "cuda:0"
-    kv_dtype = q_dtype
-    kv_layout = "NHD"
-    pos_encoding_mode = "NONE"
+def test_batch_pod_bf16(pod_workspace, ref_workspace_p, ref_workspace_d):
+    dtype = torch.bfloat16
     batch_size_p, qo_len_p, kv_len_p = 2, 64, 128
-    batch_size_d, kv_len_d, page_size = 4, 256, 16
-    num_qo_heads, num_kv_heads, head_dim = 8, 8, 128
+    batch_size_d, kv_len_d = 4, 256
+    num_qo_heads = 8
 
-    total_qo_p = batch_size_p * qo_len_p
-    q_p = torch.randn(total_qo_p, num_qo_heads, head_dim, device=device, dtype=q_dtype)
-    kv_data_p, kv_indptr_p, kv_indices_p, last_page_len_p = _make_paged_kv(
-        batch_size_p, kv_len_p, page_size, num_kv_heads, head_dim, kv_dtype, device
+    q_p, kv_data_p, qo_indptr_p, kv_indptr_p, kv_indices_p, last_page_len_p = (
+        _make_prefill_inputs(batch_size_p, qo_len_p, kv_len_p, num_qo_heads, dtype)
     )
-    qo_indptr_p = (
-        torch.arange(0, batch_size_p + 1, device=device, dtype=torch.int32) * qo_len_p
+    q_d, kv_data_d, qo_indptr_d, kv_indptr_d, kv_indices_d, last_page_len_d = (
+        _make_decode_inputs(batch_size_d, kv_len_d, num_qo_heads, dtype)
     )
 
-    q_d = torch.randn(
-        batch_size_d, num_qo_heads, head_dim, device=device, dtype=q_dtype
-    )
-    kv_data_d, kv_indptr_d, kv_indices_d, last_page_len_d = _make_paged_kv(
-        batch_size_d, kv_len_d, page_size, num_kv_heads, head_dim, kv_dtype, device
-    )
-    qo_indptr_d = torch.arange(0, batch_size_d + 1, device=device, dtype=torch.int32)
-
-    float_buf = torch.empty(64 * 1024 * 1024, device=device, dtype=torch.uint8)
-    prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-        float_buf, kv_layout, backend="fa2"
-    )
-    prefill_wrapper.plan(
+    # backend="fa2" avoids routing through AITER, whose bf16 .so requires a separate JIT build.
+    ref_p = _plan_ref_prefill(
+        ref_workspace_p,
         qo_indptr_p,
         kv_indptr_p,
         kv_indices_p,
         last_page_len_p,
         num_qo_heads,
-        num_kv_heads,
-        head_dim,
-        page_size,
+        dtype,
         causal=False,
-        pos_encoding_mode=pos_encoding_mode,
-        kv_data_type=kv_dtype,
-        q_data_type=q_dtype,
+        backend="fa2",
     )
-    o_ref_p = prefill_wrapper.run(q_p, kv_data_p)
+    o_ref_p = ref_p.run(q_p, kv_data_p)
 
-    float_buf_d = torch.empty(64 * 1024 * 1024, device=device, dtype=torch.uint8)
-    decode_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
-        float_buf_d, kv_layout, backend="fa2"
-    )
-    decode_wrapper.plan(
+    ref_d = _plan_ref_prefill(
+        ref_workspace_d,
         qo_indptr_d,
         kv_indptr_d,
         kv_indices_d,
         last_page_len_d,
         num_qo_heads,
-        num_kv_heads,
-        head_dim,
-        page_size,
+        dtype,
         causal=False,
-        pos_encoding_mode=pos_encoding_mode,
-        kv_data_type=kv_dtype,
-        q_data_type=q_dtype,
+        backend="fa2",
     )
-    o_ref_d = decode_wrapper.run(q_d, kv_data_d)
+    o_ref_d = ref_d.run(q_d, kv_data_d)
 
-    workspace_buffer = torch.empty(128 * 1024 * 1024, device=device, dtype=torch.uint8)
-    batch_pod_wrapper = flashinfer.BatchPODWithPagedKVCacheWrapper(
-        workspace_buffer, kv_layout
-    )
-    batch_pod_wrapper.plan(
+    o_p, o_d = _run_batch_pod(
+        pod_workspace,
         qo_indptr_p,
         kv_indptr_p,
         kv_indices_p,
@@ -276,19 +310,12 @@ def test_batch_pod_bf16(q_dtype):
         kv_indptr_d,
         kv_indices_d,
         last_page_len_d,
-        num_qo_heads=num_qo_heads,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-        page_size=page_size,
-        pos_encoding_mode=pos_encoding_mode,
-        q_data_type=q_dtype,
-        kv_data_type=kv_dtype,
-    )
-    o_p, o_d = batch_pod_wrapper.run(
         q_p,
         kv_data_p,
         q_d,
         kv_data_d,
+        num_qo_heads,
+        dtype,
         causal_p=False,
     )
 
@@ -300,74 +327,46 @@ def test_batch_pod_bf16(q_dtype):
     )
 
 
-def test_batch_pod_causal_p():
+def test_batch_pod_causal_p(pod_workspace, ref_workspace_p, ref_workspace_d):
     """Exercises MaskMode::kCausal on the prefill arm of BatchPOD."""
-    device = "cuda:0"
-    q_dtype = kv_dtype = torch.float16
-    kv_layout = "NHD"
-    pos_encoding_mode = "NONE"
+    dtype = torch.float16
     batch_size_p, qo_len_p, kv_len_p = 2, 64, 128
-    batch_size_d, kv_len_d, page_size = 4, 256, 16
-    num_qo_heads, num_kv_heads, head_dim = 8, 8, 128
+    batch_size_d, kv_len_d = 4, 256
+    num_qo_heads = 8
 
-    total_qo_p = batch_size_p * qo_len_p
-    q_p = torch.randn(total_qo_p, num_qo_heads, head_dim, device=device, dtype=q_dtype)
-    kv_data_p, kv_indptr_p, kv_indices_p, last_page_len_p = _make_paged_kv(
-        batch_size_p, kv_len_p, page_size, num_kv_heads, head_dim, kv_dtype, device
+    q_p, kv_data_p, qo_indptr_p, kv_indptr_p, kv_indices_p, last_page_len_p = (
+        _make_prefill_inputs(batch_size_p, qo_len_p, kv_len_p, num_qo_heads, dtype)
     )
-    qo_indptr_p = (
-        torch.arange(0, batch_size_p + 1, device=device, dtype=torch.int32) * qo_len_p
+    q_d, kv_data_d, qo_indptr_d, kv_indptr_d, kv_indices_d, last_page_len_d = (
+        _make_decode_inputs(batch_size_d, kv_len_d, num_qo_heads, dtype)
     )
 
-    q_d = torch.randn(
-        batch_size_d, num_qo_heads, head_dim, device=device, dtype=q_dtype
-    )
-    kv_data_d, kv_indptr_d, kv_indices_d, last_page_len_d = _make_paged_kv(
-        batch_size_d, kv_len_d, page_size, num_kv_heads, head_dim, kv_dtype, device
-    )
-    qo_indptr_d = torch.arange(0, batch_size_d + 1, device=device, dtype=torch.int32)
-
-    float_buf_p = torch.empty(64 * 1024 * 1024, device=device, dtype=torch.uint8)
-    ref_p = flashinfer.BatchPrefillWithPagedKVCacheWrapper(float_buf_p, kv_layout)
-    ref_p.plan(
+    ref_p = _plan_ref_prefill(
+        ref_workspace_p,
         qo_indptr_p,
         kv_indptr_p,
         kv_indices_p,
         last_page_len_p,
         num_qo_heads,
-        num_kv_heads,
-        head_dim,
-        page_size,
+        dtype,
         causal=True,
-        pos_encoding_mode=pos_encoding_mode,
-        kv_data_type=kv_dtype,
-        q_data_type=q_dtype,
     )
     o_ref_p = ref_p.run(q_p, kv_data_p)
 
-    float_buf_d = torch.empty(64 * 1024 * 1024, device=device, dtype=torch.uint8)
-    ref_d = flashinfer.BatchPrefillWithPagedKVCacheWrapper(float_buf_d, kv_layout)
-    ref_d.plan(
+    ref_d = _plan_ref_prefill(
+        ref_workspace_d,
         qo_indptr_d,
         kv_indptr_d,
         kv_indices_d,
         last_page_len_d,
         num_qo_heads,
-        num_kv_heads,
-        head_dim,
-        page_size,
+        dtype,
         causal=False,
-        pos_encoding_mode=pos_encoding_mode,
-        kv_data_type=kv_dtype,
-        q_data_type=q_dtype,
     )
     o_ref_d = ref_d.run(q_d, kv_data_d)
 
-    workspace_buffer = torch.empty(128 * 1024 * 1024, device=device, dtype=torch.uint8)
-    batch_pod_wrapper = flashinfer.BatchPODWithPagedKVCacheWrapper(
-        workspace_buffer, kv_layout
-    )
-    batch_pod_wrapper.plan(
+    o_p, o_d = _run_batch_pod(
+        pod_workspace,
         qo_indptr_p,
         kv_indptr_p,
         kv_indices_p,
@@ -376,15 +375,14 @@ def test_batch_pod_causal_p():
         kv_indptr_d,
         kv_indices_d,
         last_page_len_d,
-        num_qo_heads=num_qo_heads,
-        num_kv_heads=num_kv_heads,
-        head_dim=head_dim,
-        page_size=page_size,
-        pos_encoding_mode=pos_encoding_mode,
-        q_data_type=q_dtype,
-        kv_data_type=kv_dtype,
+        q_p,
+        kv_data_p,
+        q_d,
+        kv_data_d,
+        num_qo_heads,
+        dtype,
+        causal_p=True,
     )
-    o_p, o_d = batch_pod_wrapper.run(q_p, kv_data_p, q_d, kv_data_d, causal_p=True)
 
     torch.testing.assert_close(
         o_p, o_ref_p, rtol=1e-2, atol=1e-2, msg="BatchPOD causal prefill mismatch"

--- a/tests/rocm_tests/test_batch_pod_hip.py
+++ b/tests/rocm_tests/test_batch_pod_hip.py
@@ -1,0 +1,394 @@
+# SPDX-FileCopyrightText: 2025 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from jit_utils import gen_prefill_attention_modules
+
+import flashinfer
+from flashinfer.jit.attention import gen_batch_pod_module
+
+
+@pytest.fixture(autouse=True, scope="module")
+def warmup_jit():
+    flashinfer.jit.build_jit_specs(
+        gen_prefill_attention_modules(
+            [torch.float16],
+            [torch.float16],
+            [128],
+            [0],
+            [False],
+            [False],
+            [False],
+        )
+        + [
+            gen_batch_pod_module(
+                torch.float16,  # dtype_q
+                torch.float16,  # dtype_kv
+                torch.float16,  # dtype_o
+                128,  # head_dim
+                0,  # pos_encoding_mode_p (NONE)
+                False,  # use_sliding_window_p
+                False,  # use_logits_soft_cap_p
+                False,  # use_fp16_qk_reduction
+                torch.int32,  # dtype_idx
+                0,  # pos_encoding_mode_d (NONE)
+                False,  # use_sliding_window_d
+                False,  # use_logits_soft_cap_d
+            )
+        ],
+        verbose=False,
+    )
+    yield
+
+
+def _make_paged_kv(
+    batch_size, kv_len, page_size, num_kv_heads, head_dim, dtype, device
+):
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_pages = num_pages_per_seq * batch_size
+    kv_data = torch.randn(
+        total_pages,
+        2,
+        page_size,
+        num_kv_heads,
+        head_dim,
+        device=device,
+        dtype=dtype,
+    )
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device=device, dtype=torch.int32)
+        * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_pages, device=device, dtype=torch.int32)
+    last_page_len = torch.full(
+        (batch_size,),
+        (kv_len - 1) % page_size + 1,
+        device=device,
+        dtype=torch.int32,
+    )
+    return kv_data, kv_indptr, kv_indices, last_page_len
+
+
+@pytest.mark.parametrize("batch_size_p", [2, 4])
+@pytest.mark.parametrize("qo_len_p", [64, 256])
+@pytest.mark.parametrize("kv_len_p", [128, 512])
+@pytest.mark.parametrize("batch_size_d", [4, 16])
+@pytest.mark.parametrize("kv_len_d", [256, 1024])
+@pytest.mark.parametrize("page_size", [16])
+@pytest.mark.parametrize("num_qo_heads", [8, 32])
+@pytest.mark.parametrize("num_kv_heads", [8])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("q_dtype", [torch.float16])
+def test_batch_pod_with_paged_kv_cache(
+    batch_size_p,
+    qo_len_p,
+    kv_len_p,
+    batch_size_d,
+    kv_len_d,
+    page_size,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    q_dtype,
+):
+    device = "cuda:0"
+    kv_dtype = q_dtype
+    kv_layout = "NHD"
+    pos_encoding_mode = "NONE"
+
+    # Prefill: each request has qo_len_p tokens attending to kv_len_p tokens
+    total_qo_p = batch_size_p * qo_len_p
+    q_p = torch.randn(total_qo_p, num_qo_heads, head_dim, device=device, dtype=q_dtype)
+    kv_data_p, kv_indptr_p, kv_indices_p, last_page_len_p = _make_paged_kv(
+        batch_size_p, kv_len_p, page_size, num_kv_heads, head_dim, kv_dtype, device
+    )
+    qo_indptr_p = (
+        torch.arange(0, batch_size_p + 1, device=device, dtype=torch.int32) * qo_len_p
+    )
+
+    # Decode: each request has 1 token
+    q_d = torch.randn(
+        batch_size_d, num_qo_heads, head_dim, device=device, dtype=q_dtype
+    )
+    kv_data_d, kv_indptr_d, kv_indices_d, last_page_len_d = _make_paged_kv(
+        batch_size_d, kv_len_d, page_size, num_kv_heads, head_dim, kv_dtype, device
+    )
+    qo_indptr_d = torch.arange(0, batch_size_d + 1, device=device, dtype=torch.int32)
+
+    # Reference: batch prefill for the prefill arm
+    float_buf_ref = torch.empty(64 * 1024 * 1024, device=device, dtype=torch.uint8)
+    prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        float_buf_ref, kv_layout
+    )
+    prefill_wrapper.plan(
+        qo_indptr_p,
+        kv_indptr_p,
+        kv_indices_p,
+        last_page_len_p,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=False,
+        pos_encoding_mode=pos_encoding_mode,
+        kv_data_type=kv_dtype,
+        q_data_type=q_dtype,
+    )
+    o_ref_p = prefill_wrapper.run(q_p, kv_data_p)
+
+    # Reference: batch prefill for the decode arm (1 token per seq)
+    float_buf_ref_d = torch.empty(64 * 1024 * 1024, device=device, dtype=torch.uint8)
+    decode_prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        float_buf_ref_d, kv_layout
+    )
+    decode_prefill_wrapper.plan(
+        qo_indptr_d,
+        kv_indptr_d,
+        kv_indices_d,
+        last_page_len_d,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=False,
+        pos_encoding_mode=pos_encoding_mode,
+        kv_data_type=kv_dtype,
+        q_data_type=q_dtype,
+    )
+    o_ref_d = decode_prefill_wrapper.run(q_d, kv_data_d)
+
+    # BatchPOD wrapper
+    workspace_buffer = torch.empty(128 * 1024 * 1024, device=device, dtype=torch.uint8)
+    batch_pod_wrapper = flashinfer.BatchPODWithPagedKVCacheWrapper(
+        workspace_buffer, kv_layout
+    )
+    batch_pod_wrapper.plan(
+        qo_indptr_p,
+        kv_indptr_p,
+        kv_indices_p,
+        last_page_len_p,
+        qo_indptr_d,
+        kv_indptr_d,
+        kv_indices_d,
+        last_page_len_d,
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        page_size=page_size,
+        pos_encoding_mode=pos_encoding_mode,
+        q_data_type=q_dtype,
+        kv_data_type=kv_dtype,
+    )
+    o_p, o_d = batch_pod_wrapper.run(
+        q_p,
+        kv_data_p,
+        q_d,
+        kv_data_d,
+        causal_p=False,
+    )
+
+    torch.testing.assert_close(
+        o_p, o_ref_p, rtol=1e-2, atol=1e-2, msg="BatchPOD prefill mismatch"
+    )
+    torch.testing.assert_close(
+        o_d, o_ref_d, rtol=1e-2, atol=1e-2, msg="BatchPOD decode mismatch"
+    )
+
+
+@pytest.mark.parametrize("q_dtype", [torch.bfloat16])
+def test_batch_pod_bf16(q_dtype):
+    device = "cuda:0"
+    kv_dtype = q_dtype
+    kv_layout = "NHD"
+    pos_encoding_mode = "NONE"
+    batch_size_p, qo_len_p, kv_len_p = 2, 64, 128
+    batch_size_d, kv_len_d, page_size = 4, 256, 16
+    num_qo_heads, num_kv_heads, head_dim = 8, 8, 128
+
+    total_qo_p = batch_size_p * qo_len_p
+    q_p = torch.randn(total_qo_p, num_qo_heads, head_dim, device=device, dtype=q_dtype)
+    kv_data_p, kv_indptr_p, kv_indices_p, last_page_len_p = _make_paged_kv(
+        batch_size_p, kv_len_p, page_size, num_kv_heads, head_dim, kv_dtype, device
+    )
+    qo_indptr_p = (
+        torch.arange(0, batch_size_p + 1, device=device, dtype=torch.int32) * qo_len_p
+    )
+
+    q_d = torch.randn(
+        batch_size_d, num_qo_heads, head_dim, device=device, dtype=q_dtype
+    )
+    kv_data_d, kv_indptr_d, kv_indices_d, last_page_len_d = _make_paged_kv(
+        batch_size_d, kv_len_d, page_size, num_kv_heads, head_dim, kv_dtype, device
+    )
+    qo_indptr_d = torch.arange(0, batch_size_d + 1, device=device, dtype=torch.int32)
+
+    float_buf = torch.empty(64 * 1024 * 1024, device=device, dtype=torch.uint8)
+    prefill_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        float_buf, kv_layout
+    )
+    prefill_wrapper.plan(
+        qo_indptr_p,
+        kv_indptr_p,
+        kv_indices_p,
+        last_page_len_p,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=False,
+        pos_encoding_mode=pos_encoding_mode,
+        kv_data_type=kv_dtype,
+        q_data_type=q_dtype,
+    )
+    o_ref_p = prefill_wrapper.run(q_p, kv_data_p)
+
+    float_buf_d = torch.empty(64 * 1024 * 1024, device=device, dtype=torch.uint8)
+    decode_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        float_buf_d, kv_layout
+    )
+    decode_wrapper.plan(
+        qo_indptr_d,
+        kv_indptr_d,
+        kv_indices_d,
+        last_page_len_d,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=False,
+        pos_encoding_mode=pos_encoding_mode,
+        kv_data_type=kv_dtype,
+        q_data_type=q_dtype,
+    )
+    o_ref_d = decode_wrapper.run(q_d, kv_data_d)
+
+    workspace_buffer = torch.empty(128 * 1024 * 1024, device=device, dtype=torch.uint8)
+    batch_pod_wrapper = flashinfer.BatchPODWithPagedKVCacheWrapper(
+        workspace_buffer, kv_layout
+    )
+    batch_pod_wrapper.plan(
+        qo_indptr_p,
+        kv_indptr_p,
+        kv_indices_p,
+        last_page_len_p,
+        qo_indptr_d,
+        kv_indptr_d,
+        kv_indices_d,
+        last_page_len_d,
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        page_size=page_size,
+        pos_encoding_mode=pos_encoding_mode,
+        q_data_type=q_dtype,
+        kv_data_type=kv_dtype,
+    )
+    o_p, o_d = batch_pod_wrapper.run(
+        q_p,
+        kv_data_p,
+        q_d,
+        kv_data_d,
+        causal_p=False,
+    )
+
+    torch.testing.assert_close(
+        o_p, o_ref_p, rtol=1e-2, atol=1e-2, msg="BatchPOD bf16 prefill mismatch"
+    )
+    torch.testing.assert_close(
+        o_d, o_ref_d, rtol=1e-2, atol=1e-2, msg="BatchPOD bf16 decode mismatch"
+    )
+
+
+def test_batch_pod_causal_p():
+    """Exercises MaskMode::kCausal on the prefill arm of BatchPOD."""
+    device = "cuda:0"
+    q_dtype = kv_dtype = torch.float16
+    kv_layout = "NHD"
+    pos_encoding_mode = "NONE"
+    batch_size_p, qo_len_p, kv_len_p = 2, 64, 128
+    batch_size_d, kv_len_d, page_size = 4, 256, 16
+    num_qo_heads, num_kv_heads, head_dim = 8, 8, 128
+
+    total_qo_p = batch_size_p * qo_len_p
+    q_p = torch.randn(total_qo_p, num_qo_heads, head_dim, device=device, dtype=q_dtype)
+    kv_data_p, kv_indptr_p, kv_indices_p, last_page_len_p = _make_paged_kv(
+        batch_size_p, kv_len_p, page_size, num_kv_heads, head_dim, kv_dtype, device
+    )
+    qo_indptr_p = (
+        torch.arange(0, batch_size_p + 1, device=device, dtype=torch.int32) * qo_len_p
+    )
+
+    q_d = torch.randn(
+        batch_size_d, num_qo_heads, head_dim, device=device, dtype=q_dtype
+    )
+    kv_data_d, kv_indptr_d, kv_indices_d, last_page_len_d = _make_paged_kv(
+        batch_size_d, kv_len_d, page_size, num_kv_heads, head_dim, kv_dtype, device
+    )
+    qo_indptr_d = torch.arange(0, batch_size_d + 1, device=device, dtype=torch.int32)
+
+    float_buf_p = torch.empty(64 * 1024 * 1024, device=device, dtype=torch.uint8)
+    ref_p = flashinfer.BatchPrefillWithPagedKVCacheWrapper(float_buf_p, kv_layout)
+    ref_p.plan(
+        qo_indptr_p,
+        kv_indptr_p,
+        kv_indices_p,
+        last_page_len_p,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=True,
+        pos_encoding_mode=pos_encoding_mode,
+        kv_data_type=kv_dtype,
+        q_data_type=q_dtype,
+    )
+    o_ref_p = ref_p.run(q_p, kv_data_p)
+
+    float_buf_d = torch.empty(64 * 1024 * 1024, device=device, dtype=torch.uint8)
+    ref_d = flashinfer.BatchPrefillWithPagedKVCacheWrapper(float_buf_d, kv_layout)
+    ref_d.plan(
+        qo_indptr_d,
+        kv_indptr_d,
+        kv_indices_d,
+        last_page_len_d,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=False,
+        pos_encoding_mode=pos_encoding_mode,
+        kv_data_type=kv_dtype,
+        q_data_type=q_dtype,
+    )
+    o_ref_d = ref_d.run(q_d, kv_data_d)
+
+    workspace_buffer = torch.empty(128 * 1024 * 1024, device=device, dtype=torch.uint8)
+    batch_pod_wrapper = flashinfer.BatchPODWithPagedKVCacheWrapper(
+        workspace_buffer, kv_layout
+    )
+    batch_pod_wrapper.plan(
+        qo_indptr_p,
+        kv_indptr_p,
+        kv_indices_p,
+        last_page_len_p,
+        qo_indptr_d,
+        kv_indptr_d,
+        kv_indices_d,
+        last_page_len_d,
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        page_size=page_size,
+        pos_encoding_mode=pos_encoding_mode,
+        q_data_type=q_dtype,
+        kv_data_type=kv_dtype,
+    )
+    o_p, o_d = batch_pod_wrapper.run(q_p, kv_data_p, q_d, kv_data_d, causal_p=True)
+
+    torch.testing.assert_close(
+        o_p, o_ref_p, rtol=1e-2, atol=1e-2, msg="BatchPOD causal prefill mismatch"
+    )
+    torch.testing.assert_close(
+        o_d, o_ref_d, rtol=1e-2, atol=1e-2, msg="BatchPOD causal decode mismatch"
+    )

--- a/tests/rocm_tests/test_pod_hip.py
+++ b/tests/rocm_tests/test_pod_hip.py
@@ -8,6 +8,14 @@ from jit_utils import gen_prefill_attention_modules
 import flashinfer
 from flashinfer.jit.attention import gen_pod_module
 
+DEVICE = "cuda:0"
+HEAD_DIM = 128
+NUM_KV_HEADS = 8
+PAGE_SIZE = 16
+KV_LAYOUT = "NHD"
+POS_ENCODING_MODE = "NONE"
+WORKSPACE_BYTES = 32 * 1024 * 1024
+
 
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
@@ -15,7 +23,7 @@ def warmup_jit():
         gen_prefill_attention_modules(
             [torch.float16],
             [torch.float16],
-            [128],
+            [HEAD_DIM],
             [0],
             [False],
             [False],
@@ -23,18 +31,18 @@ def warmup_jit():
         )
         + [
             gen_pod_module(
-                torch.float16,  # dtype_q
-                torch.float16,  # dtype_kv
-                torch.float16,  # dtype_o
-                128,  # head_dim
-                0,  # pos_encoding_mode_p (NONE)
-                False,  # use_sliding_window_p
-                False,  # use_logits_soft_cap_p
-                False,  # use_fp16_qk_reduction
-                torch.int32,  # dtype_idx
-                0,  # pos_encoding_mode_d (NONE)
-                False,  # use_sliding_window_d
-                False,  # use_logits_soft_cap_d
+                torch.float16,
+                torch.float16,
+                torch.float16,
+                HEAD_DIM,
+                0,
+                False,
+                False,
+                False,
+                torch.int32,
+                0,
+                False,
+                False,
             )
         ],
         verbose=False,
@@ -42,112 +50,111 @@ def warmup_jit():
     yield
 
 
+@pytest.fixture(scope="module")
+def workspace():
+    return torch.empty(WORKSPACE_BYTES, device=DEVICE, dtype=torch.int8)
+
+
+@pytest.fixture(scope="module")
+def decode_workspace():
+    return torch.empty(WORKSPACE_BYTES, device=DEVICE, dtype=torch.int8)
+
+
+def _make_paged_kv(batch_size, kv_len, page_size, num_kv_heads, head_dim, dtype):
+    num_pages_per_seq = (kv_len + page_size - 1) // page_size
+    total_num_pages = num_pages_per_seq * batch_size
+    kv_data = torch.randn(
+        total_num_pages,
+        2,
+        page_size,
+        num_kv_heads,
+        head_dim,
+        device=DEVICE,
+        dtype=dtype,
+    )
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, device=DEVICE, dtype=torch.int32)
+        * num_pages_per_seq
+    )
+    kv_indices = torch.arange(0, total_num_pages, device=DEVICE, dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size,),
+        (kv_len - 1) % page_size + 1,
+        device=DEVICE,
+        dtype=torch.int32,
+    )
+    return kv_data, kv_indptr, kv_indices, kv_last_page_len
+
+
 @pytest.mark.parametrize("kv_len_p", [127, 4096])
 @pytest.mark.parametrize("qo_len_p", [127, 512])
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("batch_size_d", [1, 17])
 @pytest.mark.parametrize("kv_len_d", [127, 2048])
-@pytest.mark.parametrize("page_size_d", [16])
-@pytest.mark.parametrize("kv_layout_d", ["NHD"])
-@pytest.mark.parametrize("num_kv_heads", [8])
 @pytest.mark.parametrize("num_qo_heads", [8, 32])
-@pytest.mark.parametrize("head_dim", [128])
-@pytest.mark.parametrize("pos_encoding_mode", ["NONE"])
 @pytest.mark.parametrize("q_dtype", [torch.float16])
-@pytest.mark.parametrize("kv_dtype", [torch.float16])
 def test_pod_with_paged_kv_cache(
     kv_len_p,
     qo_len_p,
     causal,
     batch_size_d,
     kv_len_d,
-    page_size_d,
-    kv_layout_d,
-    num_kv_heads,
     num_qo_heads,
-    head_dim,
-    pos_encoding_mode,
     q_dtype,
-    kv_dtype,
+    workspace,
+    decode_workspace,
 ):
     if causal and qo_len_p > kv_len_p:
         pytest.skip("Causal prefill with qo_len_p > kv_len_p is not supported")
 
-    device = "cuda:0"
+    kv_dtype = q_dtype
 
-    # Prefill inputs (single-request, NHD layout)
-    q_p = torch.randn(qo_len_p, num_qo_heads, head_dim, device=device, dtype=q_dtype)
-    k_p = torch.randn(kv_len_p, num_kv_heads, head_dim, device=device, dtype=kv_dtype)
-    v_p = torch.randn(kv_len_p, num_kv_heads, head_dim, device=device, dtype=kv_dtype)
+    q_p = torch.randn(qo_len_p, num_qo_heads, HEAD_DIM, device=DEVICE, dtype=q_dtype)
+    k_p = torch.randn(kv_len_p, NUM_KV_HEADS, HEAD_DIM, device=DEVICE, dtype=kv_dtype)
+    v_p = torch.randn(kv_len_p, NUM_KV_HEADS, HEAD_DIM, device=DEVICE, dtype=kv_dtype)
 
-    # Reference prefill output
     o_ref_p = flashinfer.single_prefill_with_kv_cache(
         q_p,
         k_p,
         v_p,
         causal=causal,
-        pos_encoding_mode=pos_encoding_mode,
+        pos_encoding_mode=POS_ENCODING_MODE,
     )
 
-    # Decode inputs (paged KV cache)
     q_d = torch.randn(
-        batch_size_d, num_qo_heads, head_dim, device=device, dtype=q_dtype
+        batch_size_d, num_qo_heads, HEAD_DIM, device=DEVICE, dtype=q_dtype
     )
-    num_pages_per_seq = (kv_len_d + page_size_d - 1) // page_size_d
-    total_num_pages = num_pages_per_seq * batch_size_d
-
-    kv_data = torch.randn(
-        total_num_pages,
-        2,
-        page_size_d,
-        num_kv_heads,
-        head_dim,
-        device=device,
-        dtype=kv_dtype,
-    )
-    kv_indptr_d = (
-        torch.arange(0, batch_size_d + 1, device=device, dtype=torch.int32)
-        * num_pages_per_seq
-    )
-    kv_indices_d = torch.arange(0, total_num_pages, device=device, dtype=torch.int32)
-    kv_last_page_len = torch.full(
-        (batch_size_d,),
-        (kv_len_d - 1) % page_size_d + 1,
-        device=device,
-        dtype=torch.int32,
+    kv_data, kv_indptr_d, kv_indices_d, kv_last_page_len = _make_paged_kv(
+        batch_size_d, kv_len_d, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, kv_dtype
     )
 
-    # Reference decode output
-    decode_workspace = torch.empty(32 * 1024 * 1024, device=device, dtype=torch.int8)
     decode_wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
-        decode_workspace, kv_layout_d
+        decode_workspace, KV_LAYOUT
     )
     decode_wrapper.plan(
         kv_indptr_d,
         kv_indices_d,
         kv_last_page_len,
         num_qo_heads,
-        num_kv_heads,
-        head_dim,
-        page_size_d,
-        pos_encoding_mode=pos_encoding_mode,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        PAGE_SIZE,
+        pos_encoding_mode=POS_ENCODING_MODE,
         data_type=kv_dtype,
         q_data_type=q_dtype,
     )
     o_ref_d = decode_wrapper.run(q_d, kv_data)
 
-    # POD wrapper
-    workspace_buffer = torch.empty(32 * 1024 * 1024, device=device, dtype=torch.int8)
-    pod_wrapper = flashinfer.PODWithPagedKVCacheWrapper(workspace_buffer, kv_layout_d)
+    pod_wrapper = flashinfer.PODWithPagedKVCacheWrapper(workspace, KV_LAYOUT)
     pod_wrapper.plan(
         kv_indptr_d,
         kv_indices_d,
         kv_last_page_len,
         num_qo_heads,
-        num_kv_heads,
-        head_dim,
-        page_size_d,
-        pos_encoding_mode=pos_encoding_mode,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        PAGE_SIZE,
+        pos_encoding_mode=POS_ENCODING_MODE,
         data_type=kv_dtype,
         q_data_type=q_dtype,
     )
@@ -158,7 +165,7 @@ def test_pod_with_paged_kv_cache(
         v_p,
         q_d,
         kv_data,
-        pos_encoding_mode_p=pos_encoding_mode,
+        pos_encoding_mode_p=POS_ENCODING_MODE,
         causal_p=causal,
     )
 
@@ -170,86 +177,60 @@ def test_pod_with_paged_kv_cache(
     )
 
 
-@pytest.mark.parametrize("q_dtype", [torch.bfloat16])
-@pytest.mark.parametrize("kv_dtype", [torch.bfloat16])
-def test_pod_bf16(q_dtype, kv_dtype):
-    device = "cuda:0"
+def test_pod_bf16(workspace, decode_workspace):
+    dtype = torch.bfloat16
     qo_len_p, kv_len_p = 64, 128
-    batch_size_d, kv_len_d, page_size_d = 4, 256, 16
-    num_qo_heads, num_kv_heads, head_dim = 8, 8, 128
-    kv_layout_d = "NHD"
-    pos_encoding_mode = "NONE"
+    batch_size_d, kv_len_d = 4, 256
+    num_qo_heads = 8
 
-    q_p = torch.randn(qo_len_p, num_qo_heads, head_dim, device=device, dtype=q_dtype)
-    k_p = torch.randn(kv_len_p, num_kv_heads, head_dim, device=device, dtype=kv_dtype)
-    v_p = torch.randn(kv_len_p, num_kv_heads, head_dim, device=device, dtype=kv_dtype)
+    q_p = torch.randn(qo_len_p, num_qo_heads, HEAD_DIM, device=DEVICE, dtype=dtype)
+    k_p = torch.randn(kv_len_p, NUM_KV_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
+    v_p = torch.randn(kv_len_p, NUM_KV_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
 
+    # backend="fa2" avoids routing through AITER, whose bf16 .so requires a separate JIT build.
     o_ref_p = flashinfer.single_prefill_with_kv_cache(
         q_p,
         k_p,
         v_p,
         causal=False,
-        pos_encoding_mode=pos_encoding_mode,
+        pos_encoding_mode=POS_ENCODING_MODE,
         backend="fa2",
     )
 
-    q_d = torch.randn(
-        batch_size_d, num_qo_heads, head_dim, device=device, dtype=q_dtype
-    )
-    num_pages_per_seq = (kv_len_d + page_size_d - 1) // page_size_d
-    total_num_pages = num_pages_per_seq * batch_size_d
-    kv_data = torch.randn(
-        total_num_pages,
-        2,
-        page_size_d,
-        num_kv_heads,
-        head_dim,
-        device=device,
-        dtype=kv_dtype,
-    )
-    kv_indptr_d = (
-        torch.arange(0, batch_size_d + 1, device=device, dtype=torch.int32)
-        * num_pages_per_seq
-    )
-    kv_indices_d = torch.arange(0, total_num_pages, device=device, dtype=torch.int32)
-    kv_last_page_len = torch.full(
-        (batch_size_d,),
-        (kv_len_d - 1) % page_size_d + 1,
-        device=device,
-        dtype=torch.int32,
+    q_d = torch.randn(batch_size_d, num_qo_heads, HEAD_DIM, device=DEVICE, dtype=dtype)
+    kv_data, kv_indptr_d, kv_indices_d, kv_last_page_len = _make_paged_kv(
+        batch_size_d, kv_len_d, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype
     )
 
-    decode_workspace = torch.empty(32 * 1024 * 1024, device=device, dtype=torch.int8)
     decode_wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
-        decode_workspace, kv_layout_d
+        decode_workspace, KV_LAYOUT
     )
     decode_wrapper.plan(
         kv_indptr_d,
         kv_indices_d,
         kv_last_page_len,
         num_qo_heads,
-        num_kv_heads,
-        head_dim,
-        page_size_d,
-        pos_encoding_mode=pos_encoding_mode,
-        data_type=kv_dtype,
-        q_data_type=q_dtype,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        PAGE_SIZE,
+        pos_encoding_mode=POS_ENCODING_MODE,
+        data_type=dtype,
+        q_data_type=dtype,
     )
     o_ref_d = decode_wrapper.run(q_d, kv_data)
 
-    workspace_buffer = torch.empty(32 * 1024 * 1024, device=device, dtype=torch.int8)
-    pod_wrapper = flashinfer.PODWithPagedKVCacheWrapper(workspace_buffer, kv_layout_d)
+    pod_wrapper = flashinfer.PODWithPagedKVCacheWrapper(workspace, KV_LAYOUT)
     pod_wrapper.plan(
         kv_indptr_d,
         kv_indices_d,
         kv_last_page_len,
         num_qo_heads,
-        num_kv_heads,
-        head_dim,
-        page_size_d,
-        pos_encoding_mode=pos_encoding_mode,
-        data_type=kv_dtype,
-        q_data_type=q_dtype,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        PAGE_SIZE,
+        pos_encoding_mode=POS_ENCODING_MODE,
+        data_type=dtype,
+        q_data_type=dtype,
     )
     o_p, o_d = pod_wrapper.run(
         q_p,
@@ -257,7 +238,7 @@ def test_pod_bf16(q_dtype, kv_dtype):
         v_p,
         q_d,
         kv_data,
-        pos_encoding_mode_p=pos_encoding_mode,
+        pos_encoding_mode_p=POS_ENCODING_MODE,
         causal_p=False,
     )
 

--- a/tests/rocm_tests/test_pod_hip.py
+++ b/tests/rocm_tests/test_pod_hip.py
@@ -190,6 +190,7 @@ def test_pod_bf16(q_dtype, kv_dtype):
         v_p,
         causal=False,
         pos_encoding_mode=pos_encoding_mode,
+        backend="fa2",
     )
 
     q_d = torch.randn(

--- a/tests/rocm_tests/test_pod_hip.py
+++ b/tests/rocm_tests/test_pod_hip.py
@@ -1,0 +1,268 @@
+# SPDX-FileCopyrightText: 2025 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from jit_utils import gen_prefill_attention_modules
+
+import flashinfer
+from flashinfer.jit.attention import gen_pod_module
+
+
+@pytest.fixture(autouse=True, scope="module")
+def warmup_jit():
+    flashinfer.jit.build_jit_specs(
+        gen_prefill_attention_modules(
+            [torch.float16],
+            [torch.float16],
+            [128],
+            [0],
+            [False],
+            [False],
+            [False],
+        )
+        + [
+            gen_pod_module(
+                torch.float16,  # dtype_q
+                torch.float16,  # dtype_kv
+                torch.float16,  # dtype_o
+                128,  # head_dim
+                0,  # pos_encoding_mode_p (NONE)
+                False,  # use_sliding_window_p
+                False,  # use_logits_soft_cap_p
+                False,  # use_fp16_qk_reduction
+                torch.int32,  # dtype_idx
+                0,  # pos_encoding_mode_d (NONE)
+                False,  # use_sliding_window_d
+                False,  # use_logits_soft_cap_d
+            )
+        ],
+        verbose=False,
+    )
+    yield
+
+
+@pytest.mark.parametrize("kv_len_p", [127, 4096])
+@pytest.mark.parametrize("qo_len_p", [127, 512])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("batch_size_d", [1, 17])
+@pytest.mark.parametrize("kv_len_d", [127, 2048])
+@pytest.mark.parametrize("page_size_d", [16])
+@pytest.mark.parametrize("kv_layout_d", ["NHD"])
+@pytest.mark.parametrize("num_kv_heads", [8])
+@pytest.mark.parametrize("num_qo_heads", [8, 32])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("pos_encoding_mode", ["NONE"])
+@pytest.mark.parametrize("q_dtype", [torch.float16])
+@pytest.mark.parametrize("kv_dtype", [torch.float16])
+def test_pod_with_paged_kv_cache(
+    kv_len_p,
+    qo_len_p,
+    causal,
+    batch_size_d,
+    kv_len_d,
+    page_size_d,
+    kv_layout_d,
+    num_kv_heads,
+    num_qo_heads,
+    head_dim,
+    pos_encoding_mode,
+    q_dtype,
+    kv_dtype,
+):
+    if causal and qo_len_p > kv_len_p:
+        pytest.skip("Causal prefill with qo_len_p > kv_len_p is not supported")
+
+    device = "cuda:0"
+
+    # Prefill inputs (single-request, NHD layout)
+    q_p = torch.randn(qo_len_p, num_qo_heads, head_dim, device=device, dtype=q_dtype)
+    k_p = torch.randn(kv_len_p, num_kv_heads, head_dim, device=device, dtype=kv_dtype)
+    v_p = torch.randn(kv_len_p, num_kv_heads, head_dim, device=device, dtype=kv_dtype)
+
+    # Reference prefill output
+    o_ref_p = flashinfer.single_prefill_with_kv_cache(
+        q_p,
+        k_p,
+        v_p,
+        causal=causal,
+        pos_encoding_mode=pos_encoding_mode,
+    )
+
+    # Decode inputs (paged KV cache)
+    q_d = torch.randn(
+        batch_size_d, num_qo_heads, head_dim, device=device, dtype=q_dtype
+    )
+    num_pages_per_seq = (kv_len_d + page_size_d - 1) // page_size_d
+    total_num_pages = num_pages_per_seq * batch_size_d
+
+    kv_data = torch.randn(
+        total_num_pages,
+        2,
+        page_size_d,
+        num_kv_heads,
+        head_dim,
+        device=device,
+        dtype=kv_dtype,
+    )
+    kv_indptr_d = (
+        torch.arange(0, batch_size_d + 1, device=device, dtype=torch.int32)
+        * num_pages_per_seq
+    )
+    kv_indices_d = torch.arange(0, total_num_pages, device=device, dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size_d,),
+        (kv_len_d - 1) % page_size_d + 1,
+        device=device,
+        dtype=torch.int32,
+    )
+
+    # Reference decode output
+    decode_workspace = torch.empty(32 * 1024 * 1024, device=device, dtype=torch.int8)
+    decode_wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        decode_workspace, kv_layout_d
+    )
+    decode_wrapper.plan(
+        kv_indptr_d,
+        kv_indices_d,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size_d,
+        pos_encoding_mode=pos_encoding_mode,
+        data_type=kv_dtype,
+        q_data_type=q_dtype,
+    )
+    o_ref_d = decode_wrapper.run(q_d, kv_data)
+
+    # POD wrapper
+    workspace_buffer = torch.empty(32 * 1024 * 1024, device=device, dtype=torch.int8)
+    pod_wrapper = flashinfer.PODWithPagedKVCacheWrapper(workspace_buffer, kv_layout_d)
+    pod_wrapper.plan(
+        kv_indptr_d,
+        kv_indices_d,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size_d,
+        pos_encoding_mode=pos_encoding_mode,
+        data_type=kv_dtype,
+        q_data_type=q_dtype,
+    )
+
+    o_p, o_d = pod_wrapper.run(
+        q_p,
+        k_p,
+        v_p,
+        q_d,
+        kv_data,
+        pos_encoding_mode_p=pos_encoding_mode,
+        causal_p=causal,
+    )
+
+    torch.testing.assert_close(
+        o_p, o_ref_p, rtol=1e-2, atol=1e-2, msg="Prefill output mismatch"
+    )
+    torch.testing.assert_close(
+        o_d, o_ref_d, rtol=1e-2, atol=1e-2, msg="Decode output mismatch"
+    )
+
+
+@pytest.mark.parametrize("q_dtype", [torch.bfloat16])
+@pytest.mark.parametrize("kv_dtype", [torch.bfloat16])
+def test_pod_bf16(q_dtype, kv_dtype):
+    device = "cuda:0"
+    qo_len_p, kv_len_p = 64, 128
+    batch_size_d, kv_len_d, page_size_d = 4, 256, 16
+    num_qo_heads, num_kv_heads, head_dim = 8, 8, 128
+    kv_layout_d = "NHD"
+    pos_encoding_mode = "NONE"
+
+    q_p = torch.randn(qo_len_p, num_qo_heads, head_dim, device=device, dtype=q_dtype)
+    k_p = torch.randn(kv_len_p, num_kv_heads, head_dim, device=device, dtype=kv_dtype)
+    v_p = torch.randn(kv_len_p, num_kv_heads, head_dim, device=device, dtype=kv_dtype)
+
+    o_ref_p = flashinfer.single_prefill_with_kv_cache(
+        q_p,
+        k_p,
+        v_p,
+        causal=False,
+        pos_encoding_mode=pos_encoding_mode,
+    )
+
+    q_d = torch.randn(
+        batch_size_d, num_qo_heads, head_dim, device=device, dtype=q_dtype
+    )
+    num_pages_per_seq = (kv_len_d + page_size_d - 1) // page_size_d
+    total_num_pages = num_pages_per_seq * batch_size_d
+    kv_data = torch.randn(
+        total_num_pages,
+        2,
+        page_size_d,
+        num_kv_heads,
+        head_dim,
+        device=device,
+        dtype=kv_dtype,
+    )
+    kv_indptr_d = (
+        torch.arange(0, batch_size_d + 1, device=device, dtype=torch.int32)
+        * num_pages_per_seq
+    )
+    kv_indices_d = torch.arange(0, total_num_pages, device=device, dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size_d,),
+        (kv_len_d - 1) % page_size_d + 1,
+        device=device,
+        dtype=torch.int32,
+    )
+
+    decode_workspace = torch.empty(32 * 1024 * 1024, device=device, dtype=torch.int8)
+    decode_wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        decode_workspace, kv_layout_d
+    )
+    decode_wrapper.plan(
+        kv_indptr_d,
+        kv_indices_d,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size_d,
+        pos_encoding_mode=pos_encoding_mode,
+        data_type=kv_dtype,
+        q_data_type=q_dtype,
+    )
+    o_ref_d = decode_wrapper.run(q_d, kv_data)
+
+    workspace_buffer = torch.empty(32 * 1024 * 1024, device=device, dtype=torch.int8)
+    pod_wrapper = flashinfer.PODWithPagedKVCacheWrapper(workspace_buffer, kv_layout_d)
+    pod_wrapper.plan(
+        kv_indptr_d,
+        kv_indices_d,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size_d,
+        pos_encoding_mode=pos_encoding_mode,
+        data_type=kv_dtype,
+        q_data_type=q_dtype,
+    )
+    o_p, o_d = pod_wrapper.run(
+        q_p,
+        k_p,
+        v_p,
+        q_d,
+        kv_data,
+        pos_encoding_mode_p=pos_encoding_mode,
+        causal_p=False,
+    )
+
+    torch.testing.assert_close(
+        o_p, o_ref_p, rtol=1e-2, atol=1e-2, msg="bf16 prefill mismatch"
+    )
+    torch.testing.assert_close(
+        o_d, o_ref_d, rtol=1e-2, atol=1e-2, msg="bf16 decode mismatch"
+    )


### PR DESCRIPTION
## Summary

Ports POD (Prefill-On-Decode) attention to ROCm/HIP for CDNA3 (`gfx942`) and CDNA4 (`gfx950`), exposing `flashinfer.PODWithPagedKVCacheWrapper` and `flashinfer.BatchPODWithPagedKVCacheWrapper` with the same Python API as the CUDA path.

POD co-locates a prefill request and many decode requests on the same CU via a single fused kernel where each CTA dynamically picks `PREFILL` or `DECODE` work through a per-CU atomic counter, hiding the compute-bound prefill behind the bandwidth-bound decode.

### What changed

#### Generic device kernels (single-source, HIP + CUDA)
- **`include/flashinfer/attention/generic/pod.cuh`** — POD device kernel and host launcher, ported from `include/flashinfer/attention/pod.cuh`. Uses `gpu_iface` abstractions (`get_processor_id`, `kWarpSize`, MFMA, vec dtypes) so the same source compiles for wave32/wave64. PDL paths are gated to CUDA only; on HIP, falls back to plain `hipLaunchKernel`. Dynamic-LDS attribute call is no-op'd on HIP (size set by launch param).
- **`include/flashinfer/attention/generic/batch_pod.cuh`** — same shape for BatchPOD (both arms call `BatchPrefillWithPagedKVCacheDevice`).
- **`include/gpu_iface/sm_id.hpp`** — per-CU id via `__builtin_amdgcn_s_getreg(HW_REG_HW_ID …)`, extracting CU_ID|SH_ID|SE_ID from bits [15:8]. CUDA path is `mov.u32 %0, %smid;`.
- **`include/flashinfer/attention/generic/prefill.cuh`** — minor signature adjustment so the device functions accept explicit `tid` from POD's CTA-scheduler shim.

#### Scheduler fix (CUDA + HIP)
- **`include/flashinfer/attention/{pod,batch_pod}.cuh`** + their `generic/` copies — explicit `prefill_slots == 0` / `decode_slots == 0` branches so a one-sided workload never `atomicAdd`s against an empty op-quota and stalls. BatchPOD early-returns when both arms have zero padded batch.

#### HIP host wrappers + JIT templates
- **`flashinfer/csrc_rocm/{pod,batch_pod}.cu`** — `at::Tensor`-typed host wrappers mirroring `csrc_rocm/single_prefill.cu`. Uses `c10::hip::OptionalHIPGuardMasqueradingAsCUDA` + `getCurrentHIPStream()`; `hipError_t` returns.
- **`flashinfer/csrc_rocm/{pod,batch_pod}_jit_pybind.cu`** — `TORCH_LIBRARY_FRAGMENT` registrations.
- **`flashinfer/csrc_rocm/{pod,batch_pod}_{customize_config,kernel_inst}.jinja`** — Jinja templates with `gpu_iface/` includes and `dtype_map_hip` substitution.

#### JIT wiring (Python)
- **`flashinfer/jit/attention/modules_hip.py`** — adds `get_{pod,batch_pod}_uri`, `gen_{pod,batch_pod}_module`, and `gen_customize_{pod,batch_pod}_module`. The two `gen_customize_*` functions share a private `_gen_customize_pod_like_module(prefix, …)` helper to keep them in lockstep.
- **`flashinfer/jit/attention/__init__.py`** and **`flashinfer/jit/__init__.py`** — re-exports under the `elif IS_HIP:` branch so the existing `flashinfer.pod` Python wrappers find the HIP symbols transparently.
- **`flashinfer/__init__.py`** — exposes `PODWithPagedKVCacheWrapper` and `BatchPODWithPagedKVCacheWrapper` on HIP.
- **`flashinfer/pod.py`** — small parametrization tweaks for the HIP backend; no public API change.

### Architecture / design notes

- **POD is JIT-only on HIP** (matches CUDA). It is excluded from AOT in `aot_hip.py`.
- **CU-id encoding.** On CDNA3, HW_ID bits [15:8] pack `(SE_ID, SH_ID, CU_ID)` into 8 bits that uniquely identify a CU across the chip — see `gpu_iface/sm_id.hpp`.
- **Wave64 vs wave32.** All thread-index arithmetic flows through `gpu_iface::kWarpSize` so the device kernel is single-source. POD's `KernelTraits` lays down the same `NUM_WARPS_Q × NUM_WARPS_KV` totals as the unified prefill substrate.
- **LDS budget.** CDNA3 has 64 KB LDS per CU vs H100's 228 KB dynamic. The existing `num_ctas_per_sm` heuristic (which assumes ≥2 CTAs per SM when `max_smem_per_sm > 16·HEAD_DIM_QK·sizeof(DTypeQ)·16`) frequently resolves to 1 on MI300 for `head_dim=128, fp16`. Tuning the LDS budget for 2-CTA-per-CU co-location is left to a follow-up — correctness lands first.

## Test plan

- [x] `pytest tests/rocm_tests/test_pod_hip.py tests/rocm_tests/test_batch_pod_hip.py` — **123 passed, 8 skipped** on MI300X (`gfx942`). Covers `fp16` and `bf16`; `causal=True/False`; multiple `qo_len_p`, `kv_len_p`, `batch_size_d`, `kv_len_d`, `num_qo_heads` shapes.
- [x] `pytest -m "not slow" tests/rocm_tests/` — full ROCm fast-test suite passes (exit 0), confirming the POD work doesn't regress any other subsystem.
- [x] `pre-commit run -a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
