### PR TITLE
fix(pre-commit): restore aot_config.py clang-format exclusion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,8 +40,7 @@ repos:
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]
-        exclude: |
-          (?x)^(3rdparty/.* flashinfer/jit/aot_config.py)$
+        exclude: ^3rdparty/.*
 
   -   repo: https://github.com/pre-commit/mirrors-mypy
       rev: 'v1.17.1'  # Use the sha / tag you want to point at


### PR DESCRIPTION
## Summary

Fixes the clang-format `exclude` regex, which was a silent no-op. The two patterns were separated by a space instead of `|`, and under the `(?x)` verbose flag whitespace is stripped — so the regex collapsed to `3rdparty/.*flashinfer/jit/aot_config.py`, which matched nothing. As a result neither `3rdparty/` nor `aot_config.py` was actually excluded.

Rather than just restore the alternation, this drops the `flashinfer/jit/aot_config.py` clause entirely and keeps a plain `3rdparty/` exclusion. The `aot_config.py` clause was dead weight: it is a gitignored, generated `.py` file, and this hook only runs on `types_or: [c++, c, cuda]`, so clang-format could never process it regardless.

### What changed

- **`.pre-commit-config.yaml`** — replace the broken verbose-mode regex with `exclude: ^3rdparty/.*`; drop the unreachable `aot_config.py` clause.

## Test plan

- [x] `pre-commit run -a`