### PR TITLE
Fix ROCm torch install: use find-links, not --index-url (devcontainer, README, hip_utils)

### DIFF
--- a/.devcontainer/rocm/Dockerfile
+++ b/.devcontainer/rocm/Dockerfile
@@ -84,6 +84,9 @@ RUN \
 RUN /bin/micromamba create -n ${MAMBA_ENV_NAME} python=${PY_VERSION} gtest gmock bash-completion -c conda-forge && \
     /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install --no-cache-dir cmake ninja "scikit-build-core>=0.4.3" "setuptools-scm>=9.2" pre-commit numpy pytest pytest-cov pytest-xdist pytest-rerunfailures pybind11 ruff && \
     /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install --no-cache-dir torch==${TORCH_VERSION} -f https://repo.radeon.com/rocm/manylinux/rocm-rel-${ROCM_VERSION}/ && \
+    # Fail fast if a non-ROCm torch slipped in (e.g. a PyPI CPU/CUDA wheel if the
+    # ROCm wheel were ever missing for this Python/platform under -f/--find-links).
+    /bin/micromamba run -n ${MAMBA_ENV_NAME} python -c "import torch, sys; hip = torch.version.hip; print(f'torch {torch.__version__} (hip={hip})'); sys.exit('ERROR: installed torch has no ROCm/HIP build (hip is None)' if hip is None else 0)" && \
     /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install amd_aiter==${AITER_VERSION} --extra-index-url https://pypi.amd.com/rocm-${AITER_ROCM_VERSION}/simple
 SHELL ["/usr/local/bin/_dockerfile_shell.sh"]
 

--- a/.devcontainer/rocm/Dockerfile
+++ b/.devcontainer/rocm/Dockerfile
@@ -80,12 +80,13 @@ RUN \
     echo 'eval "$(micromamba shell hook --shell bash)"' >> /home/$USERNAME/.bashrc && \
     echo "micromamba activate ${MAMBA_ENV_NAME}" >> /home/$USERNAME/.bashrc
 
-# Create a new micromamba env and install needed packages for flashinfer development
+# Create a new micromamba env and install needed packages for flashinfer development.
+# After installing torch, assert it is a ROCm/HIP build (torch.version.hip is not
+# None) so the build fails fast if -f/--find-links ever resolves a PyPI CPU/CUDA
+# wheel instead of the radeon ROCm wheel.
 RUN /bin/micromamba create -n ${MAMBA_ENV_NAME} python=${PY_VERSION} gtest gmock bash-completion -c conda-forge && \
     /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install --no-cache-dir cmake ninja "scikit-build-core>=0.4.3" "setuptools-scm>=9.2" pre-commit numpy pytest pytest-cov pytest-xdist pytest-rerunfailures pybind11 ruff && \
     /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install --no-cache-dir torch==${TORCH_VERSION} -f https://repo.radeon.com/rocm/manylinux/rocm-rel-${ROCM_VERSION}/ && \
-    # Fail fast if a non-ROCm torch slipped in (e.g. a PyPI CPU/CUDA wheel if the
-    # ROCm wheel were ever missing for this Python/platform under -f/--find-links).
     /bin/micromamba run -n ${MAMBA_ENV_NAME} python -c "import torch, sys; hip = torch.version.hip; print(f'torch {torch.__version__} (hip={hip})'); sys.exit('ERROR: installed torch has no ROCm/HIP build (hip is None)' if hip is None else 0)" && \
     /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install amd_aiter==${AITER_VERSION} --extra-index-url https://pypi.amd.com/rocm-${AITER_ROCM_VERSION}/simple
 SHELL ["/usr/local/bin/_dockerfile_shell.sh"]

--- a/.devcontainer/rocm/Dockerfile
+++ b/.devcontainer/rocm/Dockerfile
@@ -81,9 +81,12 @@ RUN \
     echo "micromamba activate ${MAMBA_ENV_NAME}" >> /home/$USERNAME/.bashrc
 
 # Create a new micromamba env and install needed packages for flashinfer development.
-# After installing torch, assert it is a ROCm/HIP build (torch.version.hip is not
-# None) so the build fails fast if -f/--find-links ever resolves a PyPI CPU/CUDA
-# wheel instead of the radeon ROCm wheel.
+# torch uses -f/--find-links (not --index-url) because the radeon repo is a flat
+# wheel listing, not a PEP 503 simple index — with --index-url pip requests the
+# per-package path (.../torch/), which 404s, and the install fails with "No
+# matching distribution found". After installing, assert torch is a ROCm/HIP build
+# (torch.version.hip is not None) so the build fails fast if -f ever resolves a
+# PyPI CPU/CUDA wheel instead of the radeon ROCm wheel.
 RUN /bin/micromamba create -n ${MAMBA_ENV_NAME} python=${PY_VERSION} gtest gmock bash-completion -c conda-forge && \
     /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install --no-cache-dir cmake ninja "scikit-build-core>=0.4.3" "setuptools-scm>=9.2" pre-commit numpy pytest pytest-cov pytest-xdist pytest-rerunfailures pybind11 ruff && \
     /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install --no-cache-dir torch==${TORCH_VERSION} -f https://repo.radeon.com/rocm/manylinux/rocm-rel-${ROCM_VERSION}/ && \

--- a/.devcontainer/rocm/Dockerfile
+++ b/.devcontainer/rocm/Dockerfile
@@ -83,7 +83,7 @@ RUN \
 # Create a new micromamba env and install needed packages for flashinfer development
 RUN /bin/micromamba create -n ${MAMBA_ENV_NAME} python=${PY_VERSION} gtest gmock bash-completion -c conda-forge && \
     /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install --no-cache-dir cmake ninja "scikit-build-core>=0.4.3" "setuptools-scm>=9.2" pre-commit numpy pytest pytest-cov pytest-xdist pytest-rerunfailures pybind11 ruff && \
-    /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install --no-cache-dir torch==${TORCH_VERSION} --index-url https://repo.radeon.com/rocm/manylinux/rocm-rel-${ROCM_VERSION}/ && \
+    /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install --no-cache-dir torch==${TORCH_VERSION} -f https://repo.radeon.com/rocm/manylinux/rocm-rel-${ROCM_VERSION}/ && \
     /bin/micromamba run -n ${MAMBA_ENV_NAME} pip install amd_aiter==${AITER_VERSION} --extra-index-url https://pypi.amd.com/rocm-${AITER_ROCM_VERSION}/simple
 SHELL ["/usr/local/bin/_dockerfile_shell.sh"]
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Install the matching ROCm-enabled PyTorch wheel from
 <https://repo.radeon.com>:
 
 ```bash
-pip install torch==2.9.1 --index-url https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/
+pip install torch==2.9.1 -f https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/
 ```
 
 Other versions may work but have not been tested. Replace `7.2` with the
@@ -141,11 +141,14 @@ pip install amd-flashinfer --index-url https://pypi.amd.com/simple/
 Install the matching ROCm-enabled torch package from <https://repo.radeon.com>:
 
 ```bash
-pip install torch==2.9.1 --index-url https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/
+pip install torch==2.9.1 -f https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/
 ```
 
-**NOTE:** Use `--index-url` (not `-f`) so pip cannot silently fall back
-to a CPU-only PyPI wheel.
+**NOTE:** The radeon repo is a flat wheel listing, not a PEP 503 index, so
+`--index-url` fails with "No matching distribution found" — use `-f`
+(`--find-links`). pip still prefers the ROCm wheel over a same-version PyPI
+wheel because its `+rocm<X.Y>` local version ranks higher. Confirm the result
+with `python -c "import torch; assert torch.version.hip, 'not a ROCm build'"`.
 
 ### Trying the Examples
 

--- a/flashinfer/hip_utils.py
+++ b/flashinfer/hip_utils.py
@@ -536,7 +536,7 @@ def check_torch_rocm_compatibility() -> None:
             "  1. Uninstall current PyTorch:\n"
             "     pip uninstall torch\n\n"
             "  2. Install PyTorch for ROCm:\n"
-            "     pip install torch==2.7.1 --index-url https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4/\n\n"
+            "     pip install torch==2.7.1 -f https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4/\n\n"
             "See https://github.com/rocm/flashinfer for detailed installation instructions.\n"
             + "="
             * 70
@@ -559,11 +559,11 @@ def check_torch_rocm_compatibility() -> None:
                 f"  PyTorch ROCm version: {torch_rocm_major_minor}\n\n"
                 f"This may cause runtime errors or crashes.\n\n"
                 f"To fix, reinstall PyTorch for your ROCm version:\n"
-                f"  pip install torch==2.7.1 --index-url "
+                f"  pip install torch==2.7.1 -f "
                 f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{system_rocm}/\n\n"
                 f"Or if using uv:\n"
                 f"  export FLASHINFER_ROCM_VERSION={system_rocm}\n"
-                f"  uv pip install torch==2.7.1 --index-url "
+                f"  uv pip install torch==2.7.1 -f "
                 f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{system_rocm}/\n"
                 f"{'=' * 70}",
                 RuntimeWarning,


### PR DESCRIPTION
## Summary

Fix ROCm torch installation across the repo: point pip at the radeon wheel mirror with `-f`/`--find-links` instead of `--index-url`, which fails with `No matching distribution found for torch==... (from versions: none)`. Started as a devcontainer build fix and extended to the user-facing install docs and error messages that carried the same broken command.

### What changed

- **`.devcontainer/rocm/Dockerfile`** — install torch with `-f https://repo.radeon.com/rocm/manylinux/rocm-rel-${ROCM_VERSION}/` instead of `--index-url`; add a post-install assertion that fails the build if the installed torch is not a ROCm/HIP build (`torch.version.hip is None`); document the rationale in column-1 comments above the `RUN`.
- **`README.md`** — switch the two radeon torch install commands to `-f`, and rewrite the NOTE that previously recommended `--index-url` so it reflects reality (why `--index-url` fails, why `-f` still selects the ROCm wheel, and how to verify).
- **`flashinfer/hip_utils.py`** — switch the radeon torch commands in the "PyTorch has no ROCm support" error and the ROCm-version-mismatch warning (pip and uv variants) to `-f`.

Unrelated `--index-url https://pypi.amd.com/simple/` lines (a real PEP 503 index) are intentionally left unchanged.

### Why

`repo.radeon.com/rocm/manylinux/rocm-rel-X.Y/` is a flat directory listing of wheels, not a PEP 503 simple index — its per-package path (`.../torch/`) returns 404. `--index-url` makes pip request that path, so it finds zero candidates and fails. `-f`/`--find-links` reads the flat listing directly, matching what `docker/Dockerfile.rocm_ci` already does.

Switching to `-f` still resolves to AMD's internal ROCm build rather than PyPI's CUDA wheel. The radeon wheel carries a local version (`torch-2.9.1+rocm7.2.0.lw.git7e1940d4-cp312-cp312-linux_x86_64.whl`), and PEP 440 ranks `2.9.1+rocm...` strictly above PyPI's plain `2.9.1`, so pip selects it even though both satisfy `==2.9.1`. Confirmed with `pip install --dry-run` (resolved to the `+rocm7.2.0` wheel). The devcontainer additionally guards this at build time with the HIP assertion, and the README documents a one-line check for manual installs.

## Test plan

- Built the image end to end: `docker build --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) --build-arg USERNAME=demandal -t dm-fi-rocm72-torch291-py312 -f .devcontainer/rocm/Dockerfile .` — succeeds, and the HIP assertion printed `torch 2.9.1+rocm7.2.0.git7e1940d4 (hip=7.2.26015-fc0010cf6a)` before the build continued (proving the `&&` chain and the check both run).
- Verified torch inside the image is the ROCm build (`torch.version.hip` set, `torch.version.cuda` None), not a PyPI CUDA wheel.
- README and `hip_utils.py` changes are text/guidance only; the repo's required `pre-commit` check runs on this PR in CI.