### PR TITLE
feat(hip,aiter): route single-prefill through AITER mha_fwd (batch-mode) .so

### DIFF
--- a/flashinfer/csrc_rocm/aiter_loader.cc
+++ b/flashinfer/csrc_rocm/aiter_loader.cc
@@ -32,13 +32,20 @@ std::string get_jit_dir() {
 }
 
 // Build a variant .so filename from a key.
-// Segments: {prefix}{dtype}_{logits}_{bias}_{mask}_{lse}{suffix}
-// mha_varlen_fwd:    prefix="mha_varlen_fwd_",   suffix="_ndropout_nskip_nqscale.so"
-// mha_batch_prefill: prefix="mha_batch_prefill_", suffix="_ndropout_nqscale.so"
-std::string build_so_name(VariantKey const& key, std::string_view prefix, std::string_view suffix) {
+// Segments: {prefix}{dtype}[_{logits}]_{bias}_{mask}_{lse}{suffix}
+// mha_varlen_fwd:    prefix="mha_varlen_fwd_",   include_logits=true,
+//                    suffix="_ndropout_nskip_nqscale.so"
+// mha_fwd:           prefix="mha_fwd_",          include_logits=false,
+//                    suffix="_ndropout_nqscale.so"
+// mha_batch_prefill: prefix="mha_batch_prefill_", include_logits=true,
+//                    suffix="_ndropout_nqscale.so"
+std::string build_so_name(VariantKey const& key, std::string_view prefix, std::string_view suffix,
+                          bool include_logits) {
   std::string name(prefix);
   name += (key.dtype == VariantKey::Dtype::kFp16) ? "fp16" : "bf16";
-  name += key.has_logits_cap ? "_logits" : "_nlogits";
+  if (include_logits) {
+    name += key.has_logits_cap ? "_logits" : "_nlogits";
+  }
   name += key.has_alibi ? "_alibi" : "_nbias";
   name += key.causal ? "_mask" : "_nmask";
   name += key.has_lse ? "_lse" : "_nlse";
@@ -82,25 +89,37 @@ void* load_and_cache_sym(std::shared_mutex& mu, std::unordered_map<Key, void*, H
   return sym;
 }
 
-// ----- varlen MHA cache -----
-
-std::string variant_so_name(VariantKey const& key) {
-  return build_so_name(key, "mha_varlen_fwd_", "_ndropout_nskip_nqscale.so");
-}
-
 // Mangled symbol for aiter::mha_fwd(aiter::mha_fwd_args, ck_tile::stream_config const&).
 // Stable across GCC/Clang Itanium ABI; verified by `nm -D` on all shipped variants.
+// Both the mha_fwd and mha_varlen_fwd .so files export this same dispatcher symbol.
 // Pinned to amd-aiter 0.1.10. Regenerate with: nm -D <variant.so> | grep mha_fwd
 constexpr const char* kMhaFwdSymbol =
     "_ZN5aiter7mha_fwdENS_12mha_fwd_argsERKN7ck_tile13stream_configE";
 
-std::shared_mutex s_mu;
-std::unordered_map<VariantKey, void*, VariantKeyHash> s_cache;
+// ----- mha_fwd (non-varlen, batch-mode CK) cache -----
+
+std::string mha_fwd_variant_so_name(VariantKey const& key) {
+  return build_so_name(key, "mha_fwd_", "_ndropout_nqscale.so", /*include_logits=*/false);
+}
+
+std::shared_mutex s_mf_mu;
+std::unordered_map<VariantKey, void*, VariantKeyHash> s_mf_cache;
+
+// ----- mha_varlen_fwd (varlen, group-mode CK) cache -----
+
+std::string mha_varlen_fwd_variant_so_name(VariantKey const& key) {
+  return build_so_name(key, "mha_varlen_fwd_", "_ndropout_nskip_nqscale.so",
+                       /*include_logits=*/true);
+}
+
+std::shared_mutex s_vl_mu;
+std::unordered_map<VariantKey, void*, VariantKeyHash> s_vl_cache;
 
 // ----- batch-prefill cache -----
 
 std::string batch_prefill_variant_so_name(BatchPrefillVariantKey const& key) {
-  return build_so_name(key, "mha_batch_prefill_", "_ndropout_nqscale.so");
+  return build_so_name(key, "mha_batch_prefill_", "_ndropout_nqscale.so",
+                       /*include_logits=*/true);
 }
 
 // Itanium-ABI mangled symbol for aiter::mha_batch_prefill(...).
@@ -138,8 +157,19 @@ std::unordered_map<ExternCKey, void*, ExternCKeyHash> s_ec_cache;
 }  // namespace
 
 void* get_aiter_mha_fwd_handle(VariantKey const& key) {
-  std::string so_path = get_jit_dir() + "/" + variant_so_name(key);
-  return load_and_cache_sym(s_mu, s_cache, key, so_path, kMhaFwdSymbol, [&key, &so_path]() {
+  std::string so_path = get_jit_dir() + "/" + mha_fwd_variant_so_name(key);
+  return load_and_cache_sym(s_mf_mu, s_mf_cache, key, so_path, kMhaFwdSymbol, [&key, &so_path]() {
+    return "  Hint: trigger AITER's lazy JIT build by importing aiter.ops.mha and "
+           "calling mha_fwd with matching (dtype=" +
+           std::string(key.dtype == VariantKey::Dtype::kFp16 ? "fp16" : "bf16") +
+           ", causal=" + (key.causal ? "true" : "false") +
+           ", has_lse=" + (key.has_lse ? "true" : "false") + ").";
+  });
+}
+
+void* get_aiter_mha_varlen_fwd_handle(VariantKey const& key) {
+  std::string so_path = get_jit_dir() + "/" + mha_varlen_fwd_variant_so_name(key);
+  return load_and_cache_sym(s_vl_mu, s_vl_cache, key, so_path, kMhaFwdSymbol, [&key, &so_path]() {
     return "  Hint: trigger AITER's lazy JIT build by importing aiter.ops.mha and "
            "calling mha_varlen_fwd with matching (dtype=" +
            std::string(key.dtype == VariantKey::Dtype::kFp16 ? "fp16" : "bf16") +

--- a/flashinfer/csrc_rocm/aiter_loader.cc
+++ b/flashinfer/csrc_rocm/aiter_loader.cc
@@ -157,6 +157,12 @@ std::unordered_map<ExternCKey, void*, ExternCKeyHash> s_ec_cache;
 }  // namespace
 
 void* get_aiter_mha_fwd_handle(VariantKey const& key) {
+  if (key.has_logits_cap) {
+    throw std::runtime_error(
+        "get_aiter_mha_fwd_handle called with has_logits_cap=true; the mha_fwd "
+        "template has no _logits arm and would silently ignore logits_soft_cap. "
+        "Use get_aiter_mha_varlen_fwd_handle for this trait.");
+  }
   std::string so_path = get_jit_dir() + "/" + mha_fwd_variant_so_name(key);
   return load_and_cache_sym(s_mf_mu, s_mf_cache, key, so_path, kMhaFwdSymbol, [&key, &so_path]() {
     return "  Hint: trigger AITER's lazy JIT build by importing aiter.ops.mha and "

--- a/flashinfer/csrc_rocm/single_prefill_aiter.cu
+++ b/flashinfer/csrc_rocm/single_prefill_aiter.cu
@@ -22,8 +22,10 @@ using flashinfer::MaskMode;
 using flashinfer::QKVLayout;
 
 // Cache of device seqstart tensors keyed by (qo_len, kv_len, device_index).
-// Group-mode AITER variants require seqstart arrays [0, seqlen] on device.
-// Caching eliminates per-call allocation + H2D copy (~15 µs fixed overhead).
+// The mha_fwd .so handles batch=1 in batch mode (no seqstart needed); only the
+// logits_soft_cap path is forced onto the group-mode mha_varlen_fwd .so, which
+// requires seqstart [0, seqlen] arrays on device. Caching eliminates per-call
+// allocation + H2D copy (~15 µs fixed overhead).
 namespace {
 struct SeqstartKey {
   uint32_t qo_len, kv_len;
@@ -121,12 +123,12 @@ void single_prefill_with_kv_cache(at::Tensor q, at::Tensor k, at::Tensor v, at::
   params.window_left = static_cast<int32_t>(window_left);
   ADDITIONAL_PARAMS_SETTER
 
-  // The ASM v3 fast path is batch-mode; only the group-mode CK Tile fallback
-  // needs the per-(qo_len, kv_len) seqstart [0, len] device tensors.
+  // The mha_fwd .so dispatches batch=1 directly via stride/nhead_stride; only the
+  // mha_varlen_fwd .so (used when logits_soft_cap > 0) needs the per-(qo_len, kv_len)
+  // seqstart [0, len] device tensors.
   const int32_t* cu_seqlens_q_ptr = nullptr;
   const int32_t* cu_seqlens_k_ptr = nullptr;
-  if (!flashinfer::AiterAsmV3Eligible(HEAD_DIM_QK, HEAD_DIM_VO, dtype_enum,
-                                      params.logits_soft_cap > 0.0f, params.window_left)) {
+  if (params.logits_soft_cap > 0.0f) {
     std::tie(cu_seqlens_q_ptr, cu_seqlens_k_ptr) =
         get_seqstart_ptrs(params.qo_len, params.kv_len, device);
   }

--- a/flashinfer/prefill_rocm.py
+++ b/flashinfer/prefill_rocm.py
@@ -367,7 +367,7 @@ _aiter_bootstrap_lock = threading.Lock()
 
 
 @functools.lru_cache(maxsize=None)
-def _aiter_bootstrap_single_prefill(
+def _aiter_bootstrap_single_prefill_varlen(
     dtype: torch.dtype,
     head_dim: int,
     device_idx: int,
@@ -376,7 +376,8 @@ def _aiter_bootstrap_single_prefill(
 
     Non-logits and non-causal variants are pre-shipped with the AITER package.
     The logits+causal combination is missing from the pre-built set and must be
-    bootstrapped on first use.
+    bootstrapped on first use. Used by single-prefill when logits_soft_cap > 0
+    (which forces the varlen .so because mha_fwd has no _logits arm).
     """
     device = torch.device("cuda", device_idx)
     q = torch.zeros(2, 2, head_dim, dtype=dtype, device=device)
@@ -403,6 +404,43 @@ def _aiter_bootstrap_single_prefill(
         torch.ops.aiter.mha_varlen_fwd(
             q, k, v, cu_q, cu_k, return_softmax_lse=return_lse, **_common
         )
+
+
+@functools.lru_cache(maxsize=None)
+def _aiter_bootstrap_single_prefill_mha_fwd(
+    dtype: torch.dtype,
+    causal: bool,
+    has_lse: bool,
+    head_dim: int,
+    device_idx: int,
+) -> None:
+    """Force AITER's lazy JIT to compile mha_fwd_*.so for this (dtype, causal, has_lse) variant.
+
+    Unlike mha_varlen_fwd, mha_fwd ships no prebuilt .so files in the aiter
+    package; every (dtype, causal, has_lse) combination is JIT-built on first
+    use (~90s per variant). Bootstrapping here surfaces the build at plan time
+    rather than as a dlopen failure inside the C++ path.
+    """
+    from aiter.ops.mha import mha_fwd
+
+    device = torch.device("cuda", device_idx)
+    # mha_fwd expects (batch, seqlen, nhead, hdim) — non-varlen layout.
+    q = torch.zeros(1, 2, 2, head_dim, dtype=dtype, device=device)
+    k = torch.zeros(1, 4, 2, head_dim, dtype=dtype, device=device)
+    v = torch.zeros(1, 4, 2, head_dim, dtype=dtype, device=device)
+    mha_fwd(
+        q,
+        k,
+        v,
+        dropout_p=0.0,
+        softmax_scale=head_dim**-0.5,
+        is_causal=causal,
+        window_size_left=-1,
+        window_size_right=-1,
+        sink_size=0,
+        return_softmax_lse=has_lse,
+        return_dropout_randval=False,
+    )
 
 
 @functools.lru_cache(maxsize=None)
@@ -1298,17 +1336,26 @@ def single_prefill_with_kv_cache(
             head_dim_vo=v.shape[-1],
             pos_encoding_mode=pos_encoding_mode,
         )
-    elif backend == "aiter":
+
+    if backend == "aiter":
         _require_aiter_runtime(q.device)
         if pos_encoding_mode != "NONE":
             raise ValueError(
                 f"AITER backend does not support pos_encoding_mode={pos_encoding_mode!r}; "
                 "use backend='fa2' or backend='auto' instead."
             )
-        if logits_soft_cap > 0:
-            with _aiter_bootstrap_lock:
-                _aiter_bootstrap_single_prefill(
+        # logits_soft_cap > 0 forces the varlen .so (mha_fwd template has no _logits
+        # arm); only the (logits, causal) combo isn't pre-shipped by AITER.
+        # logits_soft_cap == 0 takes the mha_fwd .so, none of whose variants are
+        # pre-shipped — JIT-build the exact (dtype, causal, has_lse) we need.
+        with _aiter_bootstrap_lock:
+            if logits_soft_cap > 0:
+                _aiter_bootstrap_single_prefill_varlen(
                     q.dtype, q.shape[-1], q.device.index or 0
+                )
+            else:
+                _aiter_bootstrap_single_prefill_mha_fwd(
+                    q.dtype, causal, return_lse, q.shape[-1], q.device.index or 0
                 )
 
     # o_dtype should be provided for FP8 attention

--- a/include/flashinfer/attention/aiter/aiter_loader.h
+++ b/include/flashinfer/attention/aiter/aiter_loader.h
@@ -34,10 +34,23 @@ struct VariantKeyHash {
   }
 };
 
-// Returns the raw dlsym function pointer for aiter::mha_fwd(mha_fwd_args, stream_config const&).
-// The variant .so matching `key` is loaded via dlopen on first call; cached thereafter.
-// Throws std::runtime_error if the variant .so is not found or the symbol is missing.
+// Returns the raw dlsym function pointer for aiter::mha_fwd(mha_fwd_args, stream_config const&)
+// out of AITER's mha_fwd template .so. The CK Tile kernel instances baked in are batch-mode
+// (matching is_group_mode=false); the ASM v3 path is still reachable via use_asm_v3=true.
+// This is the preferred loader for single-sequence prefill on shapes that don't need
+// logits_soft_cap or min_seqlen_q semantics — it lets us skip group-mode seqstart
+// [0, seqlen] plumbing entirely.
+//
+// has_logits_cap is ignored when building the .so name (the mha_fwd template has no
+// _logits/_nlogits arm); callers must verify has_logits_cap==false before invoking,
+// otherwise the resulting kernel ignores logits_soft_cap.
 void* get_aiter_mha_fwd_handle(VariantKey const& key);
+
+// Returns the raw dlsym function pointer for aiter::mha_fwd out of AITER's mha_varlen_fwd
+// template .so. The CK Tile kernel instances baked in are group-mode only. Use this for
+// genuinely-varlen call sites, and for single-sequence calls that need logits_soft_cap
+// (the non-varlen mha_fwd template does not support that trait).
+void* get_aiter_mha_varlen_fwd_handle(VariantKey const& key);
 
 // Batch-prefill variants share the same key fields as mha_fwd variants.
 // page_size is NOT in the key — the .so dispatches all native page sizes at runtime.

--- a/include/flashinfer/attention/aiter/batch_prefill.cuh
+++ b/include/flashinfer/attention/aiter/batch_prefill.cuh
@@ -56,7 +56,7 @@ hipError_t BatchPrefillFlatGatherDispatched(
   };
 
   using mha_fwd_fn = float (*)(::aiter::mha_fwd_args, ::ck_tile::stream_config const&);
-  auto fn = reinterpret_cast<mha_fwd_fn>(flashinfer::aiter::get_aiter_mha_fwd_handle(key));
+  auto fn = reinterpret_cast<mha_fwd_fn>(flashinfer::aiter::get_aiter_mha_varlen_fwd_handle(key));
 
   ::aiter::mha_fwd_args args{};
   args.use_asm_v3 = false;

--- a/include/flashinfer/attention/aiter/single_prefill.cuh
+++ b/include/flashinfer/attention/aiter/single_prefill.cuh
@@ -21,21 +21,17 @@ inline constexpr int32_t kAiterMaskTopLeft = 1;  // standard causal (qo_len == k
 inline constexpr int32_t kAiterMaskBottomRight =
     2;  // prefill-with-history causal (kv_len > qo_len)
 
-// AITER's ASM v3 fast path is restricted to the (hdim_q, hdim_v) pairs that ship
-// as precompiled .co files in aiter_meta/hsa/gfx9{42,50}/fmha_v3_fwd/. Any other
-// shape forces a fallback to fmha_fwd_ck, which in the variant .so we dlopen is
-// JIT-built group-mode only — so callers must keep is_group_mode=true unless
-// ASM v3 will actually be selected. AITER also ships hd192/hd128 .co files, but
-// the single-prefill entry point hard-requires HEAD_DIM_QK == HEAD_DIM_VO (see
-// static_assert below), so only the equal-hdim pair is reachable here.
+// AITER's ASM v3 fast path is restricted to the (hdim_q, hdim_v) pairs that ship as
+// precompiled .co files in aiter_meta/hsa/gfx9{42,50}/fmha_v3_fwd/. AITER also ships
+// hd192/hd128 .co files, but the single-prefill entry point hard-requires
+// HEAD_DIM_QK == HEAD_DIM_VO (see static_assert below), so only the equal-hdim pair
+// is reachable here.
 inline constexpr bool AiterAsmV3HdimSupported(uint32_t hdim_q, uint32_t hdim_v) {
   return hdim_q == 128 && hdim_v == 128;
 }
 
 // Returns true iff AITER's mha_fwd dispatcher will hit the ASM v3 pipeline for
-// these traits (matches the guard in aiter::fmha_fwd_v3). On a hit, we use
-// batch mode (is_group_mode=false) to avoid the per-launch seqstart [0, len]
-// H2D plumbing; the kernel ignores batch_stride_* for batch=1.
+// these traits (matches the guard in aiter::fmha_fwd_v3).
 inline constexpr bool AiterAsmV3Eligible(uint32_t hdim_q, uint32_t hdim_v,
                                          flashinfer::aiter::VariantKey::Dtype dtype,
                                          bool has_logits_cap, int32_t window_left) {
@@ -45,9 +41,9 @@ inline constexpr bool AiterAsmV3Eligible(uint32_t hdim_q, uint32_t hdim_v,
 
 // params.lse: [num_qo_heads, qo_len] float32 scratch in natural-log scale; nullptr to skip.
 // tmp: unused; accepted for API parity with the FA2 template.
-// cu_seqlens_q / cu_seqlens_k: [0, seqlen] arrays on device; consumed only on the
-// group-mode (CK Tile) fallback path. May be nullptr when the caller has verified
-// that AiterAsmV3Eligible() holds.
+// cu_seqlens_q / cu_seqlens_k: [0, seqlen] arrays on device; consumed only when
+// logits_soft_cap > 0 (which forces the varlen/group-mode .so because the mha_fwd
+// template has no _logits arm). May be nullptr otherwise.
 template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, typename Params>
 hipError_t SinglePrefillWithKVCacheDispatched(Params const& params, bool causal,
                                               const char* dtype_str,
@@ -68,26 +64,31 @@ hipError_t SinglePrefillWithKVCacheDispatched(Params const& params, bool causal,
       .has_logits_cap = has_logits_cap,
   };
 
+  // AITER ships two dispatcher .so templates: mha_fwd (batch-mode CK + ASM v3) and
+  // mha_varlen_fwd (group-mode CK + ASM v3). Single-prefill is batch=1, so the
+  // mha_fwd .so is the natural fit — except it has no _logits arm, so logits_soft_cap
+  // forces us onto the varlen path.
   using mha_fwd_fn = float (*)(::aiter::mha_fwd_args, ::ck_tile::stream_config const&);
-  auto fn = reinterpret_cast<mha_fwd_fn>(flashinfer::aiter::get_aiter_mha_fwd_handle(key));
+  auto fn = reinterpret_cast<mha_fwd_fn>(
+      has_logits_cap ? flashinfer::aiter::get_aiter_mha_varlen_fwd_handle(key)
+                     : flashinfer::aiter::get_aiter_mha_fwd_handle(key));
+
+  // Defensive: the varlen pipeline dereferences seqstart_*_ptr in CK Tile. Surface
+  // missing pointers as hipErrorInvalidValue here rather than as a memory fault
+  // inside AITER.
+  if (has_logits_cap && (cu_seqlens_q == nullptr || cu_seqlens_k == nullptr)) {
+    return hipErrorInvalidValue;
+  }
 
   ::aiter::mha_fwd_args args{};
-  // ASM v3 path (bf16 + hd128/hd192_128, batch mode) is ~10-15% faster than the
-  // CK Tile group-mode fallback. Pre-compiled .co files in aiter_meta/hsa/gfx9*/
-  // fmha_v3_fwd/ ship batch-mode kernels; when ineligible we fall back to the
-  // group-mode CK Tile instances that AITER JIT-builds into the variant .so.
+  // ASM v3 path (bf16 + hd128) is ~10-15% faster than CK Tile, gated by the same
+  // eligibility predicate as aiter::fmha_fwd_v3.
   args.use_asm_v3 =
       AiterAsmV3Eligible(HEAD_DIM_QK, HEAD_DIM_VO, dtype_enum, has_logits_cap, params.window_left);
   args.v3_api_check = false;
   args.how_v3_bf16_cvt = 0;
   args.data_type = dtype_str;
-  args.is_group_mode = !args.use_asm_v3;
-  // Defensive: group mode dereferences seqstart_*_ptr in AITER's CK Tile
-  // pipeline. Catch caller/callee predicate drift here rather than as a HIP
-  // memory fault inside the kernel.
-  if (args.is_group_mode && (cu_seqlens_q == nullptr || cu_seqlens_k == nullptr)) {
-    return hipErrorInvalidValue;
-  }
+  args.is_group_mode = has_logits_cap;
   args.bias_type = 0;  // no bias / no alibi
   args.has_lse = has_lse;
   args.qscale_type = 0;
@@ -102,8 +103,8 @@ hipError_t SinglePrefillWithKVCacheDispatched(Params const& params, bool causal,
   // Group mode encodes batch=1 as seqstart arrays [0, seqlen] on device.
   // Batch mode addresses tensors via stride/nhead_stride only — batch_stride_*
   // are unused at batch=1 and left at their default 0.
-  args.seqstart_q_ptr = args.use_asm_v3 ? nullptr : static_cast<const void*>(cu_seqlens_q);
-  args.seqstart_k_ptr = args.use_asm_v3 ? nullptr : static_cast<const void*>(cu_seqlens_k);
+  args.seqstart_q_ptr = args.is_group_mode ? static_cast<const void*>(cu_seqlens_q) : nullptr;
+  args.seqstart_k_ptr = args.is_group_mode ? static_cast<const void*>(cu_seqlens_k) : nullptr;
 
   args.seqlen_q = static_cast<int32_t>(params.qo_len);
   args.seqlen_k = static_cast<int32_t>(params.kv_len);

--- a/tests/rocm_tests/test_single_prefill_kernels_hip.py
+++ b/tests/rocm_tests/test_single_prefill_kernels_hip.py
@@ -21,8 +21,8 @@ logger.setLevel(logging.ERROR)
 def warmup_jit():
     flashinfer.jit.build_jit_specs(
         gen_prefill_attention_modules(
-            [torch.float16],  # q_dtypes
-            [torch.float16],  # kv_dtypes
+            [torch.float16, torch.bfloat16],  # q_dtypes
+            [torch.float16, torch.bfloat16],  # kv_dtypes
             [64, 128, 256],  # head_dims
             [0],  # pos_encoding_modes (NONE)
             [False],  # use_sliding_windows
@@ -207,6 +207,74 @@ def test_single_prefill_threadblock_sync_mdo_states(
     torch.testing.assert_close(o, o_ref.to(o.dtype), rtol=1e-3, atol=1e-3)
     if return_lse:
         torch.testing.assert_close(lse, lse_ref.to(lse.dtype), rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("qo_len", [37, 127, 577])
+@pytest.mark.parametrize("kv_len", [128, 512, 2048])
+@pytest.mark.parametrize("num_qo_heads", [4, 32])
+@pytest.mark.parametrize("num_kv_heads", [4])
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("return_lse", [False, True])
+def test_single_prefill_aiter_bf16(
+    qo_len: int,
+    kv_len: int,
+    num_qo_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    causal: bool,
+    return_lse: bool,
+):
+    """AITER single-prefill with bf16 inputs. Exercises the ASM v3 (bf16+hd128)
+    fast path inside aiter::mha_fwd in addition to the CK Tile fallback for
+    hd64/hd256. logits_soft_cap is held at 0.0 here so this also covers the
+    mha_fwd (non-varlen, batch-mode) .so loader path that has no bf16 coverage
+    in the fp16-only matrix above."""
+    if not is_aiter_supported(torch.device("cuda:0")) or not _aiter_ops_importable():
+        pytest.skip("AITER requires a gfx942/gfx950 GPU and the aiter package")
+    if causal and qo_len > kv_len:
+        pytest.skip("causal attention requires kv_len >= qo_len")
+
+    q = torch.randn(
+        qo_len, num_qo_heads, head_dim, device="cuda:0", dtype=torch.bfloat16
+    )
+    k = torch.randn(
+        kv_len, num_kv_heads, head_dim, device="cuda:0", dtype=torch.bfloat16
+    )
+    v = torch.randn(
+        kv_len, num_kv_heads, head_dim, device="cuda:0", dtype=torch.bfloat16
+    )
+
+    if return_lse:
+        o, lse = flashinfer.single_prefill_with_kv_cache_return_lse(
+            q,
+            k,
+            v,
+            causal=causal,
+            kv_layout="NHD",
+            backend="aiter",
+        )
+        assert lse.shape == (qo_len, num_qo_heads)
+    else:
+        o = flashinfer.single_prefill_with_kv_cache(
+            q, k, v, causal=causal, kv_layout="NHD", backend="aiter"
+        )
+        lse = None
+
+    assert o.shape == (qo_len, num_qo_heads, head_dim)
+
+    o_ref, lse_ref = naive_attention(
+        q.float(),
+        k.float(),
+        v.float(),
+        causal=causal,
+        pos_encoding_mode="NONE",
+        logits_soft_cap=None,
+        return_lse=return_lse,
+    )
+    torch.testing.assert_close(o, o_ref.to(o.dtype), rtol=1e-2, atol=1e-2)
+    if return_lse:
+        torch.testing.assert_close(lse, lse_ref.to(lse.dtype), rtol=1e-2, atol=1e-2)
 
 
 @pytest.mark.parametrize("head_dim", [64, 128])


### PR DESCRIPTION
## Summary

Single-prefill is batch=1; the natural fit is AITER's non-varlen `mha_fwd` template, whose CK Tile kernel instances are batch-mode and need no seqstart `[0, seqlen]` plumbing. PR #245 worked around the varlen-only routing by gating `is_group_mode=false` on ASM v3 eligibility — this PR removes that workaround by loading the right `.so` for each case.

### What changed

#### C++ loader
- **`flashinfer/csrc_rocm/aiter_loader.cc`** — `build_so_name` parameterized with `include_logits` (the `mha_fwd` template has no `_logits/_nlogits` arm). Added `mha_fwd_variant_so_name`, `s_mf_*` cache, `get_aiter_mha_fwd_handle()` implementation. Renamed the existing varlen helpers to `mha_varlen_fwd_*` / `s_vl_*` / `get_aiter_mha_varlen_fwd_handle()`. Both loaders share `kMhaFwdSymbol` (both `.so` templates export the same dispatcher symbol — verified via `nm -D`).
- **`include/flashinfer/attention/aiter/aiter_loader.h`** — public API doc spells out the `has_logits_cap` footgun on `get_aiter_mha_fwd_handle`.

#### Dispatch
- **`include/flashinfer/attention/aiter/single_prefill.cuh`** — `has_logits_cap ? varlen_handle : fwd_handle` for loader selection; `is_group_mode = has_logits_cap` instead of `!use_asm_v3`. ASM v3 path unchanged (its eligibility predicate already excludes `has_logits_cap`).
- **`include/flashinfer/attention/aiter/batch_prefill.cuh`** — call site renamed to `get_aiter_mha_varlen_fwd_handle` (it's always been varlen).
- **`flashinfer/csrc_rocm/single_prefill_aiter.cu`** — `get_seqstart_ptrs` lookup gated on `params.logits_soft_cap > 0.0f` (the only case that still needs seqstart).

#### Python bootstrap
- **`flashinfer/prefill_rocm.py`** — renamed `_aiter_bootstrap_single_prefill` → `_aiter_bootstrap_single_prefill_varlen` for accuracy. Added `_aiter_bootstrap_single_prefill_mha_fwd(dtype, causal, has_lse, head_dim, device_idx)` that triggers `aiter.ops.mha.mha_fwd(...)`. The `mha_fwd` template ships no prebuilt `.so` files; every `(dtype, causal, has_lse)` is JIT-built on first use (~90 s per variant, cached on disk by AITER thereafter). Bootstrap call site collapsed into a single `if backend == "aiter":` block so auto-resolved-aiter and explicit-aiter share the path.

### Architecture / design notes

| Case | Loader used | `is_group_mode` | seqstart needed | Why |
|---|---|---|---|---|
| `logits_soft_cap == 0` (common) | `get_aiter_mha_fwd_handle` | `false` | no | Batch-mode CK + ASM v3 reachable via `use_asm_v3=true` |
| `logits_soft_cap > 0` | `get_aiter_mha_varlen_fwd_handle` | `true` | yes | `mha_fwd` template has no `_logits` arm |

The dispatched `aiter::mha_fwd` C++ symbol inside both `.so` files is the same dispatcher — it picks ASM v3 vs CK Tile per call based on `args.use_asm_v3`. The `.so` differs only in which CK Tile instances are baked in: `mha_fwd_*.so` has batch-mode instances, `mha_varlen_fwd_*.so` has group-mode instances. Loading the wrong `.so` would kernel-not-found inside `fmha_fwd_ck`; the predicate alignment between the loader selection and `is_group_mode` is the invariant that prevents this.

## Test plan

- [x] `pytest tests/rocm_tests/test_single_prefill_kernels_hip.py -k aiter --reruns 1` — **820 passed**, 1104 skipped (covers fp16 + bf16, hd ∈ {64, 128, 256}, causal/non-causal, LSE on/off, `logits_soft_cap ∈ {0.0, 8.0}` — both the new `mha_fwd` branch and the kept `mha_varlen_fwd` (logits-cap) branch are exercised)
- [x] `pytest tests/rocm_tests/test_single_prefill_kernels_hip.py --reruns 1` — **2456 passed**, 1392 skipped
- [x] `pytest tests/rocm_tests/ -k "prefill or aiter" --reruns 1` — **8575 passed**, 3528 skipped, 0 failed
- [x] `pre-commit run` on touched files

## Follow-ups (separate PRs, called out by /simplify)

- Per-key locking for `_aiter_bootstrap_*` so concurrent first-calls on different variants don't serialize through the single `_aiter_bootstrap_lock`.
- Shared helper to consolidate the four `_aiter_bootstrap_*` functions (~120 LOC → ~60).
- Move `_aiter_bootstrap_lock` + bootstrap helpers into `flashinfer/aiter_utils.py`.