### PR TITLE
feat(hip,aiter): add AITER backend to fused_add_rmsnorm with shape-aware auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ kernel for non-attention ops). **AITER** = ROCm AITER backend.
 | **RoPE (positional encoding)** | ✅ | — | HIP | LLaMA-style + LLaMA 3.1 scaling; fused RoPE + fp8 quant + paged-KV append (E4M3FNUZ, E5M2FNUZ) |
 | **Paged KV-cache append** | ✅ `native` | ✅ | **AITER** when `fp16/bf16` + `NHD` + gfx942/gfx950 + AITER importable; else **HIP `native`** | `append_paged_kv_cache`; fp8 KV-cache supported on the HIP path |
 | **RMSNorm** | ✅ `native` | ✅ | **HIP `native`** (auto stays on HIP — AITER is opt-in via `backend="aiter"`) | AITER path is fp16/bf16, 2-D only; slightly lower precision at `hidden_size >= 1024` |
+| **Fused add RMSNorm** | ✅ `native` | ✅ | **AITER** when 2-D + `>= 4M` elements + gfx942/gfx950 + AITER importable; else **HIP `native`** | `fused_add_rmsnorm`; AITER (CK `rmsnorm2d_fwd_with_add`) wins on large bandwidth-bound shapes; 2-D only, slightly lower precision at `hidden_size >= 1024` |
 | **LayerNorm / Gemma RMSNorm** | ✅ | — | HIP | |
 | **Sampling** | ✅ | — | HIP | Top-K / Top-P / Min-P / OnlineSoftmax / SamplingFromLogits |
 | **Logits processor** | ✅ | — | HIP | Composable processor pipeline (cap, mask, temperature, …) |
@@ -308,7 +309,8 @@ pytest -n auto --reruns 2 -m "slow"
 
 FlashInfer+ROCm can dispatch the `single_prefill`, `batch_prefill`
 (paged and ragged), `batch_decode`, `append_paged_kv_cache`, `rmsnorm`,
-and `MLA` paths to [AITER](https://github.com/ROCm/aiter). MLA on ROCm
+`fused_add_rmsnorm`, and `MLA` paths to
+[AITER](https://github.com/ROCm/aiter). MLA on ROCm
 is **AITER-only** — there is no in-tree HIP MLA kernel yet, so
 `backend="auto"` (the default for the MLA wrapper) resolves directly
 to `"aiter"`.
@@ -320,11 +322,14 @@ a one-time `logger.warning`. Pass `backend="aiter"` to require AITER
 explicitly, or pass the in-tree backend string to skip it:
 `backend="fa2"` for the attention wrappers (single/batch
 prefill/decode), `backend="native"` for non-attention ops
-(`append_paged_kv_cache`, `rmsnorm`). Two backend-specific exceptions
-to "auto picks AITER when supported":
+(`append_paged_kv_cache`, `rmsnorm`, `fused_add_rmsnorm`). Three
+backend-specific exceptions to "auto picks AITER when supported":
 
 * `rmsnorm`: `backend="auto"` stays on the HIP `native` kernel; the
   AITER path is opt-in via `backend="aiter"`.
+* `fused_add_rmsnorm`: `backend="auto"` is shape-gated — it picks AITER
+  only for 2-D inputs with `>= 4M` elements (where the CK kernel is
+  faster) and stays on the HIP `native` kernel otherwise.
 * `batch_decode`: `use_cuda_graph=True` or `use_tensor_cores=True`
   force `auto` back to `fa2` (AITER decode does not support either),
   and `pos_encoding_mode != "NONE"` raises under `backend="aiter"`.

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -45,9 +45,9 @@ if IS_HIP:
 
     # AITER's CK fused_add_rmsnorm only overtakes the native kernel on large,
     # bandwidth-bound shapes (~10-14% faster at >=2048 rows x 8192 cols); below
-    # that the native kernel is faster and more accurate. Route auto to AITER only
-    # past this element-count cutoff, safely above the ~4M-element tie point.
-    _AITER_FUSED_ADD_RMSNORM_MIN_ELEMS = 8 * 1024 * 1024
+    # that the native kernel is faster and more accurate. Route auto to AITER once
+    # the input reaches this element-count cutoff (around the measured break-even).
+    _AITER_FUSED_ADD_RMSNORM_MIN_ELEMS = 4 * 1024 * 1024
 
     def _auto_select_fused_add_rmsnorm_backend(input: torch.Tensor) -> str:
         # Cheapest guards first so the common small/medium case exits early.
@@ -190,7 +190,7 @@ def fused_add_rmsnorm(
         <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
     backend: str
         Kernel backend to use. ``"auto"`` (default) uses the native kernel for small
-        and medium inputs, and switches to AITER on ROCm for large (>= 8M element) 2D
+        and medium inputs, and switches to AITER on ROCm for large (>= 4M element) 2D
         inputs where its CK kernel is faster; it falls back to native whenever AITER
         is unavailable.
         ``"native"`` uses the FlashInfer JIT kernel on all platforms.

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -198,6 +198,13 @@ def fused_add_rmsnorm(
         (gfx942/gfx950) only; requires the ``aiter`` package and only supports 2D
         inputs. Precision is slightly lower than ``"native"`` at ``hidden_size >= 1024``.
     """
+    # Both the native and AITER kernels are 2D-only (the native kernel enforces
+    # CHECK_DIM(2) on input/residual), so reject other ranks up front with a clear
+    # Python error rather than letting it fail deeper in the kernel.
+    if input.ndim != 2:
+        raise ValueError(
+            f"fused_add_rmsnorm only supports 2D inputs; got {input.ndim}D."
+        )
     if IS_HIP:
         _backend = (
             backend
@@ -205,11 +212,6 @@ def fused_add_rmsnorm(
             else _auto_select_fused_add_rmsnorm_backend(input)
         )
         if _backend == "aiter":
-            if input.ndim != 2:
-                raise ValueError(
-                    f"AITER fused_add_rmsnorm only supports 2D inputs; got {input.ndim}D. "
-                    "Use backend='native' for 3D inputs."
-                )
             # CK kernel writes out/residual_out separately; alias them onto the
             # input/residual tensors to match FlashInfer's in-place semantics.
             _aiter_norm_ops().rmsnorm2d_fwd_with_add(

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -43,6 +43,31 @@ if IS_HIP:
         # Keep auto on the native JIT kernel; pass backend="aiter" to opt in explicitly.
         return "native"
 
+    # AITER's CK fused_add_rmsnorm only overtakes the native kernel on large,
+    # bandwidth-bound shapes (~10-14% faster at >=2048 rows x 8192 cols); below
+    # that the native kernel is faster and more accurate. Route auto to AITER only
+    # past this element-count cutoff, safely above the ~4M-element tie point.
+    _AITER_FUSED_ADD_RMSNORM_MIN_ELEMS = 8 * 1024 * 1024
+
+    def _auto_select_fused_add_rmsnorm_backend(input: torch.Tensor) -> str:
+        # Cheapest guards first so the common small/medium case exits early.
+        if input.ndim != 2:
+            return "native"
+        if input.numel() < _AITER_FUSED_ADD_RMSNORM_MIN_ELEMS:
+            return "native"
+        from .aiter_utils import is_aiter_supported
+
+        if not is_aiter_supported(input.device):
+            return "native"
+        try:
+            # Best-effort probe: a supported arch can still lack a usable aiter
+            # (not installed, or its compiled extension fails to load). auto must
+            # always be able to fall back to native, so catch any import failure.
+            _aiter_norm_ops()
+        except Exception:
+            return "native"
+        return "aiter"
+
 
 def rmsnorm(
     input: torch.Tensor,
@@ -134,13 +159,13 @@ def _rmsnorm_fake(
     pass
 
 
-@register_custom_op("flashinfer::fused_add_rmsnorm", mutates_args=("input", "residual"))
 def fused_add_rmsnorm(
     input: torch.Tensor,
     residual: torch.Tensor,
     weight: torch.Tensor,
     eps: float = 1e-6,
     enable_pdl: Optional[bool] = None,
+    backend: str = "auto",
 ) -> None:
     r"""Fused add root mean square normalization.
 
@@ -163,7 +188,49 @@ def fused_add_rmsnorm(
     enable_pdl: bool
         Whether to enable `programmatic dependent launch
         <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
+    backend: str
+        Kernel backend to use. ``"auto"`` (default) uses the native kernel for small
+        and medium inputs, and switches to AITER on ROCm for large (>= 8M element) 2D
+        inputs where its CK kernel is faster; it falls back to native whenever AITER
+        is unavailable.
+        ``"native"`` uses the FlashInfer JIT kernel on all platforms.
+        ``"aiter"`` uses AMD AITER's CK ``rmsnorm2d_fwd_with_add`` — ROCm
+        (gfx942/gfx950) only; requires the ``aiter`` package and only supports 2D
+        inputs. Precision is slightly lower than ``"native"`` at ``hidden_size >= 1024``.
     """
+    if IS_HIP:
+        _backend = (
+            backend
+            if backend != "auto"
+            else _auto_select_fused_add_rmsnorm_backend(input)
+        )
+        if _backend == "aiter":
+            if input.ndim != 2:
+                raise ValueError(
+                    f"AITER fused_add_rmsnorm only supports 2D inputs; got {input.ndim}D. "
+                    "Use backend='native' for 3D inputs."
+                )
+            # CK kernel writes out/residual_out separately; alias them onto the
+            # input/residual tensors to match FlashInfer's in-place semantics.
+            _aiter_norm_ops().rmsnorm2d_fwd_with_add(
+                input, input, residual, residual, weight, eps
+            )
+            return
+        if _backend != "native":
+            raise ValueError(
+                f"Unknown backend {backend!r}; expected one of 'auto', 'native', 'aiter'."
+            )
+    _fused_add_rmsnorm(input, residual, weight, eps, enable_pdl)
+
+
+@register_custom_op("flashinfer::fused_add_rmsnorm", mutates_args=("input", "residual"))
+def _fused_add_rmsnorm(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    enable_pdl: Optional[bool],
+) -> None:
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
     get_norm_module().fused_add_rmsnorm(input, residual, weight, eps, enable_pdl)
@@ -174,8 +241,8 @@ def _fused_add_rmsnorm_fake(
     input: torch.Tensor,
     residual: torch.Tensor,
     weight: torch.Tensor,
-    eps: float = 1e-6,
-    enable_pdl: Optional[bool] = None,
+    eps: float,
+    enable_pdl: Optional[bool],
 ) -> None:
     pass
 

--- a/tests/rocm_tests/test_norm_hip.py
+++ b/tests/rocm_tests/test_norm_hip.py
@@ -15,10 +15,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import importlib.util
+
 import pytest
 import torch
 
 import flashinfer
+from flashinfer.aiter_utils import is_aiter_supported
+
+# is_aiter_supported only checks the GPU arch; AITER is a separate source install,
+# so a supported board can still lack the package. Require both so these tests skip
+# (rather than error/fail) when the arch matches but aiter isn't importable.
+_aiter_available = (
+    is_aiter_supported(torch.device("cuda:0"))
+    and importlib.util.find_spec("aiter") is not None
+)
+requires_aiter = pytest.mark.skipif(
+    not _aiter_available,
+    reason="AITER backend requires gfx942/gfx950 and the aiter package",
+)
 
 
 def llama_rms_norm(x, w, eps=1e-6):
@@ -121,6 +136,78 @@ def test_fused_add_rmsnorm(batch_size, hidden_size, dtype, enable_pdl, contiguou
     rtol, atol = (1.6e-2, 1.6e-2) if dtype == torch.bfloat16 else (1e-3, 1e-3)
     torch.testing.assert_close(x_fused, x_native, rtol=rtol, atol=atol)
     torch.testing.assert_close(residual_fused, residual_native, rtol=rtol, atol=atol)
+
+
+@requires_aiter
+@pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
+@pytest.mark.parametrize("hidden_size", [111, 500, 1024, 3072, 3584, 4096, 8192])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_fused_add_rmsnorm_aiter(batch_size, hidden_size, dtype):
+    eps = 1e-6
+
+    x = torch.randn(batch_size, hidden_size, dtype=dtype, device="cuda")
+    residual = torch.randn_like(x)
+    weight = torch.randn(hidden_size, dtype=dtype, device="cuda")
+
+    x_native, residual_native = fused_add_rms_norm(
+        x.clone(), residual.clone(), weight, eps
+    )
+
+    x_fused = x.clone()
+    residual_fused = residual.clone()
+    flashinfer.fused_add_rmsnorm(x_fused, residual_fused, weight, eps, backend="aiter")
+
+    # AITER CK reductions are lower precision than the native kernel.
+    rtol, atol = (7e-2, 7e-2) if dtype == torch.bfloat16 else (4e-3, 4e-3)
+    torch.testing.assert_close(x_fused, x_native, rtol=rtol, atol=atol)
+    torch.testing.assert_close(residual_fused, residual_native, rtol=rtol, atol=atol)
+
+
+@requires_aiter
+@pytest.mark.parametrize(
+    "batch_size,hidden_size,expected",
+    [
+        (1, 4096, "native"),  # small
+        (128, 4096, "native"),  # medium, below cutoff
+        (989, 4096, "native"),  # ~4M elems, tie -> native
+        (2048, 8192, "aiter"),  # >= 8M elems -> aiter
+        (4096, 8192, "aiter"),  # large -> aiter
+    ],
+)
+def test_fused_add_rmsnorm_auto_selection(batch_size, hidden_size, expected):
+    from flashinfer.norm import _auto_select_fused_add_rmsnorm_backend
+
+    x = torch.empty(batch_size, hidden_size, dtype=torch.float16, device="cuda")
+    assert _auto_select_fused_add_rmsnorm_backend(x) == expected
+    # 3D always routes to native regardless of size.
+    x3d = torch.empty(batch_size, 4, hidden_size, dtype=torch.float16, device="cuda")
+    assert _auto_select_fused_add_rmsnorm_backend(x3d) == "native"
+
+
+@requires_aiter
+@pytest.mark.parametrize("batch_size", [128, 2048])
+@pytest.mark.parametrize("hidden_size", [4096, 8192])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_fused_add_rmsnorm_auto_correct(batch_size, hidden_size, dtype):
+    # 2048x8192 lands above the 8M cutoff, so this grid exercises the AITER path
+    # under backend="auto" (not just native), confirming auto stays correct there.
+    eps = 1e-6
+    x = torch.randn(batch_size, hidden_size, dtype=dtype, device="cuda")
+    residual = torch.randn_like(x)
+    weight = torch.randn(hidden_size, dtype=dtype, device="cuda")
+
+    x_native, residual_native = fused_add_rms_norm(
+        x.clone(), residual.clone(), weight, eps
+    )
+
+    x_auto = x.clone()
+    residual_auto = residual.clone()
+    flashinfer.fused_add_rmsnorm(x_auto, residual_auto, weight, eps, backend="auto")
+
+    # auto may pick AITER (CK lower precision) for large shapes, so use relaxed tol.
+    rtol, atol = (7e-2, 7e-2) if dtype == torch.bfloat16 else (4e-3, 4e-3)
+    torch.testing.assert_close(x_auto, x_native, rtol=rtol, atol=atol)
+    torch.testing.assert_close(residual_auto, residual_native, rtol=rtol, atol=atol)
 
 
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])

--- a/tests/rocm_tests/test_norm_hip.py
+++ b/tests/rocm_tests/test_norm_hip.py
@@ -169,8 +169,9 @@ def test_fused_add_rmsnorm_aiter(batch_size, hidden_size, dtype):
     [
         (1, 4096, "native"),  # small
         (128, 4096, "native"),  # medium, below cutoff
-        (989, 4096, "native"),  # ~4M elems, tie -> native
-        (2048, 8192, "aiter"),  # >= 8M elems -> aiter
+        (989, 4096, "native"),  # ~4.05M elems, just below 4M cutoff -> native
+        (512, 8192, "aiter"),  # exactly 4M elems (cutoff) -> aiter
+        (2048, 8192, "aiter"),  # >= 4M elems -> aiter
         (4096, 8192, "aiter"),  # large -> aiter
     ],
 )
@@ -200,8 +201,9 @@ def test_fused_add_rmsnorm_rejects_non_2d(backend):
 @pytest.mark.parametrize("hidden_size", [4096, 8192])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_fused_add_rmsnorm_auto_correct(batch_size, hidden_size, dtype):
-    # 2048x8192 lands above the 8M cutoff, so this grid exercises the AITER path
-    # under backend="auto" (not just native), confirming auto stays correct there.
+    # The 2048-row shapes land above the 4M cutoff, so this grid exercises the
+    # AITER path under backend="auto" (not just native), confirming auto stays
+    # correct there.
     eps = 1e-6
     x = torch.randn(batch_size, hidden_size, dtype=dtype, device="cuda")
     residual = torch.randn_like(x)

--- a/tests/rocm_tests/test_norm_hip.py
+++ b/tests/rocm_tests/test_norm_hip.py
@@ -184,6 +184,17 @@ def test_fused_add_rmsnorm_auto_selection(batch_size, hidden_size, expected):
     assert _auto_select_fused_add_rmsnorm_backend(x3d) == "native"
 
 
+@pytest.mark.parametrize("backend", ["auto", "native", "aiter"])
+def test_fused_add_rmsnorm_rejects_non_2d(backend):
+    # Both native and AITER kernels are 2D-only; any backend must raise a clear
+    # ValueError up front rather than failing deeper in the kernel.
+    x = torch.randn(4, 8, 128, dtype=torch.float16, device="cuda")
+    residual = torch.randn_like(x)
+    weight = torch.randn(128, dtype=torch.float16, device="cuda")
+    with pytest.raises(ValueError, match="2D"):
+        flashinfer.fused_add_rmsnorm(x, residual, weight, backend=backend)
+
+
 @requires_aiter
 @pytest.mark.parametrize("batch_size", [128, 2048])
 @pytest.mark.parametrize("hidden_size", [4096, 8192])


### PR DESCRIPTION
## Summary

Adds AMD AITER's CK `rmsnorm2d_fwd_with_add` as an opt-in backend for `fused_add_rmsnorm`, with a shape-aware `backend="auto"` that routes large inputs to AITER (where it is faster) and keeps everything else on the native kernel. Mirrors the existing AITER-backend pattern already used by `rmsnorm` in the same module.

### What changed

- **`flashinfer/norm.py`** — `fused_add_rmsnorm` gains a `backend` parameter (`"auto"`/`"native"`/`"aiter"`). The native custom op is split into a private `_fused_add_rmsnorm` (carrying `@register_custom_op`) behind a public Python wrapper, exactly as `rmsnorm`/`_rmsnorm` are already structured. The AITER path calls `rmsnorm2d_fwd_with_add(input, input, residual, residual, weight, eps)`, aliasing the out/residual_out buffers onto the in-place input/residual tensors to match FlashInfer's in-place semantics. A new `_auto_select_fused_add_rmsnorm_backend` selects the backend by element count and falls back to native whenever AITER is unavailable. A single up-front 2D-rank check raises a clear `ValueError` for all backends (both the native and AITER kernels are 2D-only).
- **`tests/rocm_tests/test_norm_hip.py`** — adds AITER-path correctness, auto-selection (including the exact cutoff boundary), auto-correctness, and non-2D rejection tests. AITER tests are guarded by a `requires_aiter` mark that checks both the GPU arch and that the `aiter` package is importable (so a supported board without the package skips rather than errors).
- **`README.md`** — adds a **Fused add RMSNorm** row to the Feature Support Matrix and documents the shape-gated `auto` behavior in the AITER backend-exceptions list.

### Architecture / design notes

`backend="auto"` is shape-aware because the two kernels win in different regimes (kernel-only times, MI300-class):

| input (b×h) | native | aiter | auto picks |
|---|---|---|---|
| ≤128×4096 | ~4 µs | ~5.4 µs | native |
| 989×4096 (~4.05M) | ~18 µs | ~18 µs | native (just below cutoff) |
| 2048×8192 (~16.8M) | ~62 µs | ~56 µs | **aiter** |
| 4096×8192 (~33.6M) | ~123 µs | ~108 µs | **aiter** |

The cutoff is `4M elements`, near the measured native/AITER break-even, so `auto` engages AITER as soon as its CK kernel starts to win. AITER's CK kernel uses lower-precision reductions, so it is only selected at or above this size where the speedup is real. `rmsnorm2d_fwd_with_add` was chosen over AITER's `fused_add_rms_norm_cu` because it is both faster and more accurate; its separate out/residual_out buffers are aliased in-place to preserve the API contract.

## Test plan

- [x] `pytest tests/rocm_tests/test_norm_hip.py -m "not slow"` — all norm/fused_add_rmsnorm tests pass
- [x] AITER path verified numerically against the fp32 reference within CK tolerance
- [x] auto-selection routing verified per shape (native below the 4M cutoff, aiter at/above)
- [x] non-2D inputs raise a clear `ValueError` for every backend
- [x] `pre-commit run -a` (ruff, mypy, format, markdownlint) clean on changed files