### PR TITLE
docs: add fail-closed PR target safeguard

### DIFF
--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -8,6 +8,46 @@ description: How to create and edit PRs on the ROCm/flashinfer GitHub repo (whic
 > The GitHub repo is `ROCm/flashinfer`; the Python package it publishes is
 > `amd-flashinfer`. All `gh` commands below target the GitHub repo.
 
+## CRITICAL: PR target safeguard (fail-closed)
+
+`ROCm/flashinfer` is a **GitHub fork** of `flashinfer-ai/flashinfer` (the true
+upstream). Because of this, `gh pr create` defaults the PR base to the
+fork-parent `flashinfer-ai/flashinfer` unless explicitly overridden. **A PR must
+NEVER be opened against `flashinfer-ai/flashinfer`.**
+
+All PRs go to **`ROCm/flashinfer`**, base branch **`amd-integration`**.
+
+**Before ANY `gh pr create`, run this pre-flight check and ABORT if it fails:**
+
+```bash
+gh repo set-default --view   # MUST print exactly: ROCm/flashinfer
+```
+
+If it prints anything else (or errors), STOP — do not create the PR. Report the
+mismatch to the user instead. Never guess the target.
+
+**Always pass the target and base explicitly** — never rely on gh defaults:
+
+```bash
+gh pr create --repo ROCm/flashinfer --base amd-integration \
+  --title "<title>" --body "$(cat /tmp/pr_body.md)"
+```
+
+If the resolved owner of `--repo` is ever `flashinfer-ai`, abort. It is always
+better to fail to raise a PR and explain why than to raise one against upstream.
+
+### One-time setup after a fresh clone
+
+These are local config (not checked in) and must be redone per clone:
+
+```bash
+git remote -v                        # origin should be ROCm/flashinfer; there must be NO flashinfer-ai remote
+gh repo set-default ROCm/flashinfer  # pin gh base repo so it does not fall back to the fork parent
+```
+
+If a remote pointing at `flashinfer-ai/flashinfer` exists, remove it:
+`git remote remove <name>`.
+
 ## GitHub CLI
 
 `gh pr edit` fails with a "Projects (classic) is being deprecated" GraphQL error on this repo. Use the REST API instead:
@@ -22,6 +62,8 @@ gh api repos/ROCm/flashinfer/pulls/<number> --method PATCH --field body="$(cat /
 
 Ask the user to confirm before running `git push` or `gh pr create` — these
 publish to a shared repo and shouldn't be triggered without explicit consent.
+Before any `gh pr create`, also complete the fail-closed PR target safeguard
+above.
 
 ## PR Description
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@
 
 All PRs go to **`ROCm/flashinfer`**, base branch **`amd-integration`** — NEVER
 to `flashinfer-ai/flashinfer` (the fork parent / true upstream). `gh pr create`
-defaults the base to the fork parent, so always pass `--repo ROCm/flashinfer
---base amd-integration` explicitly, and run `gh repo set-default --view` first —
+defaults the base to the fork parent, so always pass
+`--repo ROCm/flashinfer --base amd-integration` explicitly, and run `gh repo set-default --view` first —
 it MUST print `ROCm/flashinfer` or you abort. If the target owner cannot be
 positively confirmed as `ROCm`, do not create the PR; stop and report why.
 Failing to raise a PR is always preferable to raising one against upstream. Full

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,17 @@
 > The upstream CUDA repo at <https://github.com/flashinfer-ai/flashinfer> uses
 > different env vars, paths, and toolchains — its patterns don't apply here.
 
+## CRITICAL: PR target
+
+All PRs go to **`ROCm/flashinfer`**, base branch **`amd-integration`** — NEVER
+to `flashinfer-ai/flashinfer` (the fork parent / true upstream). `gh pr create`
+defaults the base to the fork parent, so always pass `--repo ROCm/flashinfer
+--base amd-integration` explicitly, and run `gh repo set-default --view` first —
+it MUST print `ROCm/flashinfer` or you abort. If the target owner cannot be
+positively confirmed as `ROCm`, do not create the PR; stop and report why.
+Failing to raise a PR is always preferable to raising one against upstream. Full
+procedure: `pr-workflow` skill.
+
 ## Essential Commands
 
 | Task | Command |


### PR DESCRIPTION
## Summary

Adds a fail-closed safeguard so PRs are never accidentally opened against the fork parent `flashinfer-ai/flashinfer`. Because `ROCm/flashinfer` is a GitHub fork, `gh pr create` defaults the base to the parent repo unless overridden — this codifies an explicit, abort-on-mismatch workflow.

### What changed

- **`.claude/skills/pr-workflow/SKILL.md`** — adds a CRITICAL fail-closed section: mandatory `gh repo set-default --view` pre-flight (must print `ROCm/flashinfer` or abort), explicit `--repo ROCm/flashinfer --base amd-integration` on every `gh pr create`, abort if the resolved owner is `flashinfer-ai`, and a one-time fresh-clone setup checklist.
- **`CLAUDE.md`** — adds an always-on backstop with the same rule, in case the skill does not load.

## Test plan

- [x] `pre-commit run -a` (ran via commit hooks; markdownlint and file checks passed)