### PR TITLE
chore(rocm): align devcontainer Dockerfile with pyproject deps

### DIFF
--- a/.devcontainer/rocm/Dockerfile
+++ b/.devcontainer/rocm/Dockerfile
@@ -1,6 +1,6 @@
 ARG ROCM_VERSION=7.2
 
-FROM mambaorg/micromamba:2.1.1 as micromamba
+FROM mambaorg/micromamba:2.1.1 AS micromamba
 
 FROM rocm/dev-ubuntu-24.04:${ROCM_VERSION}-complete
 
@@ -82,8 +82,8 @@ RUN \
 
 # Create a new micromamba env and install needed packages for flashinfer development
 RUN /bin/micromamba create -n ${MAMBA_ENV_NAME} python=${PY_VERSION} gtest gmock bash-completion -c conda-forge && \
-    /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install --no-cache-dir cmake ninja scikit-build-core setuptools-scm pre-commit numpy pytest pytest-cov pytest-xdist pybind11 ruff && \
-    /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install --no-cache-dir torch==${TORCH_VERSION} -f https://repo.radeon.com/rocm/manylinux/rocm-rel-${ROCM_VERSION}/ && \
+    /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install --no-cache-dir cmake ninja "scikit-build-core>=0.4.3" "setuptools-scm>=9.2" pre-commit numpy pytest pytest-cov pytest-xdist pytest-rerunfailures pybind11 ruff && \
+    /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install --no-cache-dir torch==${TORCH_VERSION} --index-url https://repo.radeon.com/rocm/manylinux/rocm-rel-${ROCM_VERSION}/ && \
     /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install amd_aiter==${AITER_VERSION} --extra-index-url https://pypi.amd.com/rocm-${AITER_ROCM_VERSION}/simple
 SHELL ["/usr/local/bin/_dockerfile_shell.sh"]
 


### PR DESCRIPTION
## Summary

Bring the ROCm devcontainer Dockerfile in line with `pyproject.toml` so the
built image satisfies every requirement out of the box, and fix a latent torch
install hazard.

### What changed

- **`.devcontainer/rocm/Dockerfile`**
  - Add **`pytest-rerunfailures`** — required by the documented test command
    (`pytest -n auto --reruns 2`) and listed under `[project.optional-dependencies].dev`; it was the only outright missing dep.
  - Pin **`scikit-build-core>=0.4.3`** and **`setuptools-scm>=9.2`** to match the
    constraints in `[build-system].requires`.
  - Switch the torch install from `-f` to **`--index-url`**. Both `CLAUDE.md` and
    `README.md` warn that `-f` lets pip silently fall back to a CPU-only wheel
    from PyPI; `--index-url` pins the resolver to AMD's ROCm repo.
  - Uppercase `FROM ... AS` to silence BuildKit's `FromAsCasing` lint warning.

## Test plan

- [x] `docker build` arg surface unchanged (ROCM_VERSION / PY_VERSION / TORCH_VERSION / AITER_VERSION)
- [x] `pre-commit run -a` (passed on commit)