### PR TITLE
docs: add fail-closed safeguard against PRs from amd-integration

### DIFF
--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -55,7 +55,7 @@ PR, and must never be pushed to directly via a PR flow. Before pushing a branch
 for a PR or running `gh pr create`, check the current branch:
 
 ```bash
-git branch --show-current   # if this is "amd-integration", do NOT push/PR from it
+git branch --show-current   # if this is "amd-integration" (or empty/detached), do NOT push/PR from it
 ```
 
 If you are on `amd-integration` and have commits to ship, do NOT raise the PR

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -48,6 +48,41 @@ gh repo set-default ROCm/flashinfer  # pin gh base repo so it does not fall back
 If a remote pointing at `flashinfer-ai/flashinfer` exists, remove it:
 `git remote remove <name>`.
 
+## CRITICAL: never PR from `amd-integration` (fail-closed)
+
+`amd-integration` is the **base** branch — it must never be the **head** of a
+PR, and must never be pushed to directly via a PR flow. Before pushing a branch
+for a PR or running `gh pr create`, check the current branch:
+
+```bash
+git branch --show-current   # if this is "amd-integration", do NOT push/PR from it
+```
+
+If you are on `amd-integration` and have commits to ship, do NOT raise the PR
+from it. Instead, relocate the commits to a fresh topic branch, restore
+`amd-integration` to match the remote, then PR from the topic branch:
+
+```bash
+# 1. Capture the local-only commits onto a new branch at current HEAD
+git branch <topic-branch>
+
+# 2. Move amd-integration back to the pristine remote state (no commits lost —
+#    they are preserved on <topic-branch>). Verify origin/amd-integration is
+#    fetched and up to date first.
+git fetch origin amd-integration
+git reset --hard origin/amd-integration
+
+# 3. Switch to the topic branch and proceed with the normal PR flow
+git checkout <topic-branch>
+```
+
+Only `git reset --hard` here because the commits are already safe on
+`<topic-branch>` (confirm with `git log <topic-branch>` before resetting). If
+anything is ambiguous — uncommitted changes, unclear which commits are
+local-only, the topic branch already exists — STOP and report rather than
+reset. It is always better to fail to raise a PR than to push to or PR from
+`amd-integration`.
+
 ## GitHub CLI
 
 `gh pr edit` fails with a "Projects (classic) is being deprecated" GraphQL error on this repo. Use the REST API instead:

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -58,6 +58,10 @@ for a PR or running `gh pr create`, check the current branch:
 git branch --show-current   # if this is "amd-integration" (or empty/detached), do NOT push/PR from it
 ```
 
+This command prints an **empty string** in a detached-HEAD state. Treat empty
+output as an abort condition too — do NOT push/PR from a detached HEAD; STOP and
+report so the user can check out a proper topic branch first.
+
 If you are on `amd-integration` and have commits to ship, do NOT raise the PR
 from it. Instead, relocate the commits to a fresh topic branch, restore
 `amd-integration` to match the remote, then PR from the topic branch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,8 @@ Failing to raise a PR is always preferable to raising one against upstream.
 
 Also NEVER push to or raise a PR from the `amd-integration` branch itself — it
 is the base, never the head. If you are on `amd-integration` with commits to
-ship, move them to a fresh topic branch (`git branch <topic>`), reset
-`amd-integration` to `origin/amd-integration`, then PR from the topic branch.
+ship, preserve them on a fresh topic branch at the current HEAD (`git branch <topic-branch>`),
+reset `amd-integration` to `origin/amd-integration`, then PR from the topic branch.
 Full procedure: `pr-workflow` skill.
 
 ## Essential Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,11 @@ Failing to raise a PR is always preferable to raising one against upstream.
 
 Also NEVER push to or raise a PR from the `amd-integration` branch itself — it
 is the base, never the head. If you are on `amd-integration` with commits to
-ship, preserve them on a fresh topic branch at the current HEAD (`git branch <topic-branch>`),
-reset `amd-integration` to `origin/amd-integration`, then PR from the topic branch.
+ship, create a fresh topic branch at the current HEAD
+(`git branch <topic-branch>`), then `git fetch origin amd-integration &&
+git reset --hard origin/amd-integration` to restore `amd-integration` (the
+commits stay safe on `<topic-branch>`), and PR from `<topic-branch>`. Treat a
+detached HEAD (empty `git branch --show-current`) as an abort condition too.
 Full procedure: `pr-workflow` skill.
 
 ## Essential Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,13 @@ defaults the base to the fork parent, so always pass
 `--repo ROCm/flashinfer --base amd-integration` explicitly, and run `gh repo set-default --view` first —
 it MUST print `ROCm/flashinfer` or you abort. If the target owner cannot be
 positively confirmed as `ROCm`, do not create the PR; stop and report why.
-Failing to raise a PR is always preferable to raising one against upstream. Full
-procedure: `pr-workflow` skill.
+Failing to raise a PR is always preferable to raising one against upstream.
+
+Also NEVER push to or raise a PR from the `amd-integration` branch itself — it
+is the base, never the head. If you are on `amd-integration` with commits to
+ship, move them to a fresh topic branch (`git branch <topic>`), reset
+`amd-integration` to `origin/amd-integration`, then PR from the topic branch.
+Full procedure: `pr-workflow` skill.
 
 ## Essential Commands
 


### PR DESCRIPTION
## Summary

Adds a fail-closed safeguard so a PR is never accidentally raised from the `amd-integration` branch itself. `amd-integration` is the PR base; it must never be the head. If commits land on it locally, they are relocated to a fresh topic branch before the PR is raised.

### What changed

- **`.claude/skills/pr-workflow/SKILL.md`** — adds a CRITICAL section: check `git branch --show-current` before pushing/PR'ing; if on `amd-integration`, move commits to a new topic branch (`git branch <topic>`), reset `amd-integration` to `origin/amd-integration`, then PR from the topic branch. Resets only because commits are already preserved on the topic branch; abort on any ambiguity.
- **`CLAUDE.md`** — adds an always-on backstop with the same rule.

## Test plan

- [x] `pre-commit run -a` (ran via commit hooks; markdownlint and file checks passed)