### PR TITLE
docs(claude): split CLAUDE.md sections into focused skills

### DIFF
--- a/.claude/skills/benchmark-kernel/SKILL.md
+++ b/.claude/skills/benchmark-kernel/SKILL.md
@@ -80,3 +80,16 @@ Output (under `benchmarks/rocm_benchmarks/`, gitignored):
 - **Empty `_counter_collection.csv`:** `kernel_name_regex` doesn't match the mangled name. Run `rocprofv3 --stats --kernel-trace -- python my_bench.py` first and copy the prefix from `*_kernel_stats.csv`.
 - **Hang or no output:** confirm `which rocprofv3` is on `PATH`; the wrapper uses script `print()` output as a heartbeat — make sure the `if __name__ == "__main__":` block prints something.
 - **Use `--timing-only` first** to verify the kernel path works before involving `rocprofv3`.
+
+## External tuning references
+
+When optimizing a CDNA kernel, consult these in order:
+
+- **Composable Kernel (CK)** — ground truth for LDS layout, `sched_group_barrier`
+  ratios, and tiling on CDNA. For a specific hdim/dtype combination, read
+  `qr_ks_vs.hpp` in [CK](https://github.com/ROCmSoftwarePlatform/composable_kernel)
+  first.
+- **AITER** — performance reference for fp16/hdim=256 attention on gfx942.
+  [AITER repo](https://github.com/ROCm/aiter)
+- **HipKittens** (arxiv 2511.08083) — producer/consumer patterns underperform on
+  CDNA; **4-wave interleave** is the recommended approach instead.

--- a/.claude/skills/plan-review/SKILL.md
+++ b/.claude/skills/plan-review/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: plan-review
+description: Interactive plan-mode review workflow for amd-flashinfer changes — engineering preferences, the four review stages (Architecture / Code Quality / Tests / Performance), per-issue option format, and the BIG/SMALL CHANGE interaction model. Load when entering plan mode or when the user asks for a structured plan review.
+---
+
+# Plan Review Workflow
+
+Review this plan thoroughly before making any code changes. For every issue or
+recommendation, explain the concrete tradeoffs, give an opinionated
+recommendation, and ask for the user's input before assuming a direction.
+
+## Engineering preferences (use these to guide recommendations)
+
+- **DRY is important** — tag repetition aggressively.
+- **Well-tested code is non-negotiable** — err toward too many tests, not too few.
+- Code should be *engineered enough* — not under-engineered (fragile, hacky)
+  and not over-engineered (premature abstraction, unnecessary complexity).
+- Err on the side of **readable code** over edge cases, but never thoughtlessness
+  or speed.
+
+## Review stages
+
+### 1. Architecture review
+
+- Overall system design and component boundaries.
+- Dependency graph and coupling concerns.
+- Data flow patterns and potential bottlenecks.
+- Scaling characteristics and single points of failure.
+- Security architecture (auth, data access, API boundaries).
+
+### 2. Code quality review
+
+- Code organization and module structure.
+- DRY violations — be aggressive here.
+- Error handling patterns and missing edge cases (call these out explicitly).
+- Technical debt hotspots.
+- Areas that are over- or under-engineered relative to the preferences above.
+
+### 3. Test review
+
+- Test coverage gaps (unit, integration, e2e).
+- Test quality and assertion strength.
+- Missing edge case coverage — be thorough.
+- Untested failure modes and error paths.
+
+### 4. Performance review
+
+- N+1 queries and database access patterns.
+- Memory usage concerns.
+- Caching opportunities.
+- Slow or high-complexity code paths.
+
+## Per-issue format
+
+For every specific issue (bug, smell, design concern, or risk):
+
+- Describe the problem clearly, with file and line references.
+- Present **2–3 options**, including a **"do nothing"** option where reasonable.
+- For each option, specify:
+  - Implementation effort
+  - Risk
+  - Impact on behavior, code, and maintenance burden
+- Give an explicit **recommended option** and why.
+- Then **explicitly ask whether the user wants a different direction before
+  proceeding**.
+
+## Workflow and interaction
+
+- Do **not** assume the user's priorities on timeline or scale.
+- After each section, pause and ask for feedback before moving on.
+
+## Before you start — ask which mode
+
+- **BIG CHANGE** — Work through interactively, one section at a time
+  (Architecture → Code Quality → Tests → Performance) with at most **4 top
+  issues** per section.
+- **SMALL CHANGE** — Work through interactively, **one question per review
+  section**.
+
+## For each stage
+
+Output the explanation and pros/cons of each stage's questions **and** an
+opinionated recommendation with reasoning.
+
+Then use **`AskUserQuestion`**:
+
+- Use **NUMBERED issues**.
+- Use **LETTERED options**.
+- Label each option with the issue **NUMBER** and option **LETTER** so the user
+  can reference recommendations precisely (e.g., "1A", "2C").

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: pr-workflow
+description: How to create and edit PRs on the amd-flashinfer repo — gh CLI quirks and the project's PR-description conventions.
+---
+
+# PR Workflow (amd-flashinfer)
+
+## GitHub CLI
+
+`gh pr edit` fails with a "Projects (classic) is being deprecated" GraphQL error on this repo. Use the REST API instead:
+
+```bash
+# Update PR description
+gh api repos/ROCm/flashinfer/pulls/<number> --method PATCH --field body="<body>"
+
+# Or from a file
+gh api repos/ROCm/flashinfer/pulls/<number> --method PATCH --field body="$(cat /tmp/pr_body.md)"
+```
+
+Ask to push to remote.
+
+## PR Description
+
+**Body** — include sections that apply, skip the rest:
+
+- `## Summary` — 1–3 sentences on what and why.
+- `### What changed` with `####` per component when the PR spans multiple
+  subsystems. Bullet by file: ``- **`path`** — one-line purpose``. Call out
+  non-obvious design choices.
+- `### Architecture / design notes` — only when there's a real choice to record.
+  Tables for routing/dispatch logic; explain *why*.
+- `## Benchmark results` — for perf-touching PRs. Shape line + table per entry
+  point + mean overhead/speedup row.
+- `## Test plan` — checklist of what was actually run (not aspirational), ending
+  with `pre-commit run -a`.
+
+Don't restate the diff and commits. Explain non-obvious decisions and surprising behaviors.

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -20,7 +20,8 @@ gh api repos/ROCm/flashinfer/pulls/<number> --method PATCH --field body="<body>"
 gh api repos/ROCm/flashinfer/pulls/<number> --method PATCH --field body="$(cat /tmp/pr_body.md)"
 ```
 
-Ask to push to remote.
+Ask the user to confirm before running `git push` or `gh pr create` — these
+publish to a shared repo and shouldn't be triggered without explicit consent.
 
 ## PR Description
 

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: pr-workflow
-description: How to create and edit PRs on the amd-flashinfer repo — gh CLI quirks and the project's PR-description conventions.
+description: How to create and edit PRs on the ROCm/flashinfer GitHub repo (which publishes the amd-flashinfer package) — gh CLI quirks and the project's PR-description conventions.
 ---
 
-# PR Workflow (amd-flashinfer)
+# PR Workflow (ROCm/flashinfer)
+
+> The GitHub repo is `ROCm/flashinfer`; the Python package it publishes is
+> `amd-flashinfer`. All `gh` commands below target the GitHub repo.
 
 ## GitHub CLI
 

--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,6 @@ cython_debug/
 *_counter_collection.csv
 *_roofline.png
 *.rocprofv3/
+
+# Claude Code per-developer overrides — settings.json is shared, *.local.json is not.
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,17 +19,10 @@
 
 ## Installing Torch
 
-Torch must come from AMD's ROCm repo via `--index-url`. Using `-f` (find-links)
-still allows PyPI fallback and may silently install a CPU-only wheel.
-
-```bash
-pip install torch==<torch-version> \
-  --index-url https://repo.radeon.com/rocm/manylinux/rocm-rel-<rocm-version>/
-```
-
-See the [GPU, ROCm, and PyTorch Support](README.md#gpu-rocm-and-pytorch-support)
-table in `README.md` for current `<torch-version>` and `<rocm-version>`
-values.
+Torch must come from AMD's ROCm repo via `--index-url` (not `-f`, which can
+silently install a CPU-only wheel from PyPI). See the
+[GPU, ROCm, and PyTorch Support](README.md#gpu-rocm-and-pytorch-support) table
+in `README.md` for the version and command.
 
 ## Non-Obvious Gotchas
 
@@ -65,47 +58,10 @@ cd aiter && python3 setup.py develop
 
 Check availability in code: `from flashinfer.aiter_utils import is_aiter_supported`
 
-## Key External References
+## Arch ↔ codename
 
-Arch ↔ codename mapping (frequently needed mid-coding): MI300X / MI325X =
-gfx942 = CDNA3; MI350X = gfx950 = CDNA4.
+MI300X / MI325X = gfx942 = CDNA3; MI350X = gfx950 = CDNA4.
 
-- **Composable Kernel (CK)** — ground truth for LDS layout,
-  `sched_group_barrier` ratios, and tiling on CDNA. When tuning a kernel,
-  read `qr_ks_vs.hpp` in [CK](https://github.com/ROCmSoftwarePlatform/composable_kernel)
-  for the specific hdim/dtype combination first.
-- **AITER** — performance reference for fp16/hdim=256 attention on gfx942.
-  [AITER repo](https://github.com/ROCm/aiter)
-- **HipKittens** (arxiv 2511.08083) — producer/consumer patterns underperform
-  on CDNA; 4-wave interleave is the recommended approach.
-
-## GitHub CLI
-
-`gh pr edit` fails with a "Projects (classic) is being deprecated" GraphQL error on this repo. Use the REST API instead:
-
-```bash
-# Update PR description
-gh api repos/ROCm/flashinfer/pulls/<number> --method PATCH --field body="<body>"
-
-# Or from a file
-gh api repos/ROCm/flashinfer/pulls/<number> --method PATCH --field body="$(cat /tmp/pr_body.md)"
-```
-
-Ask to push to remote.
-
-## PR Description
-
-**Body** — include sections that apply, skip the rest:
-
-- `## Summary` — 1–3 sentences on what and why.
-- `### What changed` with `####` per component when the PR spans multiple
-  subsystems. Bullet by file: ``- **`path`** — one-line purpose``. Call out
-  non-obvious design choices.
-- `### Architecture / design notes` — only when there's a real choice to record.
-  Tables for routing/dispatch logic; explain *why*.
-- `## Benchmark results` — for perf-touching PRs. Shape line + table per entry
-  point + mean overhead/speedup row.
-- `## Test plan` — checklist of what was actually run (not aspirational), ending
-  with `pre-commit run -a`.
-
-Don't restate the diff and commits. Explain non-obvious decisions and surprising behaviors.
+External tuning references (CK, AITER, HipKittens) live in the
+`benchmark-kernel` skill; PR/`gh` workflow details live in the `pr-workflow`
+skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Check availability in code: `from flashinfer.aiter_utils import is_aiter_support
 
 ## Arch ↔ codename
 
-MI300X / MI325X = gfx942 = CDNA3; MI350X = gfx950 = CDNA4.
+MI300X / MI325X = gfx942 = CDNA3; MI355X = gfx950 = CDNA4.
 
 External tuning references (CK, AITER, HipKittens) live in the
 `benchmark-kernel` skill; PR/`gh` workflow details live in the `pr-workflow`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,4 +64,15 @@ MI300X / MI325X = gfx942 = CDNA3; MI355X = gfx950 = CDNA4.
 
 External tuning references (CK, AITER, HipKittens) live in the
 `benchmark-kernel` skill; PR/`gh` workflow details live in the `pr-workflow`
-skill.
+skill; the interactive plan-review workflow lives in the `plan-review` skill.
+
+## Model Usage Policy
+
+- **Plan Mode** (`/plan` or Shift+Tab): Always use `opus` at max effort for architecture decisions, system design, and multi-file analysis.
+- **Agent / Agentic tasks**: Use `opus` at high effort when running multi-step autonomous tasks (bash commands, multi-file edits).
+- **Edit / Implementation**: Use `sonnet` for routine code implementation, test writing, and refactoring once a plan is approved.
+- **Quick tasks**: Use `sonnet` for Q&A, simple lookups, and documentation.
+
+Switch model before starting each phase:
+  /model opus     → for planning and agent runs
+  /model sonnet   → for implementation and quick tasks


### PR DESCRIPTION
## Summary

Split conditional-use guidance out of the always-loaded `CLAUDE.md` into focused Claude Code skills, so PR/`gh` workflow advice, external tuning references, and the interactive plan-review prompt only enter the model's context when the relevant skill is invoked. Net: `CLAUDE.md` shrinks ~60% (4.6 KB → ~1.8 KB), and per-developer Claude settings are now ignored from git.

### What changed

- **`CLAUDE.md`** — drop the `GitHub CLI`, `PR Description`, and `Key External References` sections (now live in skills); move the ~100-line plan-mode review prompt into a `plan-review` skill; collapse the `Installing Torch` blurb into a one-line pointer to the README table; shrink the Arch ↔ codename note to one line. The short *Model Usage Policy* stays in `CLAUDE.md` (broadly applicable, low cost).
- **`.claude/skills/pr-workflow/SKILL.md`** (new) — holds the `gh api repos/ROCm/flashinfer/pulls/...` workaround for the `gh pr edit` GraphQL failure and the project's PR-description template.
- **`.claude/skills/plan-review/SKILL.md`** (new) — interactive plan-mode review workflow: engineering preferences, the four review stages (Architecture / Code Quality / Tests / Performance), the per-issue option format, and the BIG/SMALL CHANGE interaction model. While moving, the non-existent `AskBeforeAction` tool reference was replaced with the real `AskUserQuestion` tool so the skill is actionable as written.
- **`.claude/skills/benchmark-kernel/SKILL.md`** — appends an *External tuning references* section (CK as the ground truth for LDS/scheduling, AITER as fp16/hdim=256 perf reference, HipKittens 4-wave-interleave guidance). These are tuning-time references, naturally co-located with the benchmarking guide.
- **`.gitignore`** — ignore `.claude/settings.local.json` so per-developer Claude Code overrides aren't committed.

### Design notes

- The split follows the principle that `CLAUDE.md` loads into every prompt while skills load only on invocation. External tuning references, PR-edit quirks, and the plan-mode review template are all conditional-use, so they belong in skills.
- The tuning references landed in `benchmark-kernel` (not `add-rocm-kernel`) because they're consulted during *perf iteration*, not initial scaffolding.
- Plan-review prompt is moved verbatim apart from the `AskBeforeAction` → `AskUserQuestion` substitution (real Claude Code tool name).

## Test plan

- [x] `git diff` reviewed — only doc/skill files touched
- [x] `pre-commit run --files` clean on every commit (markdownlint, trailing whitespace, line endings)
- [x] Cross-references between `CLAUDE.md` and the three skills verified
- [x] `.claude/settings.local.json` confirmed ignored (`git check-ignore`)