### PR TITLE
feat(hip,aiter): C++-level AITER backends for fused_add_rmsnorm, silu_and_mul, rope

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ kernel for non-attention ops). **AITER** = ROCm AITER backend.
 | **Cascade attention** | ✅ | — | HIP | Two-level shared-prefix attention; a fused single-kernel HIP variant is gated behind `FLASHINFER_HIP_FUSED_CASCADE=1` |
 | **MLA (Multi-Latent Attention)** | — | ✅ | **AITER** (no HIP fallback) | DeepSeek-style 192/128 head-dim split; bf16 + `page_size=1`; `backend="auto"` (default) resolves to `"aiter"` |
 | **POD attention** | ✅ `fa2` | — | HIP | MHA / GQA / MQA; single + batch variants (`PODWithPagedKVCacheWrapper`, `BatchPODWithPagedKVCacheWrapper`); JIT-only (excluded from AOT, same as upstream CUDA) |
-| **RoPE (positional encoding)** | ✅ `native` | ✅ | **AITER** for the cos/sin-cache path when `fp16` + `>= 2048` tokens + gfx942/gfx950; else **HIP `native`** | LLaMA-style + LLaMA 3.1 scaling; fused RoPE + fp8 quant + paged-KV append (E4M3FNUZ, E5M2FNUZ). AITER backend covers `apply_rope_with_cos_sin_cache` and its inplace variant (CK `rope_cached_positions_2c`); ~1.3–2.8x over native at large nnz (zero-copy via the `_impl` entry point); bf16 stays native (slightly lower precision) |
+| **RoPE (positional encoding)** | ✅ `native` | ✅ | **AITER** for the cos/sin-cache path on gfx942/gfx950; else **HIP `native`** | LLaMA-style + LLaMA 3.1 scaling; fused RoPE + fp8 quant + paged-KV append (E4M3FNUZ, E5M2FNUZ). AITER backend covers `apply_rope_with_cos_sin_cache` and its inplace variant via AITER's C++ `rope_cached_positions_2c_fwd_impl` (linked at the C++ level, no runtime `import aiter`); cos/sin passed as float32 |
 | **Paged KV-cache append** | ✅ `native` | ✅ | **AITER** when `fp16/bf16` + `NHD` + gfx942/gfx950 + AITER importable; else **HIP `native`** | `append_paged_kv_cache`; fp8 KV-cache supported on the HIP path |
 | **RMSNorm** | ✅ `native` | ✅ | **HIP `native`** (auto stays on HIP — AITER is opt-in via `backend="aiter"`) | AITER path is fp16/bf16, 2-D only; slightly lower precision at `hidden_size >= 1024` |
-| **Fused add RMSNorm** | ✅ `native` | ✅ | **AITER** when 2-D + `>= 4M` elements + gfx942/gfx950 + AITER importable; else **HIP `native`** | `fused_add_rmsnorm`; AITER (CK `rmsnorm2d_fwd_with_add`) wins on large bandwidth-bound shapes; 2-D only, slightly lower precision at `hidden_size >= 1024` |
+| **Fused add RMSNorm** | ✅ `native` | ✅ | **AITER** on gfx942/gfx950; else **HIP `native`** | `fused_add_rmsnorm`; AITER's C++ CK `rmsnorm2d_with_add` (linked at the C++ level, no runtime `import aiter`); 2-D only, slightly lower precision at `hidden_size >= 1024` |
 | **LayerNorm / Gemma RMSNorm** | ✅ | — | HIP | |
 | **Sampling** | ✅ | — | HIP | Top-K / Top-P / Min-P / OnlineSoftmax / SamplingFromLogits |
 | **Logits processor** | ✅ | — | HIP | Composable processor pipeline (cap, mask, temperature, …) |
-| **Activation** | ✅ `native` | ✅ | **AITER** for `silu_and_mul` when `fp16` + 2-D + `>= 33M` elements; else **HIP `native`** | SiLU / GELU with fused gating. AITER path (`silu_and_mul` only) is opt-in via `backend="aiter"`; matches native precision in fp16, lower in bf16 |
+| **Activation** | ✅ `native` | ✅ | **AITER** for `silu_and_mul` on gfx942/gfx950; else **HIP `native`** | SiLU / GELU with fused gating. AITER path (`silu_and_mul` only) via AITER's C++ `aiter::silu_and_mul` (linked at the C++ level, no runtime `import aiter`); matches native precision in fp16, lower in bf16 |
 | **Quantization** | ✅ | — | HIP | `packbits`, `segment_packbits` |
 | **`torch.compile`** | ✅ (opt-in) | n/a | n/a | Set `FLASHINFER_USE_TORCH_CUSTOM_OPS=1` **before** importing `flashinfer`; requires PyTorch ≥ 2.4. Without it, `torch.compile` raises a clear error if it traces into a flashinfer op |
 
@@ -323,26 +323,25 @@ explicitly, or pass the in-tree backend string to skip it:
 `backend="fa2"` for the attention wrappers (single/batch
 prefill/decode), `backend="native"` for non-attention ops
 (`append_paged_kv_cache`, `rmsnorm`, `fused_add_rmsnorm`,
-`silu_and_mul`, `rope`). Five backend-specific exceptions to "auto picks
-AITER when supported":
+`silu_and_mul`, `rope`).
+
+The `fused_add_rmsnorm`, `silu_and_mul`, and `rope` (cos/sin-cache) AITER
+backends are integrated at the **C++ level**: FlashInfer's JIT compiles a
+small HIP shim that calls AITER's C++ kernels
+(`rmsnorm2d_with_add`, `aiter::silu_and_mul`,
+`rope_cached_positions_2c_fwd_impl`) directly and links a symbol-visible
+AITER `.so` — there is no runtime `import aiter` on these paths. The first
+JIT build of each op builds the corresponding AITER module once with
+`AITER_SYMBOL_VISIBLE=1` and caches it under
+`~/.cache/flashinfer/aiter_libs/` (the CK `module_rmsnorm` build is large
+and can take many minutes the first time). For these three ops,
+`backend="auto"` resolves to AITER on gfx942/gfx950 and to HIP `native`
+elsewhere; a later performance pass may re-introduce shape-based gating.
+
+Backend-specific exceptions to "auto picks AITER when supported":
 
 * `rmsnorm`: `backend="auto"` stays on the HIP `native` kernel; the
-  AITER path is opt-in via `backend="aiter"`.
-* `fused_add_rmsnorm`: `backend="auto"` is shape-gated — it picks AITER
-  only for 2-D inputs with `>= 4M` elements (where the CK kernel is
-  faster) and stays on the HIP `native` kernel otherwise.
-* `silu_and_mul`: `backend="auto"` picks AITER only for `fp16` + 2-D +
-  `>= 33M`-element inputs (where it is faster and matches native
-  precision) and otherwise stays on HIP `native`; the AITER path is also
-  available explicitly via `backend="aiter"`.
-* `rope` (`apply_rope_with_cos_sin_cache` / `_inplace`): `backend="auto"`
-  picks AITER for `fp16` inputs with `>= 2048` tokens (where the AITER
-  kernel is ~1.3–2.8x faster and fp16 precision stays inside tolerance)
-  and otherwise stays on HIP `native`. Both the inplace and out-of-place
-  wrappers benefit — the helper uses AITER's `..._impl` entry point with
-  distinct in/out tensors, so the out-of-place path needs no Q/K copy.
-  bf16 always stays native (slightly lower precision). The AITER path is
-  also available explicitly via `backend="aiter"`.
+  AITER C++ path (`rms_norm`) is opt-in via `backend="aiter"`.
 * `batch_decode`: `use_cuda_graph=True` or `use_tensor_cores=True`
   force `auto` back to `fa2` (AITER decode does not support either),
   and `pos_encoding_mode != "NONE"` raises under `backend="aiter"`.

--- a/flashinfer/activation.py
+++ b/flashinfer/activation.py
@@ -127,15 +127,12 @@ def silu_and_mul(
             f"Unknown backend {backend!r}; expected one of 'auto', 'native', 'aiter'."
         )
     if backend == "aiter":
-        # Validate the explicit opt-in on every platform so a misconfiguration
-        # surfaces here instead of silently running native off ROCm.
-        from .aiter_utils import is_aiter_supported
+        # Validate the explicit opt-in up front so a misconfiguration (unsupported
+        # device or missing aiter package) surfaces as a clear ValueError here
+        # instead of a raw import/build error deeper in the JIT loader.
+        from .aiter_utils import require_aiter
 
-        if not (IS_HIP and is_aiter_supported(input.device)):
-            raise ValueError(
-                f"backend='aiter' requires a ROCm gfx942/gfx950 device; got "
-                f"device {input.device}."
-            )
+        require_aiter(input.device, "silu_and_mul")
     if input.shape[-1] * input.dtype.itemsize % 16 != 0:
         raise ValueError("The pointers must be multiple of 16 bytes.")
     if out is not None:

--- a/flashinfer/activation.py
+++ b/flashinfer/activation.py
@@ -36,39 +36,19 @@ if IS_CUDA:
 if IS_HIP:
 
     @functools.cache
-    def _aiter_act_ops():
-        import aiter as _aiter
+    def get_silu_and_mul_aiter_module():
+        from .jit.activation import gen_silu_and_mul_aiter_module
 
-        return _aiter
-
-    # AITER's silu_and_mul only overtakes the native kernel on large,
-    # bandwidth-bound shapes (~5-10% faster); below that a fixed ~0.7us launch
-    # overhead makes it slower. It also matches the native kernel's precision
-    # only in fp16 (bf16 is ~6e-2 vs ~4e-3 max err). The cutoff counts elements
-    # of the full input (rows x 2*hidden); ~33M is the measured break-even
-    # (e.g. 2048 x 16384). fp16 only.
-    _AITER_SILU_AND_MUL_MIN_ELEMS = 33 * 1024 * 1024
+        return gen_silu_and_mul_aiter_module().build_and_load()
 
     def _auto_select_silu_and_mul_backend(input: torch.Tensor) -> str:
-        # Cheapest guards first so the common small/medium case exits early.
-        if input.dtype != torch.float16:
-            return "native"
-        if input.ndim != 2:
-            return "native"
-        if input.numel() < _AITER_SILU_AND_MUL_MIN_ELEMS:
-            return "native"
-        from .aiter_utils import is_aiter_supported
+        # auto routes to the C++ AITER kernel on supported gfx942/gfx950 devices
+        # and falls back to native everywhere else (incl. when AITER is not
+        # installed, so auto never raises). (Shape/precision tuning is deferred to
+        # a later performance pass.)
+        from .aiter_utils import is_aiter_available
 
-        if not is_aiter_supported(input.device):
-            return "native"
-        try:
-            # Best-effort probe: a supported arch can still lack a usable aiter
-            # (not installed, or its compiled extension fails to load). auto must
-            # always be able to fall back to native, so catch any import failure.
-            _aiter_act_ops()
-        except Exception:
-            return "native"
-        return "aiter"
+        return "aiter" if is_aiter_available(input.device) else "native"
 
 
 @functools.cache
@@ -130,16 +110,12 @@ def silu_and_mul(
         <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
 
     backend: str
-        Kernel backend to use. ``"auto"`` (default) uses the native kernel for small
-        and medium inputs, and switches to AITER on ROCm for large (>= 33M element)
-        2D fp16 inputs where its kernel is faster and matches native precision; it
-        falls back to native whenever AITER is unavailable.
+        Kernel backend to use. ``"auto"`` (default) routes to the C++ AITER kernel
+        on ROCm (gfx942/gfx950) and to the native FlashInfer JIT kernel everywhere
+        else.
         ``"native"`` uses the FlashInfer JIT kernel on all platforms.
-        ``"aiter"`` uses AMD AITER's ``silu_and_mul`` — ROCm (gfx942/gfx950) only;
-        requires the ``aiter`` package, and raises ``ValueError`` on any other
-        platform. Precision matches ``"native"`` in fp16 but is lower in bf16
-        (max err ~6e-2 vs ~4e-3), which is why ``"auto"`` restricts the AITER path
-        to fp16.
+        ``"aiter"`` uses AMD AITER's ``silu_and_mul`` C++ kernel — ROCm
+        (gfx942/gfx950) only; raises ``ValueError`` on any other platform.
 
     Returns
     -------
@@ -160,13 +136,6 @@ def silu_and_mul(
                 f"backend='aiter' requires a ROCm gfx942/gfx950 device; got "
                 f"device {input.device}."
             )
-        try:
-            _aiter_act_ops()
-        except Exception as e:
-            raise ValueError(
-                "backend='aiter' requires the aiter package, which failed to "
-                f"import: {e}"
-            ) from e
     if input.shape[-1] * input.dtype.itemsize % 16 != 0:
         raise ValueError("The pointers must be multiple of 16 bytes.")
     if out is not None:
@@ -182,7 +151,7 @@ def silu_and_mul(
             backend if backend != "auto" else _auto_select_silu_and_mul_backend(input)
         )
         if _backend == "aiter":
-            _aiter_act_ops().silu_and_mul(out, input)
+            get_silu_and_mul_aiter_module().silu_and_mul_aiter(out, input)
             return out
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)

--- a/flashinfer/aiter_utils.py
+++ b/flashinfer/aiter_utils.py
@@ -21,6 +21,27 @@ def is_aiter_supported(device: torch.device) -> bool:
     return arch in FLASHINFER_SUPPORTED_ROCM_ARCHS
 
 
+@functools.lru_cache(maxsize=1)
+def _aiter_importable() -> bool:
+    """True when the AITER source package needed for the C++ backends is importable."""
+    import importlib.util
+
+    return (
+        importlib.util.find_spec("aiter") is not None
+        and importlib.util.find_spec("aiter_meta") is not None
+    )
+
+
+def is_aiter_available(device: torch.device) -> bool:
+    """Return True when ``backend="auto"`` may route to AITER for ``device``.
+
+    Combines the arch check with a cheap import probe so ``auto`` falls back to the
+    native kernel (rather than raising at build time) when the AITER package is not
+    installed. Explicit ``backend="aiter"`` still surfaces a clear error.
+    """
+    return is_aiter_supported(device) and _aiter_importable()
+
+
 @functools.cache
 def get_aiter_mha_module():
     from aiter.ops import mha as aiter_mha_module

--- a/flashinfer/aiter_utils.py
+++ b/flashinfer/aiter_utils.py
@@ -23,23 +23,51 @@ def is_aiter_supported(device: torch.device) -> bool:
 
 @functools.lru_cache(maxsize=1)
 def _aiter_importable() -> bool:
-    """True when the AITER source package needed for the C++ backends is importable."""
-    import importlib.util
+    """True when the AITER packages needed for the C++ backends actually import.
 
-    return (
-        importlib.util.find_spec("aiter") is not None
-        and importlib.util.find_spec("aiter_meta") is not None
-    )
+    Uses a real import (not ``find_spec``) so a broken or partially-installed AITER
+    — where the spec exists but importing the compiled extension fails, e.g. missing
+    ROCm deps — is reported as unavailable rather than routing ``auto`` into a path
+    that raises at build/load time.
+    """
+    try:
+        import aiter  # noqa: F401
+        import aiter_meta  # noqa: F401
+        from aiter.jit import core as _core  # noqa: F401
+    except Exception:
+        return False
+    return True
 
 
 def is_aiter_available(device: torch.device) -> bool:
     """Return True when ``backend="auto"`` may route to AITER for ``device``.
 
-    Combines the arch check with a cheap import probe so ``auto`` falls back to the
+    Combines the arch check with an import probe so ``auto`` falls back to the
     native kernel (rather than raising at build time) when the AITER package is not
-    installed. Explicit ``backend="aiter"`` still surfaces a clear error.
+    installed or not importable. Explicit ``backend="aiter"`` still surfaces a clear
+    error via :func:`require_aiter`.
     """
     return is_aiter_supported(device) and _aiter_importable()
+
+
+def require_aiter(device: torch.device, op: str) -> None:
+    """Validate the explicit ``backend="aiter"`` opt-in, raising a clear error.
+
+    Surfaces a ``ValueError`` (rather than a raw ``ImportError`` from the JIT module
+    loader) when the device is unsupported or the AITER package is missing/broken,
+    matching the public-API docs that say this mode "requires the aiter package".
+    """
+    if not is_aiter_supported(device):
+        raise ValueError(
+            f"AITER {op} requires an AMD gfx942/gfx950 device; got {device}. "
+            "Use backend='native' instead."
+        )
+    if not _aiter_importable():
+        raise ValueError(
+            f"backend='aiter' for {op} requires the aiter package, which is not "
+            "installed or failed to import. Install it (see the AITER Support "
+            "section in the README) or use backend='native'."
+        )
 
 
 @functools.cache

--- a/flashinfer/csrc_rocm/activation_aiter.cu
+++ b/flashinfer/csrc_rocm/activation_aiter.cu
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// PyTorch entry point for AITER's silu_and_mul C++ API. FlashInfer links the
+// symbol-visible AITER module (see flashinfer/jit/aiter_source.py) and calls the
+// kernel directly — no Python `import aiter` at runtime.
+
+#include <ATen/ATen.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <c10/hip/HIPGuard.h>
+
+// AITER's public header (activation.h) pulls in <torch/extension.h> → full
+// pybind11, which clashes with FlashInfer's -DPy_LIMITED_API. torch::Tensor is
+// at::Tensor, so forward-declare the entry point; the linker resolves it against
+// the symbol-visible AITER .so.
+namespace aiter {
+void silu_and_mul(at::Tensor& out, at::Tensor& input);
+}  // namespace aiter
+
+void silu_and_mul_aiter(at::Tensor out, at::Tensor input) {
+  const c10::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(input.device());
+  aiter::silu_and_mul(out, input);
+}

--- a/flashinfer/csrc_rocm/activation_aiter_jit_pybind.cu
+++ b/flashinfer/csrc_rocm/activation_aiter_jit_pybind.cu
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <ATen/ATen.h>
+
+#include "pytorch_extension_utils.h"
+
+void silu_and_mul_aiter(at::Tensor out, at::Tensor input);
+
+TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) { m.def("silu_and_mul_aiter", silu_and_mul_aiter); }

--- a/flashinfer/csrc_rocm/norm_aiter.cu
+++ b/flashinfer/csrc_rocm/norm_aiter.cu
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// PyTorch entry point for AITER's CK fused-add RMSNorm (rmsnorm2d_with_add).
+// FlashInfer links the symbol-visible AITER module (see
+// flashinfer/jit/aiter_source.py) and calls the kernel directly — no Python
+// `import aiter` at runtime.
+//
+// FlashInfer's fused_add_rmsnorm is in-place:
+//   residual = input + residual; input = rmsnorm(residual) * weight
+// AITER's CK kernel writes out / residual_out separately; alias them onto
+// input / residual to match the in-place semantics.
+
+#include <ATen/ATen.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <c10/hip/HIPGuard.h>
+
+// AITER's public header (rmsnorm.h) pulls in <torch/extension.h> → full pybind11,
+// which clashes with FlashInfer's -DPy_LIMITED_API. torch::Tensor is at::Tensor,
+// so forward-declare the entry points; the linker resolves them against the
+// symbol-visible AITER .so.
+void rmsnorm2d_with_add(at::Tensor& out, at::Tensor& input, at::Tensor& residual_in,
+                        at::Tensor& residual_out, at::Tensor& weight, double epsilon,
+                        int use_model_sensitive_rmsnorm);
+void rms_norm(at::Tensor& out, at::Tensor& input, at::Tensor& weight, double epsilon);
+
+void fused_add_rmsnorm_aiter(at::Tensor input, at::Tensor residual, at::Tensor weight, double eps) {
+  const c10::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(input.device());
+  // CK expects weight as [1, n]; FlashInfer passes [n]. reshape (not view) so a
+  // non-contiguous weight is handled rather than throwing — weight is read-only,
+  // so the copy is harmless.
+  at::Tensor weight2d = weight.reshape({1, -1});
+  rmsnorm2d_with_add(input, input, residual, residual, weight2d, eps,
+                     /*use_model_sensitive_rmsnorm=*/0);
+}
+
+void rmsnorm_aiter(at::Tensor out, at::Tensor input, at::Tensor weight, double eps) {
+  const c10::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(input.device());
+  rms_norm(out, input, weight, eps);
+}

--- a/flashinfer/csrc_rocm/norm_aiter_jit_pybind.cu
+++ b/flashinfer/csrc_rocm/norm_aiter_jit_pybind.cu
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <ATen/ATen.h>
+
+#include "pytorch_extension_utils.h"
+
+void fused_add_rmsnorm_aiter(at::Tensor input, at::Tensor residual, at::Tensor weight, double eps);
+void rmsnorm_aiter(at::Tensor out, at::Tensor input, at::Tensor weight, double eps);
+
+TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
+  m.def("fused_add_rmsnorm_aiter", fused_add_rmsnorm_aiter);
+  m.def("rmsnorm_aiter", rmsnorm_aiter);
+}

--- a/flashinfer/csrc_rocm/rope_aiter.cu
+++ b/flashinfer/csrc_rocm/rope_aiter.cu
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// PyTorch entry point for AITER's cos/sin-cache RoPE C++ API
+// (rope_cached_positions_2c_fwd_impl). FlashInfer links the symbol-visible AITER
+// module (see flashinfer/jit/aiter_source.py) and calls the kernel directly — no
+// Python `import aiter` at runtime.
+//
+// FlashInfer stores cos_sin_cache as (max_seq_len, rotary_dim) float32 with cosine
+// in the first half and sine in the second half. AITER wants two separate
+// (max_seq_len, 1, 1, rotary_dim/2) tables (reuse_freqs_front_part=true). Q/K are
+// viewed as AITER's SBHD (1, nnz, num_heads, head_dim) layout and only the leading
+// rotary_dim slice is rotated (nope_first=false). AITER ships float32-cos/sin
+// instances for fp16/bf16 data, so the tables are passed as float32 (better
+// precision than downcasting to the query dtype).
+
+#include <ATen/ATen.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <c10/hip/HIPGuard.h>
+
+// AITER's public header (rope.h) pulls in <torch/extension.h> → full pybind11,
+// which clashes with FlashInfer's -DPy_LIMITED_API. torch::Tensor is at::Tensor,
+// so forward-declare the entry point instead; the linker resolves it against the
+// symbol-visible AITER .so (verified mangling matches at::Tensor& signature).
+void rope_cached_positions_2c_fwd_impl(at::Tensor& output_x, at::Tensor& output_y,
+                                       const at::Tensor& input_x, const at::Tensor& input_y,
+                                       const at::Tensor& cos, const at::Tensor& sin,
+                                       const at::Tensor& positions, const int32_t rotate_style,
+                                       const bool reuse_freqs_front_part, const bool nope_first);
+
+void apply_rope_pos_ids_cos_sin_cache_aiter(at::Tensor query, at::Tensor key, at::Tensor query_out,
+                                            at::Tensor key_out, at::Tensor cos_sin_cache,
+                                            at::Tensor positions, int64_t head_size, bool is_neox) {
+  const c10::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(query.device());
+
+  TORCH_CHECK(query.scalar_type() == key.scalar_type(),
+              "AITER rope requires query and key to share a dtype; got query=", query.scalar_type(),
+              ", key=", key.scalar_type());
+
+  const int64_t rotary_dim = cos_sin_cache.size(-1);
+  TORCH_CHECK(rotary_dim % 2 == 0, "cos_sin_cache last dim must be even (cos||sin); got ",
+              rotary_dim);
+  TORCH_CHECK(rotary_dim <= head_size, "rotary_dim (", rotary_dim,
+              ") from cos_sin_cache exceeds head_size (", head_size, ")");
+
+  const int64_t nnz = query.size(0);
+  const int64_t half = rotary_dim / 2;
+
+  // Split cos||sin into two (max_seq_len, 1, 1, rotary_dim/2) float32 tables.
+  at::Tensor cos = cos_sin_cache.slice(/*dim=*/1, 0, half).unsqueeze(1).unsqueeze(1).contiguous();
+  at::Tensor sin =
+      cos_sin_cache.slice(/*dim=*/1, half, rotary_dim).unsqueeze(1).unsqueeze(1).contiguous();
+
+  // SBHD views (1, nnz, num_heads, head_size).
+  at::Tensor q_in = query.view({1, nnz, -1, head_size});
+  at::Tensor k_in = key.view({1, nnz, -1, head_size});
+  at::Tensor q_out = query_out.view({1, nnz, -1, head_size});
+  at::Tensor k_out = key_out.view({1, nnz, -1, head_size});
+
+  // The kernel only writes the rotated [:rotary_dim] slice. For partial rotary
+  // into a fresh output, copy the untouched nope tail across first (skipped when
+  // the output aliases the input, and when rotary_dim covers the full head_size).
+  if (rotary_dim < head_size) {
+    if (query_out.data_ptr() != query.data_ptr()) {
+      q_out.slice(3, rotary_dim, head_size).copy_(q_in.slice(3, rotary_dim, head_size));
+    }
+    if (key_out.data_ptr() != key.data_ptr()) {
+      k_out.slice(3, rotary_dim, head_size).copy_(k_in.slice(3, rotary_dim, head_size));
+    }
+  }
+
+  // AITER's kernel requires int64, contiguous positions of shape (1, nnz).
+  at::Tensor pos = positions.to(at::kLong).contiguous().view({1, nnz});
+
+  at::Tensor q_out_rot = q_out.slice(3, 0, rotary_dim);
+  at::Tensor k_out_rot = k_out.slice(3, 0, rotary_dim);
+  at::Tensor q_in_rot = q_in.slice(3, 0, rotary_dim);
+  at::Tensor k_in_rot = k_in.slice(3, 0, rotary_dim);
+
+  rope_cached_positions_2c_fwd_impl(q_out_rot, k_out_rot, q_in_rot, k_in_rot, cos, sin, pos,
+                                    /*rotate_style=*/is_neox ? 0 : 1,
+                                    /*reuse_freqs_front_part=*/true,
+                                    /*nope_first=*/false);
+}

--- a/flashinfer/csrc_rocm/rope_aiter_jit_pybind.cu
+++ b/flashinfer/csrc_rocm/rope_aiter_jit_pybind.cu
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <ATen/ATen.h>
+
+#include "pytorch_extension_utils.h"
+
+void apply_rope_pos_ids_cos_sin_cache_aiter(at::Tensor query, at::Tensor key, at::Tensor query_out,
+                                            at::Tensor key_out, at::Tensor cos_sin_cache,
+                                            at::Tensor positions, int64_t head_size, bool is_neox);
+
+TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
+  m.def("apply_rope_pos_ids_cos_sin_cache_aiter", apply_rope_pos_ids_cos_sin_cache_aiter);
+}

--- a/flashinfer/jit/activation.py
+++ b/flashinfer/jit/activation.py
@@ -148,3 +148,16 @@ def gen_act_and_mul_module(act_func_name: str) -> JitSpec:
         f"{act_func_name}_and_mul",
         sources,
     )
+
+
+def gen_silu_and_mul_aiter_module() -> JitSpec:
+    from .aiter_source import aiter_jitspec_kwargs
+
+    return gen_jit_spec(
+        "silu_and_mul_aiter",
+        [
+            jit_env.FLASHINFER_CSRC_DIR / "activation_aiter.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "activation_aiter_jit_pybind.cu",
+        ],
+        **aiter_jitspec_kwargs("module_activation"),
+    )

--- a/flashinfer/jit/activation.py
+++ b/flashinfer/jit/activation.py
@@ -151,13 +151,15 @@ def gen_act_and_mul_module(act_func_name: str) -> JitSpec:
 
 
 def gen_silu_and_mul_aiter_module() -> JitSpec:
-    from .aiter_source import aiter_jitspec_kwargs
+    from .aiter_source import aiter_jitspec_flags
 
+    extra_include_paths, extra_ldflags = aiter_jitspec_flags("module_activation")
     return gen_jit_spec(
         "silu_and_mul_aiter",
         [
             jit_env.FLASHINFER_CSRC_DIR / "activation_aiter.cu",
             jit_env.FLASHINFER_CSRC_DIR / "activation_aiter_jit_pybind.cu",
         ],
-        **aiter_jitspec_kwargs("module_activation"),
+        extra_include_paths=extra_include_paths,
+        extra_ldflags=extra_ldflags,
     )

--- a/flashinfer/jit/aiter_source.py
+++ b/flashinfer/jit/aiter_source.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Shared plumbing for FlashInfer's C++-level AITER backends (ROCm).
+
+FlashInfer wraps AITER kernels by compiling a small ``csrc_rocm/*_aiter.cu`` shim
+that ``#include``s AITER's public C++ header and calls the kernel directly, then
+links the symbol-visible AITER ``.so``.
+
+AITER's installed wheel builds its modules with ``-fvisibility=hidden``, so the
+kernel symbols (e.g. ``rope_cached_positions_2c_fwd_impl``) are not linkable. This
+helper rebuilds the needed AITER module once with ``AITER_SYMBOL_VISIBLE=1`` via
+AITER's own ``aiter.jit.core.build_module`` (which also runs CK blob codegen for CK
+ops), caches the result under FlashInfer's cache dir as ``lib<module>.so``, and
+hands back the include/link flags for ``gen_jit_spec``.
+"""
+
+import functools
+import os
+import shutil
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from . import env as jit_env
+
+
+def _aiter_cache_tag() -> str:
+    """A filesystem-safe tag keying the lib cache by target arch and AITER version.
+
+    Without the arch component, a lib built for one arch would be silently reused
+    on a machine with a different arch. Without the version component, an AITER
+    upgrade (which can change the C++ ABI the FlashInfer shim links against) would
+    silently reuse the stale .so. The FlashInfer JIT dir already keys by its own
+    version+arch, but this cache sits outside it."""
+    arch = os.environ.get("FLASHINFER_ROCM_ARCH_LIST", "gfx942").replace(";", ",")
+    arch = arch.replace(",", "_")
+    try:
+        import importlib.metadata as _md
+
+        version = _md.version("amd-aiter")
+    except Exception:
+        version = "unknown"
+    return f"{arch}__aiter-{version}"
+
+
+@functools.lru_cache(maxsize=1)
+def _aiter_libs_dir() -> Path:
+    # Keyed by arch + AITER version so a cached lib is never reused across an
+    # incompatible arch or a changed AITER ABI.
+    d = jit_env.FLASHINFER_CACHE_DIR / "aiter_libs" / _aiter_cache_tag()
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+@functools.lru_cache(maxsize=1)
+def _aiter_csrc_include_dir() -> Path:
+    """The aiter_meta C++ public header dir (rmsnorm.h / activation.h / rope.h)."""
+    # aiter ships its C++ sources/headers in the sibling aiter_meta package,
+    # which is a namespace package (no __file__) — resolve via __path__.
+    import aiter_meta
+
+    for p in aiter_meta.__path__:
+        inc = Path(p) / "csrc" / "include"
+        if inc.exists():
+            return inc
+    raise RuntimeError(
+        "Could not locate aiter_meta/csrc/include; is the aiter source package installed?"
+    )
+
+
+def ensure_aiter_lib(module_name: str) -> Path:
+    """
+    Build (once, cached) a symbol-visible AITER module and return the path to the
+    linkable ``lib<module_name>.so`` under FlashInfer's cache.
+
+    Idempotent: if the cached lib already exists it is returned without rebuilding.
+    """
+    libs_dir = _aiter_libs_dir()
+    lib_path = libs_dir / f"lib{module_name}.so"
+    if lib_path.exists():
+        return lib_path
+
+    # Build into a FlashInfer-owned dir so we never mutate the AITER install.
+    aiter_build_dir = libs_dir / "build"
+    aiter_build_dir.mkdir(parents=True, exist_ok=True)
+
+    # AITER reads these from the environment at build time.
+    from ..hip_utils import get_rocm_home
+
+    arch_list = os.environ.get("FLASHINFER_ROCM_ARCH_LIST", "gfx942")
+    prev = {
+        "AITER_SYMBOL_VISIBLE": os.environ.get("AITER_SYMBOL_VISIBLE"),
+        "AITER_JIT_DIR": os.environ.get("AITER_JIT_DIR"),
+        "GPU_ARCHS": os.environ.get("GPU_ARCHS"),
+        "ROCM_HOME": os.environ.get("ROCM_HOME"),
+    }
+    os.environ["AITER_SYMBOL_VISIBLE"] = "1"
+    os.environ["AITER_JIT_DIR"] = str(aiter_build_dir)
+    os.environ["GPU_ARCHS"] = arch_list.replace(";", ",")
+    os.environ["ROCM_HOME"] = get_rocm_home()
+
+    built: Optional[Path] = None
+    try:
+        from aiter.jit import core as aiter_core
+        from aiter.jit.core import build_module, get_args_of_build
+
+        # AITER's cpp_extension bakes -fvisibility=hidden into COMMON_HIPCC_FLAGS
+        # at import time when AITER_SYMBOL_VISIBLE is unset. If aiter was already
+        # imported (e.g. the MHA/MLA path ran first), setting the env var now is
+        # too late, so force default visibility via the per-build flags — they are
+        # appended after COMMON_HIPCC_FLAGS, and the later flag wins. Without this,
+        # the rebuilt .so hides the kernel symbols and the FlashInfer shim fails to
+        # link with "undefined symbol".
+        a = get_args_of_build(module_name)
+        flags_extra_hip = list(a["flags_extra_hip"]) + ["-fvisibility=default"]
+        build_module(
+            md_name=module_name,
+            srcs=a["srcs"],
+            flags_extra_cc=a["flags_extra_cc"],
+            flags_extra_hip=flags_extra_hip,
+            blob_gen_cmd=a["blob_gen_cmd"],
+            extra_include=a["extra_include"],
+            extra_ldflags=a["extra_ldflags"],
+            verbose=os.environ.get("FLASHINFER_JIT_VERBOSE", "0") == "1",
+            is_python_module=a["is_python_module"],
+            is_standalone=a["is_standalone"],
+            torch_exclude=a["torch_exclude"],
+            hipify=a.get("hipify", False),
+        )
+
+        # AITER decides the output dir from a module-level `bd_dir` global that is
+        # frozen at import time, so the .so does not reliably land in
+        # aiter_build_dir when aiter was imported before we set AITER_JIT_DIR.
+        # Resolve the produced file from AITER's own get_user_jit_dir() (which
+        # re-reads the env), falling back to a recursive search of our build dir.
+        built = _find_built_so(
+            module_name, aiter_build_dir, Path(aiter_core.get_user_jit_dir())
+        )
+    finally:
+        for k, v in prev.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    if built is None:
+        raise RuntimeError(
+            f"AITER build for {module_name!r} did not produce a {module_name}.so. "
+            "Check that aiter is installed and ROCm is available."
+        )
+    # Copy (not symlink) the artifact into our arch-keyed cache so it survives
+    # cleanup of AITER's build tree, and publish it atomically via os.replace so a
+    # concurrent loader never observes a partial/missing file.
+    tmp_lib = lib_path.with_name(f".{lib_path.name}.{os.getpid()}.tmp")
+    shutil.copy2(built, tmp_lib)
+    os.replace(tmp_lib, lib_path)
+    return lib_path
+
+
+def _find_built_so(module_name: str, *search_dirs: Path) -> Optional[Path]:
+    """Locate the freshly built ``<module_name>.so`` across AITER's output dirs."""
+    name = f"{module_name}.so"
+    for d in search_dirs:
+        candidate = d / name
+        if candidate.is_file():
+            return candidate
+    for d in search_dirs:
+        if d.exists():
+            for found in d.rglob(name):
+                if found.is_file():
+                    return found
+    return None
+
+
+def aiter_jitspec_kwargs(module_name: str) -> Dict[str, List]:
+    """
+    Build the AITER lib if needed and return the ``extra_include_paths`` /
+    ``extra_ldflags`` to merge into ``gen_jit_spec`` so the FlashInfer shim can
+    ``#include`` AITER's header and link the kernel.
+    """
+    ensure_aiter_lib(module_name)
+    libs_dir = _aiter_libs_dir()
+    return {
+        "extra_include_paths": [str(_aiter_csrc_include_dir())],
+        "extra_ldflags": [
+            f"-L{libs_dir}",
+            f"-l{module_name}",
+            f"-Wl,-rpath,{libs_dir}",
+        ],
+    }

--- a/flashinfer/jit/aiter_source.py
+++ b/flashinfer/jit/aiter_source.py
@@ -4,8 +4,11 @@
 Shared plumbing for FlashInfer's C++-level AITER backends (ROCm).
 
 FlashInfer wraps AITER kernels by compiling a small ``csrc_rocm/*_aiter.cu`` shim
-that ``#include``s AITER's public C++ header and calls the kernel directly, then
-links the symbol-visible AITER ``.so``.
+that calls AITER's C++ entry point directly and links the symbol-visible AITER
+``.so``. The shim forward-declares the entry point rather than ``#include``-ing
+AITER's public header, because that header pulls in pybind11, which clashes with
+FlashInfer's ``-DPy_LIMITED_API`` build; ``torch::Tensor`` is ``at::Tensor``, so
+the linker resolves the symbol from the AITER ``.so``.
 
 AITER's installed wheel builds its modules with ``-fvisibility=hidden``, so the
 kernel symbols (e.g. ``rope_cached_positions_2c_fwd_impl``) are not linkable. This

--- a/flashinfer/jit/aiter_source.py
+++ b/flashinfer/jit/aiter_source.py
@@ -22,7 +22,7 @@ import functools
 import os
 import shutil
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import List, Optional, Tuple, Union
 
 from . import env as jit_env
 
@@ -175,19 +175,20 @@ def _find_built_so(module_name: str, *search_dirs: Path) -> Optional[Path]:
     return None
 
 
-def aiter_jitspec_kwargs(module_name: str) -> Dict[str, List]:
+def aiter_jitspec_flags(
+    module_name: str,
+) -> Tuple[List[Union[str, Path]], List[str]]:
     """
-    Build the AITER lib if needed and return the ``extra_include_paths`` /
-    ``extra_ldflags`` to merge into ``gen_jit_spec`` so the FlashInfer shim can
-    ``#include`` AITER's header and link the kernel.
+    Build the AITER lib if needed and return ``(extra_include_paths, extra_ldflags)``
+    to pass to ``gen_jit_spec`` so the FlashInfer shim can find AITER's header and
+    link the kernel.
     """
     ensure_aiter_lib(module_name)
     libs_dir = _aiter_libs_dir()
-    return {
-        "extra_include_paths": [str(_aiter_csrc_include_dir())],
-        "extra_ldflags": [
-            f"-L{libs_dir}",
-            f"-l{module_name}",
-            f"-Wl,-rpath,{libs_dir}",
-        ],
-    }
+    extra_include_paths: List[Union[str, Path]] = [str(_aiter_csrc_include_dir())]
+    extra_ldflags = [
+        f"-L{libs_dir}",
+        f"-l{module_name}",
+        f"-Wl,-rpath,{libs_dir}",
+    ]
+    return extra_include_paths, extra_ldflags

--- a/flashinfer/jit/norm.py
+++ b/flashinfer/jit/norm.py
@@ -31,3 +31,16 @@ def gen_norm_module() -> JitSpec:
         ],
         extra_cuda_cflags=nvcc_flags,
     )
+
+
+def gen_norm_aiter_module() -> JitSpec:
+    from .aiter_source import aiter_jitspec_kwargs
+
+    return gen_jit_spec(
+        "norm_aiter",
+        [
+            jit_env.FLASHINFER_CSRC_DIR / "norm_aiter.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "norm_aiter_jit_pybind.cu",
+        ],
+        **aiter_jitspec_kwargs("module_rmsnorm"),
+    )

--- a/flashinfer/jit/norm.py
+++ b/flashinfer/jit/norm.py
@@ -34,13 +34,15 @@ def gen_norm_module() -> JitSpec:
 
 
 def gen_norm_aiter_module() -> JitSpec:
-    from .aiter_source import aiter_jitspec_kwargs
+    from .aiter_source import aiter_jitspec_flags
 
+    extra_include_paths, extra_ldflags = aiter_jitspec_flags("module_rmsnorm")
     return gen_jit_spec(
         "norm_aiter",
         [
             jit_env.FLASHINFER_CSRC_DIR / "norm_aiter.cu",
             jit_env.FLASHINFER_CSRC_DIR / "norm_aiter_jit_pybind.cu",
         ],
-        **aiter_jitspec_kwargs("module_rmsnorm"),
+        extra_include_paths=extra_include_paths,
+        extra_ldflags=extra_ldflags,
     )

--- a/flashinfer/jit/rope.py
+++ b/flashinfer/jit/rope.py
@@ -29,13 +29,15 @@ def gen_rope_module() -> JitSpec:
 
 
 def gen_rope_aiter_module() -> JitSpec:
-    from .aiter_source import aiter_jitspec_kwargs
+    from .aiter_source import aiter_jitspec_flags
 
+    extra_include_paths, extra_ldflags = aiter_jitspec_flags("module_rope_pos_fwd")
     return gen_jit_spec(
         "rope_aiter",
         [
             jit_env.FLASHINFER_CSRC_DIR / "rope_aiter.cu",
             jit_env.FLASHINFER_CSRC_DIR / "rope_aiter_jit_pybind.cu",
         ],
-        **aiter_jitspec_kwargs("module_rope_pos_fwd"),
+        extra_include_paths=extra_include_paths,
+        extra_ldflags=extra_ldflags,
     )

--- a/flashinfer/jit/rope.py
+++ b/flashinfer/jit/rope.py
@@ -26,3 +26,16 @@ def gen_rope_module() -> JitSpec:
             jit_env.FLASHINFER_CSRC_DIR / "flashinfer_rope_binding.cu",
         ],
     )
+
+
+def gen_rope_aiter_module() -> JitSpec:
+    from .aiter_source import aiter_jitspec_kwargs
+
+    return gen_jit_spec(
+        "rope_aiter",
+        [
+            jit_env.FLASHINFER_CSRC_DIR / "rope_aiter.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "rope_aiter_jit_pybind.cu",
+        ],
+        **aiter_jitspec_kwargs("module_rope_pos_fwd"),
+    )

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -95,13 +95,9 @@ def rmsnorm(
             backend if backend != "auto" else _auto_select_norm_backend(input.device)
         )
         if _backend == "aiter":
-            from .aiter_utils import is_aiter_supported
+            from .aiter_utils import require_aiter
 
-            if not is_aiter_supported(input.device):
-                raise ValueError(
-                    "AITER rmsnorm requires an AMD gfx942/gfx950 device; "
-                    "use backend='native' instead."
-                )
+            require_aiter(input.device, "rmsnorm")
             if input.ndim != 2:
                 raise ValueError(
                     f"AITER rmsnorm only supports 2D inputs; got {input.ndim}D. "
@@ -199,13 +195,9 @@ def fused_add_rmsnorm(
             else _auto_select_fused_add_rmsnorm_backend(input)
         )
         if _backend == "aiter":
-            from .aiter_utils import is_aiter_supported
+            from .aiter_utils import require_aiter
 
-            if not is_aiter_supported(input.device):
-                raise ValueError(
-                    "AITER fused_add_rmsnorm requires an AMD gfx942/gfx950 device; "
-                    "use backend='native' instead."
-                )
+            require_aiter(input.device, "fused_add_rmsnorm")
             get_norm_aiter_module().fused_add_rmsnorm_aiter(
                 input, residual, weight, eps
             )

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -32,41 +32,25 @@ def get_norm_module():
 if IS_HIP:
 
     @functools.cache
-    def _aiter_norm_ops():
-        import aiter as _aiter
+    def get_norm_aiter_module():
+        from .jit.norm import gen_norm_aiter_module
 
-        return _aiter
+        return gen_norm_aiter_module().build_and_load()
 
-    def _auto_select_norm_backend(device: torch.device, dtype: torch.dtype) -> str:
-        # AITER rms_norm uses lower-precision reductions that exceed the flashinfer
-        # test tolerance (fp16 atol=1e-3, bf16 atol=1.6e-2) at hidden_size >= 1024.
-        # Keep auto on the native JIT kernel; pass backend="aiter" to opt in explicitly.
+    def _auto_select_norm_backend(device: torch.device) -> str:
+        # auto routes plain rmsnorm to native: AITER's rms_norm uses lower-precision
+        # reductions that exceed the flashinfer test tolerance at hidden_size >= 1024.
+        # Pass backend="aiter" to opt in explicitly.
         return "native"
 
-    # AITER's CK fused_add_rmsnorm only overtakes the native kernel on large,
-    # bandwidth-bound shapes (~10-14% faster at >=2048 rows x 8192 cols); below
-    # that the native kernel is faster and more accurate. Route auto to AITER once
-    # the input reaches this element-count cutoff (around the measured break-even).
-    _AITER_FUSED_ADD_RMSNORM_MIN_ELEMS = 4 * 1024 * 1024
-
     def _auto_select_fused_add_rmsnorm_backend(input: torch.Tensor) -> str:
-        # Cheapest guards first so the common small/medium case exits early.
-        if input.ndim != 2:
-            return "native"
-        if input.numel() < _AITER_FUSED_ADD_RMSNORM_MIN_ELEMS:
-            return "native"
-        from .aiter_utils import is_aiter_supported
+        # auto routes fused_add_rmsnorm to the C++ AITER CK kernel on supported
+        # devices and falls back to native everywhere else (incl. when AITER is not
+        # installed, so auto never raises). (Shape/precision tuning is deferred to
+        # a later performance pass.)
+        from .aiter_utils import is_aiter_available
 
-        if not is_aiter_supported(input.device):
-            return "native"
-        try:
-            # Best-effort probe: a supported arch can still lack a usable aiter
-            # (not installed, or its compiled extension fails to load). auto must
-            # always be able to fall back to native, so catch any import failure.
-            _aiter_norm_ops()
-        except Exception:
-            return "native"
-        return "aiter"
+        return "aiter" if is_aiter_available(input.device) else "native"
 
 
 def rmsnorm(
@@ -97,9 +81,9 @@ def rmsnorm(
     backend: str
         Kernel backend to use. ``"auto"`` (default) selects the best available backend.
         ``"native"`` uses the FlashInfer JIT kernel on all platforms.
-        ``"aiter"`` uses AMD AITER's rms_norm — ROCm (gfx942/gfx950) only; requires the
-        ``aiter`` package and only supports 2D inputs. Precision is slightly lower than
-        ``"native"`` at ``hidden_size >= 1024`` (fp16 atol ~4e-3, bf16 ~7e-2).
+        ``"aiter"`` uses AMD AITER's ``rms_norm`` C++ kernel — ROCm (gfx942/gfx950)
+        only, 2D inputs only. Precision is slightly lower than ``"native"`` at
+        ``hidden_size >= 1024`` (fp16 atol ~4e-3, bf16 ~7e-2).
 
     Returns
     -------
@@ -108,21 +92,25 @@ def rmsnorm(
     """
     if IS_HIP:
         _backend = (
-            backend
-            if backend != "auto"
-            else _auto_select_norm_backend(input.device, input.dtype)
+            backend if backend != "auto" else _auto_select_norm_backend(input.device)
         )
         if _backend == "aiter":
+            from .aiter_utils import is_aiter_supported
+
+            if not is_aiter_supported(input.device):
+                raise ValueError(
+                    "AITER rmsnorm requires an AMD gfx942/gfx950 device; "
+                    "use backend='native' instead."
+                )
             if input.ndim != 2:
                 raise ValueError(
                     f"AITER rmsnorm only supports 2D inputs; got {input.ndim}D. "
                     "Use backend='native' for 3D inputs."
                 )
-            result = _aiter_norm_ops().rms_norm(input, weight, eps)
-            if out is not None:
-                out.copy_(result)
-                return out
-            return result
+            if out is None:
+                out = torch.empty_like(input)
+            get_norm_aiter_module().rmsnorm_aiter(out, input, weight, eps)
+            return out
         if _backend not in ("native",):
             raise ValueError(
                 f"Unknown backend {backend!r}; expected one of 'auto', 'native', 'aiter'."
@@ -189,14 +177,13 @@ def fused_add_rmsnorm(
         Whether to enable `programmatic dependent launch
         <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#programmatic-dependent-launch-and-synchronization>`_
     backend: str
-        Kernel backend to use. ``"auto"`` (default) uses the native kernel for small
-        and medium inputs, and switches to AITER on ROCm for large (>= 4M element) 2D
-        inputs where its CK kernel is faster; it falls back to native whenever AITER
-        is unavailable.
+        Kernel backend to use. ``"auto"`` (default) routes to the C++ AITER CK
+        kernel on ROCm (gfx942/gfx950) and to the native FlashInfer JIT kernel
+        everywhere else.
         ``"native"`` uses the FlashInfer JIT kernel on all platforms.
-        ``"aiter"`` uses AMD AITER's CK ``rmsnorm2d_fwd_with_add`` — ROCm
-        (gfx942/gfx950) only; requires the ``aiter`` package and only supports 2D
-        inputs. Precision is slightly lower than ``"native"`` at ``hidden_size >= 1024``.
+        ``"aiter"`` uses AMD AITER's CK ``rmsnorm2d_with_add`` C++ kernel — ROCm
+        (gfx942/gfx950) only, 2D inputs only. Precision is slightly lower than
+        ``"native"`` at ``hidden_size >= 1024``.
     """
     # Both the native and AITER kernels are 2D-only (the native kernel enforces
     # CHECK_DIM(2) on input/residual), so reject other ranks up front with a clear
@@ -212,10 +199,15 @@ def fused_add_rmsnorm(
             else _auto_select_fused_add_rmsnorm_backend(input)
         )
         if _backend == "aiter":
-            # CK kernel writes out/residual_out separately; alias them onto the
-            # input/residual tensors to match FlashInfer's in-place semantics.
-            _aiter_norm_ops().rmsnorm2d_fwd_with_add(
-                input, input, residual, residual, weight, eps
+            from .aiter_utils import is_aiter_supported
+
+            if not is_aiter_supported(input.device):
+                raise ValueError(
+                    "AITER fused_add_rmsnorm requires an AMD gfx942/gfx950 device; "
+                    "use backend='native' instead."
+                )
+            get_norm_aiter_module().fused_add_rmsnorm_aiter(
+                input, residual, weight, eps
             )
             return
         if _backend != "native":

--- a/flashinfer/rope.py
+++ b/flashinfer/rope.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 import functools
-import weakref
 from typing import Optional, Tuple
 
 import torch
@@ -33,76 +32,22 @@ def get_rope_module():
 if IS_HIP:
 
     @functools.cache
-    def _aiter_rope_ops():
-        import aiter as _aiter
+    def get_rope_aiter_module():
+        from .jit.rope import gen_rope_aiter_module
 
-        return _aiter
-
-    # Token count above which AITER's cos/sin-cache rope beats the native JIT
-    # kernel. Measured on gfx942 (fp16, q32/k8, hd128): AITER crosses over around
-    # nnz~1024-1536 and reaches ~2.6-2.8x at large nnz, while native's lower
-    # launch overhead wins below it. 2048 leaves headroom over launch jitter.
-    _AITER_ROPE_MIN_TOKENS = 2048
+        return gen_rope_aiter_module().build_and_load()
 
     def _auto_select_rope_backend(query: torch.Tensor, key: torch.Tensor) -> str:
-        # AITER's cos/sin-cache rope consumes the cos/sin tables in the query
-        # dtype, whereas the native JIT kernel rotates in float32. For bf16 this
-        # pushes max abs error to ~5e-2 (vs native ~3e-2), at the edge of the
-        # rope test tolerance, so auto never picks AITER for bf16 — only fp16,
-        # whose AITER error (~7e-3) stays comfortably inside tolerance.
-        #
-        # AITER wins on both the inplace and out-of-place paths once nnz is large
-        # enough: the helper uses the ..._impl entry point with distinct in/out
-        # tensors, so out-of-place needs no Q/K copy. Below the token threshold,
-        # native's lower launch overhead wins.
-        if query.dtype != torch.float16:
-            return "native"
+        # auto routes to the C++ AITER kernel on supported devices and falls back
+        # to native everywhere else. auto must never raise, so fall back to native
+        # for cases the AITER kernel rejects: mixed query/key dtypes (it rotates
+        # both with one cos/sin table), and when AITER is unavailable. (Shape /
+        # precision tuning is deferred to a later performance pass.)
+        from .aiter_utils import is_aiter_available
+
         if key.dtype != query.dtype:
-            # AITER rotates Q and K with one cos/sin table in the query dtype and
-            # rejects mismatched dtypes; native handles them. auto must not raise,
-            # so fall back rather than route into the helper's dtype guard.
             return "native"
-        if query.shape[0] < _AITER_ROPE_MIN_TOKENS:
-            return "native"
-        from .aiter_utils import is_aiter_supported
-
-        if not is_aiter_supported(query.device):
-            return "native"
-        try:
-            # Best-effort probe: a supported arch can still lack a usable aiter
-            # (not installed, or its compiled extension fails to load). auto must
-            # always fall back to native, never raise — matching norm/activation.
-            _aiter_rope_ops()
-        except Exception:
-            return "native"
-        return "aiter"
-
-    # Memoize the AITER-format cos/sin tables. ``cos_sin_cache`` is a fixed
-    # precomputed float32 table (typically a persistent module buffer) reused
-    # across every forward pass, so converting the whole table to the query
-    # dtype on each call is pure overhead — significant during decode, where
-    # nnz is tiny but max_seq_len is large. Keyed by id() (tensors aren't
-    # value-hashable) with a finalizer that evicts the entry when the cache is
-    # GC'd, so the cached tables never outlive their source. A weakref to the
-    # source is stored alongside the entry so a hit is only honored when it
-    # still resolves to the *same* tensor — guarding against id() reuse if a
-    # transient cache is freed and a new tensor lands on the same address.
-    _aiter_cos_sin_tables: dict = {}
-
-    def _aiter_rope_cos_sin(
-        cos_sin_cache: torch.Tensor, dtype: torch.dtype
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        key = id(cos_sin_cache)
-        cached = _aiter_cos_sin_tables.get(key)
-        if cached is not None and cached[0] == dtype and cached[1]() is cos_sin_cache:
-            return cached[2], cached[3]
-        half = cos_sin_cache.shape[-1] // 2
-        cos = cos_sin_cache[:, :half].unsqueeze(1).unsqueeze(1).to(dtype).contiguous()
-        sin = cos_sin_cache[:, half:].unsqueeze(1).unsqueeze(1).to(dtype).contiguous()
-        if cached is None:
-            weakref.finalize(cos_sin_cache, _aiter_cos_sin_tables.pop, key, None)
-        _aiter_cos_sin_tables[key] = (dtype, weakref.ref(cos_sin_cache), cos, sin)
-        return cos, sin
+        return "aiter" if is_aiter_available(query.device) else "native"
 
     def _apply_rope_cos_sin_cache_aiter(
         query: torch.Tensor,
@@ -114,23 +59,7 @@ if IS_HIP:
         head_size: int,
         is_neox: bool,
     ) -> None:
-        r"""Dispatch the cos/sin-cache rope to AITER's rope_cached_positions_2c kernel.
-
-        FlashInfer stores ``cos_sin_cache`` as ``(max_seq_len, rotary_dim)`` float32
-        with cosine in the first half and sine in the second half. AITER wants two
-        separate ``(max_seq_len, 1, 1, rotary_dim // 2)`` tables in the query dtype
-        with ``reuse_freqs_front_part=True``. Q/K are reshaped to AITER's
-        ``(1, nnz, num_heads, head_dim)`` layout and only the leading ``rotary_dim``
-        slice is rotated (matching ``nope_first=False``).
-
-        Uses the ``..._impl`` entry point with distinct input/output tensors so the
-        out-of-place case writes straight into ``query_out``/``key_out`` with no Q/K
-        copy (measured ~1.3-2.8x faster than copy-then-rotate). The kernel only
-        writes the rotated ``[:rotary_dim]`` slice, so for partial rotary
-        (``rotary_dim < head_size``) the untouched nope tail is copied across when
-        the output is a fresh tensor. When ``query_out``/``key_out`` alias the
-        inputs (the inplace variant) this is ``_impl(x, y, x, y, ...)``.
-        """
+        r"""Dispatch the cos/sin-cache rope to AITER's C++ rope_cached_positions_2c kernel."""
         from .aiter_utils import is_aiter_supported
 
         if not is_aiter_supported(query.device):
@@ -138,69 +67,20 @@ if IS_HIP:
                 "AITER rope backend requires an AMD gfx942/gfx950 device; "
                 "use backend='native' instead."
             )
-        try:
-            aiter_ops = _aiter_rope_ops()
-        except Exception as e:
-            raise ValueError(
-                "backend='aiter' requires the aiter package, which failed to "
-                f"import: {e}"
-            ) from e
         if key.dtype != query.dtype:
-            # AITER rotates Q and K with a single cos/sin table built in the
-            # query dtype; the native path tolerates mixed dtypes by rotating
-            # in float32, but AITER cannot.
             raise ValueError(
                 "AITER rope backend requires query and key to share a dtype; "
                 f"got query={query.dtype}, key={key.dtype}. Use backend='native'."
             )
-
-        rotary_dim = cos_sin_cache.shape[-1]
-        # cos_sin_cache stacks cos||sin on its last dim, so rotary_dim must be
-        # even, and the rotated slice q[..., :rotary_dim] must fit in head_size.
-        if rotary_dim % 2 != 0:
-            raise ValueError(
-                f"cos_sin_cache last dim must be even (cos||sin); got {rotary_dim}."
-            )
-        if rotary_dim > head_size:
-            raise ValueError(
-                f"rotary_dim ({rotary_dim}) from cos_sin_cache exceeds head_size "
-                f"({head_size})."
-            )
-
-        nnz = query.shape[0]
-        cos, sin = _aiter_rope_cos_sin(cos_sin_cache, query.dtype)
-
-        q_in = query.view(1, nnz, -1, head_size)
-        k_in = key.view(1, nnz, -1, head_size)
-        q_out = query_out.view(1, nnz, -1, head_size)
-        k_out = key_out.view(1, nnz, -1, head_size)
-
-        # The kernel only writes the rotated [:rotary_dim] slice. For partial
-        # rotary into a fresh output, copy the untouched nope tail [rotary_dim:]
-        # across first (skipped when output aliases input, and when rotary_dim
-        # covers the full head_size).
-        if rotary_dim < head_size:
-            if query_out.data_ptr() != query.data_ptr():
-                q_out[..., rotary_dim:].copy_(q_in[..., rotary_dim:])
-            if key_out.data_ptr() != key.data_ptr():
-                k_out[..., rotary_dim:].copy_(k_in[..., rotary_dim:])
-
-        # AITER's HIP kernel asserts int64, contiguous positions of shape
-        # (1, nnz) (stride(1) == 1) — a strided/non-int64 positions tensor
-        # otherwise trips a C assert that aborts the process.
-        pos = positions.to(torch.int64).contiguous().view(1, nnz)
-
-        aiter_ops.rope_cached_positions_2c_fwd_impl(
-            q_out[..., :rotary_dim],
-            k_out[..., :rotary_dim],
-            q_in[..., :rotary_dim],
-            k_in[..., :rotary_dim],
-            cos,
-            sin,
-            pos,
-            0 if is_neox else 1,  # rotate_style: 0=NEOX, 1=GPT-J
-            True,  # reuse_freqs_front_part (cos/sin are rotary_dim//2 sized)
-            False,  # nope_first
+        get_rope_aiter_module().apply_rope_pos_ids_cos_sin_cache_aiter(
+            query,
+            key,
+            query_out,
+            key_out,
+            cos_sin_cache,
+            positions,
+            head_size,
+            is_neox,
         )
 
 
@@ -1342,16 +1222,14 @@ def apply_rope_with_cos_sin_cache(
           we rotate the even dimensions ``([..., ::2])`` and odd dimensions ``([..., 1::2])``.
 
     backend : str
-        Kernel backend to use. ``"auto"`` (default) selects the best backend for
-        the call: on ROCm (gfx942/gfx950) it picks AITER for fp16 inputs with at
-        least ~2048 tokens (where the AITER kernel is measurably faster), and stays
-        on ``"native"`` otherwise — for bf16 (precision), small token counts
-        (launch overhead), and non-ROCm platforms.
+        Kernel backend to use. ``"auto"`` (default) routes to the C++ AITER kernel
+        on ROCm (gfx942/gfx950) and to the native FlashInfer JIT kernel everywhere
+        else; it also falls back to native for mixed query/key dtypes and when the
+        AITER package is unavailable, so it never raises.
         ``"native"`` uses the FlashInfer JIT kernel on all platforms.
-        ``"aiter"`` uses AMD AITER's rope_cached kernel — ROCm (gfx942/gfx950) only;
-        requires the ``aiter`` package. Precision is slightly lower than ``"native"``
-        for bfloat16 (max abs error ~5e-2 vs ~3e-2) because AITER consumes the cos/sin
-        tables in the query dtype rather than float32.
+        ``"aiter"`` uses AMD AITER's C++ ``rope_cached_positions_2c_fwd_impl``
+        kernel — ROCm (gfx942/gfx950) only; requires the ``aiter`` package and
+        query/key to share a dtype.
 
     Returns
     -------

--- a/flashinfer/rope.py
+++ b/flashinfer/rope.py
@@ -60,13 +60,9 @@ if IS_HIP:
         is_neox: bool,
     ) -> None:
         r"""Dispatch the cos/sin-cache rope to AITER's C++ rope_cached_positions_2c kernel."""
-        from .aiter_utils import is_aiter_supported
+        from .aiter_utils import require_aiter
 
-        if not is_aiter_supported(query.device):
-            raise ValueError(
-                "AITER rope backend requires an AMD gfx942/gfx950 device; "
-                "use backend='native' instead."
-            )
+        require_aiter(query.device, "rope")
         if key.dtype != query.dtype:
             raise ValueError(
                 "AITER rope backend requires query and key to share a dtype; "

--- a/tests/rocm_tests/test_activation_aiter_hip.py
+++ b/tests/rocm_tests/test_activation_aiter_hip.py
@@ -74,5 +74,5 @@ def test_silu_and_mul_aiter_backend_rejected_when_unsupported():
     """Explicit backend='aiter' raises (not silently falls back) on an unsupported device."""
     cpu_x = torch.randn(8, 256, dtype=torch.float16)
     if not is_aiter_supported(cpu_x.device):
-        with pytest.raises(ValueError, match="requires a ROCm"):
+        with pytest.raises(ValueError, match="gfx942/gfx950"):
             flashinfer.activation.silu_and_mul(cpu_x, backend="aiter")

--- a/tests/rocm_tests/test_activation_aiter_hip.py
+++ b/tests/rocm_tests/test_activation_aiter_hip.py
@@ -42,35 +42,12 @@ def test_silu_and_mul_aiter_vs_ref(dtype, d, num_tokens):
 
 @requires_aiter
 def test_silu_and_mul_auto_backend_selection():
-    """auto stays native for small/bf16 inputs and picks AITER for large fp16 2D inputs."""
-    from flashinfer.activation import (
-        _AITER_SILU_AND_MUL_MIN_ELEMS,
-        _auto_select_silu_and_mul_backend,
-    )
+    """auto routes to the C++ AITER kernel on supported gfx942/gfx950 devices."""
+    from flashinfer.activation import _auto_select_silu_and_mul_backend
 
     device = torch.device("cuda:0")
-
-    # Small inputs: native regardless of dtype.
-    for dtype in (torch.float16, torch.bfloat16):
-        small = torch.empty(8, 256, dtype=dtype, device=device)
-        assert _auto_select_silu_and_mul_backend(small) == "native"
-
-    # Large enough fp16 2D input (>= cutoff). cols is a multiple of 8 so the
-    # shape also clears silu_and_mul's 16-byte alignment guard, i.e. it is a
-    # shape that could actually flow through the public function to AITER.
-    rows = 8192
-    cols = -(-_AITER_SILU_AND_MUL_MIN_ELEMS // (rows * 8)) * 8  # ceil to mult of 8
-    large_fp16 = torch.empty(rows, cols, dtype=torch.float16, device=device)
-    assert large_fp16.numel() >= _AITER_SILU_AND_MUL_MIN_ELEMS
-    assert _auto_select_silu_and_mul_backend(large_fp16) == "aiter"
-
-    # Same large shape in bf16: native (precision guard).
-    large_bf16 = torch.empty(rows, cols, dtype=torch.bfloat16, device=device)
-    assert _auto_select_silu_and_mul_backend(large_bf16) == "native"
-
-    # Large fp16 but 3D: native (2D guard).
-    large_3d = torch.empty(2, rows, cols, dtype=torch.float16, device=device)
-    assert _auto_select_silu_and_mul_backend(large_3d) == "native"
+    x = torch.empty(8, 256, dtype=torch.float16, device=device)
+    assert _auto_select_silu_and_mul_backend(x) == "aiter"
 
 
 @requires_aiter

--- a/tests/rocm_tests/test_norm_hip.py
+++ b/tests/rocm_tests/test_norm_hip.py
@@ -150,25 +150,12 @@ def test_fused_add_rmsnorm_aiter(batch_size, hidden_size, dtype):
 
 
 @requires_aiter
-@pytest.mark.parametrize(
-    "batch_size,hidden_size,expected",
-    [
-        (1, 4096, "native"),  # small
-        (128, 4096, "native"),  # medium, below cutoff
-        (989, 4096, "native"),  # ~4.05M elems, just below 4M cutoff -> native
-        (512, 8192, "aiter"),  # exactly 4M elems (cutoff) -> aiter
-        (2048, 8192, "aiter"),  # >= 4M elems -> aiter
-        (4096, 8192, "aiter"),  # large -> aiter
-    ],
-)
-def test_fused_add_rmsnorm_auto_selection(batch_size, hidden_size, expected):
+def test_fused_add_rmsnorm_auto_selection():
+    """auto routes fused_add_rmsnorm to the C++ AITER kernel on supported devices."""
     from flashinfer.norm import _auto_select_fused_add_rmsnorm_backend
 
-    x = torch.empty(batch_size, hidden_size, dtype=torch.float16, device="cuda")
-    assert _auto_select_fused_add_rmsnorm_backend(x) == expected
-    # 3D always routes to native regardless of size.
-    x3d = torch.empty(batch_size, 4, hidden_size, dtype=torch.float16, device="cuda")
-    assert _auto_select_fused_add_rmsnorm_backend(x3d) == "native"
+    x = torch.empty(512, 8192, dtype=torch.float16, device="cuda")
+    assert _auto_select_fused_add_rmsnorm_backend(x) == "aiter"
 
 
 @pytest.mark.parametrize("backend", ["auto", "native", "aiter"])

--- a/tests/rocm_tests/test_rmsnorm_aiter_hip.py
+++ b/tests/rocm_tests/test_rmsnorm_aiter_hip.py
@@ -47,10 +47,7 @@ def test_rmsnorm_auto_backend_stays_native():
     from flashinfer.norm import _auto_select_norm_backend
 
     device = torch.device("cuda:0")
-    assert _auto_select_norm_backend(device, torch.float16) == "native"
-    assert _auto_select_norm_backend(device, torch.bfloat16) == "native"
-    # fp32 also native (no AITER path for fp32)
-    assert _auto_select_norm_backend(device, torch.float32) == "native"
+    assert _auto_select_norm_backend(device) == "native"
 
 
 @requires_aiter

--- a/tests/rocm_tests/test_rope_aiter_hip.py
+++ b/tests/rocm_tests/test_rope_aiter_hip.py
@@ -123,34 +123,18 @@ def test_rope_cos_sin_cache_aiter_inplace(is_neox_style, dtype):
 
 
 def test_rope_auto_backend_selection():
-    """auto picks AITER for fp16 + large-nnz (both inplace and out-of-place, since
-    the _impl path needs no Q/K copy), where it is both faster (~1.3-2.8x) and
-    precise enough (fp16 err ~7e-3); bf16 and small nnz stay native."""
-    from flashinfer.rope import _AITER_ROPE_MIN_TOKENS, _auto_select_rope_backend
+    """auto routes to AITER on supported devices, but never raises: it falls back
+    to native for mixed query/key dtypes."""
+    from flashinfer.rope import _auto_select_rope_backend
 
     device = torch.device("cuda:0")
-    big = _AITER_ROPE_MIN_TOKENS
-    small = _AITER_ROPE_MIN_TOKENS - 1
+    q = torch.randn(2048, 128, dtype=torch.float16, device=device)
+    k = torch.randn(2048, 128, dtype=torch.float16, device=device)
+    assert _auto_select_rope_backend(q, k) == "aiter"
 
-    # fp16 + nnz >= threshold routes to AITER (selection is shape/dtype-based and
-    # backend dispatch is shared by both the inplace and out-of-place wrappers).
-    q_fp16_big = torch.randn(big, 128, dtype=torch.float16, device=device)
-    k_fp16_big = torch.randn(big, 128, dtype=torch.float16, device=device)
-    assert _auto_select_rope_backend(q_fp16_big, k_fp16_big) == "aiter"
-
-    # bf16 always native (precision: ~5e-2 vs native ~3e-2).
-    q_bf16_big = torch.randn(big, 128, dtype=torch.bfloat16, device=device)
-    k_bf16_big = torch.randn(big, 128, dtype=torch.bfloat16, device=device)
-    assert _auto_select_rope_backend(q_bf16_big, k_bf16_big) == "native"
-
-    # Below the token threshold, native's lower launch overhead wins.
-    q_fp16_small = torch.randn(small, 128, dtype=torch.float16, device=device)
-    k_fp16_small = torch.randn(small, 128, dtype=torch.float16, device=device)
-    assert _auto_select_rope_backend(q_fp16_small, k_fp16_small) == "native"
-
-    # Mixed q/k dtype falls back to native rather than raising: AITER can't rotate
-    # both with one cos/sin table, but auto must never raise.
-    assert _auto_select_rope_backend(q_fp16_big, k_bf16_big) == "native"
+    # Mixed q/k dtype must fall back to native, not route into AITER and raise.
+    k_bf16 = torch.randn(2048, 128, dtype=torch.bfloat16, device=device)
+    assert _auto_select_rope_backend(q, k_bf16) == "native"
 
 
 def test_rope_unknown_backend_raises():
@@ -186,7 +170,7 @@ def test_rope_aiter_odd_rotary_dim_raises():
     pos_ids = torch.arange(8, device=device)
     query = torch.randn(8, 8 * 128, dtype=torch.float16, device=device)
     key = torch.randn(8, 8 * 128, dtype=torch.float16, device=device)
-    with pytest.raises(ValueError, match="even"):
+    with pytest.raises((ValueError, RuntimeError), match="even"):
         flashinfer.apply_rope_with_cos_sin_cache(
             pos_ids, query, key, 128, cos_sin_cache, backend="aiter"
         )
@@ -200,7 +184,7 @@ def test_rope_aiter_rotary_dim_exceeds_head_size_raises():
     pos_ids = torch.arange(8, device=device)
     query = torch.randn(8, 8 * head_size, dtype=torch.float16, device=device)
     key = torch.randn(8, 8 * head_size, dtype=torch.float16, device=device)
-    with pytest.raises(ValueError, match="exceeds head_size"):
+    with pytest.raises((ValueError, RuntimeError), match="exceeds head_size"):
         flashinfer.apply_rope_with_cos_sin_cache(
             pos_ids, query, key, head_size, cos_sin_cache, backend="aiter"
         )
@@ -246,25 +230,3 @@ def test_rope_aiter_noncontiguous_positions(dtype):
     )
     torch.testing.assert_close(q_strided, q_contig, rtol=0, atol=0)
     torch.testing.assert_close(k_strided, k_contig, rtol=0, atol=0)
-
-
-def test_rope_auto_falls_back_when_aiter_unimportable(monkeypatch):
-    """On a supported arch with a missing/broken aiter install, auto must fall
-    back to native rather than raise — _auto_select_rope_backend probes the
-    import and returns 'native' on failure."""
-    from flashinfer import rope
-    from flashinfer.rope import _AITER_ROPE_MIN_TOKENS, _auto_select_rope_backend
-
-    device = torch.device("cuda:0")
-    n = _AITER_ROPE_MIN_TOKENS
-    q = torch.randn(n, 128, dtype=torch.float16, device=device)
-    k = torch.randn(n, 128, dtype=torch.float16, device=device)
-
-    # Sanity: with aiter importable this shape selects aiter.
-    assert _auto_select_rope_backend(q, k) == "aiter"
-
-    def _boom():
-        raise ImportError("simulated missing aiter")
-
-    monkeypatch.setattr(rope, "_aiter_rope_ops", _boom)
-    assert _auto_select_rope_backend(q, k) == "native"


### PR DESCRIPTION
## Summary

Replace the Python-level AITER integration (runtime `import aiter` calling AITER's prebuilt pybind functions) with a **C++-level** integration for three ROCm ops — `fused_add_rmsnorm`, `silu_and_mul`, and `rope` (cos/sin-cache) — matching the pattern already used for prefill/decode/MLA. FlashInfer's JIT now compiles a thin HIP shim that calls AITER's C++ kernels directly and links a symbol-visible AITER `.so`; there is no runtime `import aiter` on these paths.

### What changed

#### Shared plumbing
- **`flashinfer/jit/aiter_source.py`** (new) — builds the needed AITER module once with `AITER_SYMBOL_VISIBLE=1`, locates the produced `.so` robustly, and caches it under `~/.cache/flashinfer/aiter_libs/<arch>__aiter-<version>/` keyed by arch + AITER version. Returns the include/link flags for `gen_jit_spec`.
- **`flashinfer/aiter_utils.py`** — add `is_aiter_available()` (arch check + import probe) so `backend="auto"` falls back to native instead of raising when AITER is unavailable.

#### C++ shims (one wrapper + one binding per op, in `flashinfer/csrc_rocm/`)
- **`rope_aiter.cu`** — calls AITER's `rope_cached_positions_2c_fwd_impl`; adapts FlashInfer's `(max_seq_len, rotary_dim)` float32 cos/sin cache to AITER's split SBHD layout; handles partial rotary + in-place aliasing. cos/sin passed as float32 (AITER ships fp32-cos/sin instances), improving bf16 precision over the old query-dtype downcast.
- **`activation_aiter.cu`** — calls `aiter::silu_and_mul`.
- **`norm_aiter.cu`** — calls AITER's CK `rmsnorm2d_with_add` (fused-add) and `rms_norm` (plain).
- Each shim **forward-declares** the AITER entry point rather than including AITER's header, which pulls in pybind11 and clashes with FlashInfer's `-DPy_LIMITED_API`. `torch::Tensor` is `at::Tensor`, so the linker resolves the symbol from the symbol-visible AITER `.so`.

#### Python dispatch (`flashinfer/{norm,activation,rope}.py`)
- Removed all runtime `import aiter` scaffolding (`_aiter_*_ops`, the rope weakref cos/sin memo, the shape-threshold selectors and their constants).
- Added `@functools.cache get_*_aiter_module()` loaders and rewrote dispatch to call the C++ binding.

### Architecture / design notes

**Why C++ link, not dlopen.** The existing `aiter_loader.cc` (used for attention) dlopen/dlsym pattern works because AITER exports a stable `aiter::mha_fwd` symbol. The norm/silu/rope kernels are `torch::Tensor&` C++ functions that AITER's wheel hides with `-fvisibility=hidden`, so they are neither dlsym-able nor linkable as shipped. The fix is to rebuild the AITER module symbol-visible and link it — delegating the heavy CK blob codegen to AITER's own `build_module` rather than re-implementing it.

**`backend="auto"` policy** (per-op, with `auto` never raising):

| op | `auto` resolves to |
| --- | --- |
| `fused_add_rmsnorm` | AITER on gfx942/gfx950 (else native); native if AITER unavailable |
| `silu_and_mul` | AITER on gfx942/gfx950 (else native); native if AITER unavailable |
| `rope` cos/sin-cache | AITER on gfx942/gfx950; native for mixed q/k dtype or if AITER unavailable |
| `rmsnorm` (plain) | native (AITER opt-in via `backend="aiter"`; precision) |

Shape/precision-based gating from the old Python path was intentionally dropped; a performance pass will revisit it.

## Test plan

- [x] `pytest -n auto --reruns 2 -m "not slow"` on `test_rope_aiter_hip.py`, `test_activation_aiter_hip.py`, `test_rmsnorm_aiter_hip.py`, `test_norm_hip.py` — 827 passed
- [x] Verified no runtime `import aiter` remains in `norm.py` / `activation.py` / `rope.py`
- [x] Verified the symbol-visible AITER lib builds and links (rpath via `ldd`) even when `aiter` was imported before the first FlashInfer aiter call
- [x] `pre-commit run -a` (clang-format / mypy / ruff) on all changed files

> Note: the first `fused_add_rmsnorm` build triggers AITER's CK blob codegen (large; several minutes), then cached.