### PR TITLE
fix(devcontainer): align AITER ROCm index with PyTorch ROCm version

### DIFF
--- a/.devcontainer/rocm/Dockerfile
+++ b/.devcontainer/rocm/Dockerfile
@@ -8,7 +8,7 @@ ARG ROCM_VERSION
 ARG PY_VERSION=3.12
 ARG TORCH_VERSION=2.9.1
 ARG AITER_VERSION=0.1.10
-ARG AITER_ROCM_VERSION=7.1.1
+ARG AITER_ROCM_VERSION=${ROCM_VERSION}
 
 # Update package lists and install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

The devcontainer Dockerfile installed PyTorch from `rocm-rel-7.2` but AITER from the `rocm-7.1.1` PyPI index. That mismatch can cause binary incompatibilities between the two packages at runtime.

## What changed

- **`.devcontainer/rocm/Dockerfile`** — default `AITER_ROCM_VERSION` to `${ROCM_VERSION}` so both packages are pulled from the same ROCm release. The arg can still be overridden at build time if needed.

## Test plan

- [x] Dockerfile-only change; no Python tests applicable
- [x] `pre-commit run -a` (via commit hook on staged file)


Made with [Cursor](https://cursor.com)