### PR TITLE
fix(comm): make flashinfer.comm safe to import on ROCm with clean ImportError surface

### DIFF
--- a/flashinfer/comm/__init__.py
+++ b/flashinfer/comm/__init__.py
@@ -51,5 +51,47 @@ if IS_CUDA:
     from .vllm_ar import meta_size as vllm_meta_size
     from .vllm_ar import register_buffer as vllm_register_buffer
     from .vllm_ar import register_graph_buffers as vllm_register_graph_buffers
+else:
+    # On ROCm, every other comm submodule is CUDA-only: cuda_ipc and
+    # trtllm_ar eagerly bind to libcudart at import time (AssertionError);
+    # vllm_ar / nvshmem / nvshmem_allreduce import OK but explode at call
+    # time when JIT loading triggers; mnnvl imports pynvml which isn't
+    # installed. Install a meta-path finder that intercepts every
+    # CUDA-only submodule lookup and raises a uniform catchable
+    # ImportError — for both `from X import Y` and plain `import X`.
+    import importlib.abc
+    import importlib.machinery
+    import sys
+
+    _CUDA_ONLY_SUBMODULES = frozenset(
+        {
+            "flashinfer.comm.cuda_ipc",
+            "flashinfer.comm.trtllm_ar",
+            "flashinfer.comm.trtllm_alltoall",
+            "flashinfer.comm.trtllm_mnnvl_ar",
+            "flashinfer.comm.vllm_ar",
+            "flashinfer.comm.mnnvl",
+            "flashinfer.comm.nvshmem",
+            "flashinfer.comm.nvshmem_allreduce",
+        }
+    )
+
+    class _CudaOnlyLoader(importlib.abc.Loader):
+        def create_module(self, spec):
+            return None
+
+        def exec_module(self, module):
+            raise ImportError(
+                f"{module.__spec__.name} is CUDA-only and not available on ROCm"
+            )
+
+    class _CudaOnlyFinder(importlib.abc.MetaPathFinder):
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname in _CUDA_ONLY_SUBMODULES:
+                return importlib.machinery.ModuleSpec(fullname, _CudaOnlyLoader())
+            return None
+
+    if not any(isinstance(f, _CudaOnlyFinder) for f in sys.meta_path):
+        sys.meta_path.insert(0, _CudaOnlyFinder())
 
 # from .mnnvl import MnnvlMemory, MnnvlMoe, MoEAlltoallInfo

--- a/flashinfer/comm/__init__.py
+++ b/flashinfer/comm/__init__.py
@@ -86,12 +86,20 @@ else:
             )
 
     class _CudaOnlyFinder(importlib.abc.MetaPathFinder):
+        # Stable marker so the idempotency check below survives
+        # importlib.reload(flashinfer.comm), which redefines the class object
+        # and would otherwise make isinstance() return False against the
+        # already-installed finder from the previous load.
+        _is_flashinfer_cuda_only_finder = True
+
         def find_spec(self, fullname, path=None, target=None):
             if fullname in _CUDA_ONLY_SUBMODULES:
                 return importlib.machinery.ModuleSpec(fullname, _CudaOnlyLoader())
             return None
 
-    if not any(isinstance(f, _CudaOnlyFinder) for f in sys.meta_path):
+    if not any(
+        getattr(f, "_is_flashinfer_cuda_only_finder", False) for f in sys.meta_path
+    ):
         sys.meta_path.insert(0, _CudaOnlyFinder())
 
 # from .mnnvl import MnnvlMemory, MnnvlMoe, MoEAlltoallInfo

--- a/flashinfer/comm/__init__.py
+++ b/flashinfer/comm/__init__.py
@@ -1,42 +1,56 @@
-from .cuda_ipc import CudaRTLibrary, create_shared_buffer, free_shared_buffer
+from ..device_utils import IS_CUDA
+
+# Backend-agnostic exports (pure Python, work on both CUDA and ROCm).
 from .dlpack_utils import pack_strided_memory
 from .mapping import Mapping
-from .trtllm_ar import AllReduceFusionOp as AllReduceFusionOp
-from .trtllm_ar import AllReduceFusionPattern as AllReduceFusionPattern
-from .trtllm_ar import AllReduceStrategyConfig as AllReduceStrategyConfig
-from .trtllm_ar import AllReduceStrategyType as AllReduceStrategyType
-from .trtllm_ar import QuantizationSFLayout as QuantizationSFLayout
-from .trtllm_ar import (
-    compute_fp4_swizzled_layout_sf_size as compute_fp4_swizzled_layout_sf_size,
-)
-from .trtllm_ar import gen_trtllm_comm_module as gen_trtllm_comm_module
-from .trtllm_ar import trtllm_allreduce_fusion as trtllm_allreduce_fusion
-from .trtllm_ar import (
-    trtllm_create_ipc_workspace_for_all_reduce as trtllm_create_ipc_workspace_for_all_reduce,
-)
-from .trtllm_ar import (
-    trtllm_create_ipc_workspace_for_all_reduce_fusion as trtllm_create_ipc_workspace_for_all_reduce_fusion,
-)
-from .trtllm_ar import trtllm_custom_all_reduce as trtllm_custom_all_reduce
-from .trtllm_ar import (
-    trtllm_destroy_ipc_workspace_for_all_reduce as trtllm_destroy_ipc_workspace_for_all_reduce,
-)
-from .trtllm_ar import (
-    trtllm_destroy_ipc_workspace_for_all_reduce_fusion as trtllm_destroy_ipc_workspace_for_all_reduce_fusion,
-)
-from .trtllm_ar import trtllm_lamport_initialize as trtllm_lamport_initialize
-from .trtllm_ar import trtllm_lamport_initialize_all as trtllm_lamport_initialize_all
-from .trtllm_ar import trtllm_moe_allreduce_fusion as trtllm_moe_allreduce_fusion
-from .trtllm_ar import (
-    trtllm_moe_finalize_allreduce_fusion as trtllm_moe_finalize_allreduce_fusion,
-)
-from .vllm_ar import all_reduce as vllm_all_reduce
-from .vllm_ar import dispose as vllm_dispose
-from .vllm_ar import gen_vllm_comm_module as gen_vllm_comm_module
-from .vllm_ar import get_graph_buffer_ipc_meta as vllm_get_graph_buffer_ipc_meta
-from .vllm_ar import init_custom_ar as vllm_init_custom_ar
-from .vllm_ar import meta_size as vllm_meta_size
-from .vllm_ar import register_buffer as vllm_register_buffer
-from .vllm_ar import register_graph_buffers as vllm_register_graph_buffers
+
+# CUDA-only re-exports: cuda_ipc binds to libcudart at import time, and
+# trtllm_ar / vllm_ar / mnnvl wrap kernels and APIs (CUDA IPC, NVSHMEM,
+# NVLink) with no ROCm equivalents. Load only on CUDA so `import
+# flashinfer.comm` succeeds on ROCm — callers that need these features
+# (e.g. vLLM's flashinfer_all_reduce.py) detect availability via attribute
+# checks like `hasattr(flashinfer_comm, "allreduce_fusion")`, which return
+# False here. Matches the IS_CUDA / IS_HIP split in flashinfer/__init__.py.
+if IS_CUDA:
+    from .cuda_ipc import CudaRTLibrary, create_shared_buffer, free_shared_buffer
+    from .trtllm_ar import AllReduceFusionOp as AllReduceFusionOp
+    from .trtllm_ar import AllReduceFusionPattern as AllReduceFusionPattern
+    from .trtllm_ar import AllReduceStrategyConfig as AllReduceStrategyConfig
+    from .trtllm_ar import AllReduceStrategyType as AllReduceStrategyType
+    from .trtllm_ar import QuantizationSFLayout as QuantizationSFLayout
+    from .trtllm_ar import (
+        compute_fp4_swizzled_layout_sf_size as compute_fp4_swizzled_layout_sf_size,
+    )
+    from .trtllm_ar import gen_trtllm_comm_module as gen_trtllm_comm_module
+    from .trtllm_ar import trtllm_allreduce_fusion as trtllm_allreduce_fusion
+    from .trtllm_ar import (
+        trtllm_create_ipc_workspace_for_all_reduce as trtllm_create_ipc_workspace_for_all_reduce,
+    )
+    from .trtllm_ar import (
+        trtllm_create_ipc_workspace_for_all_reduce_fusion as trtllm_create_ipc_workspace_for_all_reduce_fusion,
+    )
+    from .trtllm_ar import trtllm_custom_all_reduce as trtllm_custom_all_reduce
+    from .trtllm_ar import (
+        trtllm_destroy_ipc_workspace_for_all_reduce as trtllm_destroy_ipc_workspace_for_all_reduce,
+    )
+    from .trtllm_ar import (
+        trtllm_destroy_ipc_workspace_for_all_reduce_fusion as trtllm_destroy_ipc_workspace_for_all_reduce_fusion,
+    )
+    from .trtllm_ar import trtllm_lamport_initialize as trtllm_lamport_initialize
+    from .trtllm_ar import (
+        trtllm_lamport_initialize_all as trtllm_lamport_initialize_all,
+    )
+    from .trtllm_ar import trtllm_moe_allreduce_fusion as trtllm_moe_allreduce_fusion
+    from .trtllm_ar import (
+        trtllm_moe_finalize_allreduce_fusion as trtllm_moe_finalize_allreduce_fusion,
+    )
+    from .vllm_ar import all_reduce as vllm_all_reduce
+    from .vllm_ar import dispose as vllm_dispose
+    from .vllm_ar import gen_vllm_comm_module as gen_vllm_comm_module
+    from .vllm_ar import get_graph_buffer_ipc_meta as vllm_get_graph_buffer_ipc_meta
+    from .vllm_ar import init_custom_ar as vllm_init_custom_ar
+    from .vllm_ar import meta_size as vllm_meta_size
+    from .vllm_ar import register_buffer as vllm_register_buffer
+    from .vllm_ar import register_graph_buffers as vllm_register_graph_buffers
 
 # from .mnnvl import MnnvlMemory, MnnvlMoe, MoEAlltoallInfo

--- a/flashinfer/comm/__init__.py
+++ b/flashinfer/comm/__init__.py
@@ -5,12 +5,11 @@ from .dlpack_utils import pack_strided_memory
 from .mapping import Mapping
 
 # CUDA-only re-exports: cuda_ipc binds to libcudart at import time, and
-# trtllm_ar / vllm_ar / mnnvl wrap kernels and APIs (CUDA IPC, NVSHMEM,
-# NVLink) with no ROCm equivalents. Load only on CUDA so `import
-# flashinfer.comm` succeeds on ROCm — callers that need these features
-# (e.g. vLLM's flashinfer_all_reduce.py) detect availability via attribute
-# checks like `hasattr(flashinfer_comm, "allreduce_fusion")`, which return
-# False here. Matches the IS_CUDA / IS_HIP split in flashinfer/__init__.py.
+# trtllm_ar / vllm_ar wrap kernels and APIs with no ROCm equivalents.
+# Load only on CUDA so `import flashinfer.comm` succeeds on ROCm; callers
+# that need these features can detect availability via the exported CUDA-only
+# names, such as `trtllm_allreduce_fusion`. Matches the IS_CUDA / IS_HIP
+# split in flashinfer/__init__.py.
 if IS_CUDA:
     from .cuda_ipc import CudaRTLibrary, create_shared_buffer, free_shared_buffer
     from .trtllm_ar import AllReduceFusionOp as AllReduceFusionOp

--- a/flashinfer/comm/cuda_ipc.py
+++ b/flashinfer/comm/cuda_ipc.py
@@ -21,6 +21,15 @@ from typing import Any, Dict, List, Optional
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
 
+from ..device_utils import IS_HIP
+
+# cuda_ipc uses libcudart and the CUDA IPC API (cudaIpcGetMemHandle /
+# cudaIpcOpenMemHandle), which have no ROCm equivalents. Raise ImportError
+# immediately so callers that wrap the import in try/except ImportError
+# (e.g. vLLM's flashinfer_all_reduce.py) degrade gracefully on ROCm.
+if IS_HIP:
+    raise ImportError("flashinfer.comm.cuda_ipc is not available on ROCm/HIP")
+
 # NOTE(Zihao): we should use cuda-python instead of ctypes cuda runtime bindings.
 # However, cuda-python's API is not stable yet, so we use ctypes bindings instead.
 # which is copied from vllm codebase.

--- a/flashinfer/comm/cuda_ipc.py
+++ b/flashinfer/comm/cuda_ipc.py
@@ -21,15 +21,6 @@ from typing import Any, Dict, List, Optional
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
 
-from ..device_utils import IS_HIP
-
-# cuda_ipc uses libcudart and the CUDA IPC API (cudaIpcGetMemHandle /
-# cudaIpcOpenMemHandle), which have no ROCm equivalents. Raise ImportError
-# immediately so callers that wrap the import in try/except ImportError
-# (e.g. vLLM's flashinfer_all_reduce.py) degrade gracefully on ROCm.
-if IS_HIP:
-    raise ImportError("flashinfer.comm.cuda_ipc is not available on ROCm/HIP")
-
 # NOTE(Zihao): we should use cuda-python instead of ctypes cuda runtime bindings.
 # However, cuda-python's API is not stable yet, so we use ctypes bindings instead.
 # which is copied from vllm codebase.

--- a/tests/rocm_tests/test_comm_import_gate_hip.py
+++ b/tests/rocm_tests/test_comm_import_gate_hip.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for the ROCm import gate in flashinfer/comm/__init__.py.
+#
+# On ROCm the comm package must:
+#   1. Import successfully and expose the backend-agnostic re-exports
+#      (Mapping, pack_strided_memory).
+#   2. Raise ImportError — not AssertionError — for every CUDA-only submodule,
+#      via both `import X` and `from X import Y`. vLLM's
+#      flashinfer_all_reduce.py guards on ImportError; anything else escapes.
+
+import importlib
+
+import pytest
+
+from flashinfer.device_utils import IS_HIP
+
+pytestmark = pytest.mark.skipif(
+    not IS_HIP, reason="comm import gate is only installed on ROCm"
+)
+
+
+_CUDA_ONLY_SUBMODULES = [
+    "flashinfer.comm.cuda_ipc",
+    "flashinfer.comm.trtllm_ar",
+    "flashinfer.comm.trtllm_alltoall",
+    "flashinfer.comm.trtllm_mnnvl_ar",
+    "flashinfer.comm.vllm_ar",
+    "flashinfer.comm.mnnvl",
+    "flashinfer.comm.nvshmem",
+    "flashinfer.comm.nvshmem_allreduce",
+]
+
+
+def test_comm_package_imports_and_exposes_backend_agnostic_symbols():
+    import flashinfer.comm as comm
+
+    assert hasattr(comm, "Mapping")
+    assert hasattr(comm, "pack_strided_memory")
+
+
+@pytest.mark.parametrize("modname", _CUDA_ONLY_SUBMODULES)
+def test_cuda_only_submodule_import_raises_importerror(modname):
+    with pytest.raises(ImportError):
+        importlib.import_module(modname)
+
+
+@pytest.mark.parametrize("modname", _CUDA_ONLY_SUBMODULES)
+def test_cuda_only_submodule_from_import_raises_importerror(modname):
+    # `from X import Y` exercises a different code path than plain
+    # `import X` — the loader must raise ImportError for both.
+    with pytest.raises(ImportError):
+        exec(f"from {modname} import _anything", {})


### PR DESCRIPTION
## Problem

`flashinfer/comm/__init__.py` line 1 does `from .cuda_ipc import ...`, and `cuda_ipc.py` instantiates `CudaRTLibrary()` at module level (line 194). `CudaRTLibrary.__init__` calls `find_loaded_library("libcudart")` and asserts the result is not `None` — which fails on ROCm with:

`AssertionError: libcudart is not loaded in the current process`

`cuda_ipc.py` is entirely CUDA-specific (it wraps `libcudart` and uses the CUDA IPC API), and the other CUDA-bound modules under `comm/` — `trtllm_ar`, `vllm_ar`, `mnnvl`, `nvshmem`, `nvshmem_allreduce` — have no ROCm equivalents either.

The crash surfaces when `flashinfer.comm` is imported on ROCm — e.g. by vLLM's `distributed/device_communicators/flashinfer_all_reduce.py`, which wraps the import in `try/except ImportError`. Since `AssertionError` is not a subclass of `ImportError`, the guard does not catch it and the worker crashes at startup.

## Hazard surface on ROCm (before this PR)

| Import | Behavior |
|---|---|
| `import flashinfer.comm` | ❌ `AssertionError` (from `cuda_ipc` at line 1 of `__init__.py`) |
| `from flashinfer.comm.cuda_ipc import X` | ❌ `AssertionError` (uncatchable as `ImportError`) |
| `from flashinfer.comm.trtllm_ar import X` | ❌ `AssertionError` (transitively via `cuda_ipc`) |
| `from flashinfer.comm.vllm_ar import X` | ⚠️ imports OK, JIT explodes at call time |
| `from flashinfer.comm.nvshmem import X` | ⚠️ imports OK, JIT explodes at call time |
| `from flashinfer.comm.nvshmem_allreduce import X` | ⚠️ imports OK, JIT explodes at call time |

## Fix

Two-part change to `flashinfer/comm/__init__.py`:

### 1. Gate CUDA-only re-exports behind `if IS_CUDA:`

Move all CUDA-bound imports (`cuda_ipc`, `trtllm_ar`, `vllm_ar`) into an `if IS_CUDA:` block. Pure-Python modules (`mapping`, `dlpack_utils`) stay unconditional. This mirrors the `IS_CUDA / IS_HIP` split already used in `flashinfer/__init__.py`.

After this part: `import flashinfer.comm` succeeds on ROCm and exposes `Mapping` and `pack_strided_memory`. CUDA-only names are simply absent — `hasattr(flashinfer_comm, "allreduce_fusion")` returns `False`, which is exactly what vLLM's guard checks.

### 2. Install a `sys.meta_path` finder for CUDA-only submodule imports

Part 1 alone fixed the package-level `import flashinfer.comm` but left the per-submodule hazards intact: direct imports like `from flashinfer.comm.cuda_ipc import X` still leak `AssertionError`, and `vllm_ar` / `nvshmem` / `nvshmem_allreduce` still appear to succeed at import then explode at call time.

The `else:` branch installs an `importlib.abc.MetaPathFinder` + `Loader` pair that intercepts every CUDA-only submodule lookup on ROCm and raises a uniform catchable `ImportError` — for both `from X import Y` and plain `import X`. The blocklist covers all 8 CUDA-bound submodules under `comm/`.

The finder/loader pattern was chosen over the simpler `sys.modules` stub approach because the latter breaks torch — torch's `inspect.getmodule()` walks `sys.modules` and calls `hasattr(m, '__file__')` on every entry, and Python 3's `hasattr` only suppresses `AttributeError`. Stubs that raise from `__getattr__` propagate into torch's normal operation. The finder doesn't put anything in `sys.modules` until an actual import attempt, so torch's walks see nothing to trip over.

## Hazard surface on ROCm (after this PR)

| Import | Behavior |
|---|---|
| `import flashinfer.comm` | ✅ ok |
| `from flashinfer.comm import Mapping` / `pack_strided_memory` | ✅ ok |
| `from flashinfer.comm import vllm_all_reduce` *(or any CUDA-only name)* | ✅ `ImportError` |
| `import flashinfer.comm.cuda_ipc` / `trtllm_ar` / `vllm_ar` / `nvshmem` / `nvshmem_allreduce` / `mnnvl` / `trtllm_alltoall` / `trtllm_mnnvl_ar` | ✅ `ImportError` with clear message |
| `from flashinfer.comm.<any CUDA-only submodule> import X` | ✅ `ImportError` with clear message |
| `import flashinfer.comm.mapping` / `dlpack_utils` | ✅ ok |

## Why all of this lives in `comm/__init__.py`

The AMD-specific delta is intentionally confined to one file:

- `cuda_ipc.py`, `trtllm_ar.py`, `vllm_ar.py`, etc. stay byte-identical to upstream — zero merge friction when upstream changes them.
- `comm/__init__.py` is effectively an index file; the fork can own it.
- The blocklist of CUDA-only submodules is one tuple in one place; future upstream-added `comm/foo.py` modules need one string added during merge, easy to spot in PR review.

## Testing

Verified on MI300X (gfx942):

- [x] `import flashinfer.comm` succeeds
- [x] `from flashinfer.comm import Mapping` works on ROCm
- [x] Every direct import of a CUDA-only submodule raises `ImportError` with a clear message
- [x] vLLM's exact import pattern from `flashinfer_all_reduce.py` sets `fi_ar_available = False` cleanly with no uncaught exceptions; the worker initialises cleanly
- [x] Full `import flashinfer` plus `torch.zeros(4, device='cuda')` works unchanged — the meta-path finder does not interfere with torch's `sys.modules` walks
