### PR TITLE
docs: add branch-naming / push-safety / body-formatting rules

### DIFF
--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -1,26 +1,26 @@
 ---
 name: pr-workflow
-description: How to create and edit PRs on the ROCm/flashinfer GitHub repo (which publishes the amd-flashinfer package) — gh CLI quirks and the project's PR-description conventions.
+description: How to create and edit PRs on the AMD-Ecosystem/flashinfer GitHub repo (which publishes the amd-flashinfer package) — gh CLI quirks and the project's PR-description conventions.
 ---
 
-# PR Workflow (ROCm/flashinfer)
+# PR Workflow (AMD-Ecosystem/flashinfer)
 
-> The GitHub repo is `ROCm/flashinfer`; the Python package it publishes is
+> The GitHub repo is `AMD-Ecosystem/flashinfer`; the Python package it publishes is
 > `amd-flashinfer`. All `gh` commands below target the GitHub repo.
 
 ## CRITICAL: PR target safeguard (fail-closed)
 
-`ROCm/flashinfer` is a **GitHub fork** of `flashinfer-ai/flashinfer` (the true
+`AMD-Ecosystem/flashinfer` is a **GitHub fork** of `flashinfer-ai/flashinfer` (the true
 upstream). Because of this, `gh pr create` defaults the PR base to the
 fork-parent `flashinfer-ai/flashinfer` unless explicitly overridden. **A PR must
 NEVER be opened against `flashinfer-ai/flashinfer`.**
 
-All PRs go to **`ROCm/flashinfer`**, base branch **`amd-integration`**.
+All PRs go to **`AMD-Ecosystem/flashinfer`**, base branch **`amd-integration`**.
 
 **Before ANY `gh pr create`, run this pre-flight check and ABORT if it fails:**
 
 ```bash
-gh repo set-default --view   # MUST print exactly: ROCm/flashinfer
+gh repo set-default --view   # MUST print exactly: AMD-Ecosystem/flashinfer
 ```
 
 If it prints anything else (or errors), STOP — do not create the PR. Report the
@@ -29,7 +29,7 @@ mismatch to the user instead. Never guess the target.
 **Always pass the target and base explicitly** — never rely on gh defaults:
 
 ```bash
-gh pr create --repo ROCm/flashinfer --base amd-integration \
+gh pr create --repo AMD-Ecosystem/flashinfer --base amd-integration \
   --title "<title>" --body "$(cat /tmp/pr_body.md)"
 ```
 
@@ -41,8 +41,8 @@ better to fail to raise a PR and explain why than to raise one against upstream.
 These are local config (not checked in) and must be redone per clone:
 
 ```bash
-git remote -v                        # origin should be ROCm/flashinfer; there must be NO flashinfer-ai remote
-gh repo set-default ROCm/flashinfer  # pin gh base repo so it does not fall back to the fork parent
+git remote -v                        # origin should be AMD-Ecosystem/flashinfer; there must be NO flashinfer-ai remote
+gh repo set-default AMD-Ecosystem/flashinfer  # pin gh base repo so it does not fall back to the fork parent
 ```
 
 If a remote pointing at `flashinfer-ai/flashinfer` exists, remove it:
@@ -93,10 +93,10 @@ reset. It is always better to fail to raise a PR than to push to or PR from
 
 ```bash
 # Update PR description
-gh api repos/ROCm/flashinfer/pulls/<number> --method PATCH --field body="<body>"
+gh api repos/AMD-Ecosystem/flashinfer/pulls/<number> --method PATCH --field body="<body>"
 
 # Or from a file
-gh api repos/ROCm/flashinfer/pulls/<number> --method PATCH --field body="$(cat /tmp/pr_body.md)"
+gh api repos/AMD-Ecosystem/flashinfer/pulls/<number> --method PATCH --field body="$(cat /tmp/pr_body.md)"
 ```
 
 Ask the user to confirm before running `git push` or `gh pr create` — these
@@ -159,14 +159,14 @@ not exposed via REST (replying to a comment is available over REST — see below
 # Bump `first:` if a PR may have more than 50 threads / 10 comments per thread —
 # this query is not exhaustive beyond those limits.
 gh api graphql -f query='
-{ repository(owner:"ROCm", name:"flashinfer") {
+{ repository(owner:"AMD-Ecosystem", name:"flashinfer") {
     pullRequest(number: <PR>) {
       reviewThreads(first: 50) { nodes {
         id isResolved
         comments(first: 10) { nodes { databaseId author { login } path body } } } } } } }'
 
 # Reply to a comment (use the databaseId from above)
-gh api repos/ROCm/flashinfer/pulls/<PR>/comments/<commentDatabaseId>/replies \
+gh api repos/AMD-Ecosystem/flashinfer/pulls/<PR>/comments/<commentDatabaseId>/replies \
   --method POST --field body="<reply>"
 
 # Resolve a thread (use the thread node id, e.g. PRRT_...)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,12 @@
 
 ## CRITICAL: PR target
 
-All PRs go to **`ROCm/flashinfer`**, base branch **`amd-integration`** — NEVER
+All PRs go to **`AMD-Ecosystem/flashinfer`**, base branch **`amd-integration`** — NEVER
 to `flashinfer-ai/flashinfer` (the fork parent / true upstream). `gh pr create`
 defaults the base to the fork parent, so always pass
-`--repo ROCm/flashinfer --base amd-integration` explicitly, and run `gh repo set-default --view` first —
-it MUST print `ROCm/flashinfer` or you abort. If the target owner cannot be
-positively confirmed as `ROCm`, do not create the PR; stop and report why.
+`--repo AMD-Ecosystem/flashinfer --base amd-integration` explicitly, and run `gh repo set-default --view` first —
+it MUST print `AMD-Ecosystem/flashinfer` or you abort. If the target owner cannot be
+positively confirmed as `AMD-Ecosystem`, do not create the PR; stop and report why.
 Failing to raise a PR is always preferable to raising one against upstream.
 
 Also NEVER push to or raise a PR from the `amd-integration` branch itself — it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,15 @@ followed by `git reset --hard origin/amd-integration` to restore
 an abort condition too.
 Full procedure: `pr-workflow` skill.
 
+## PR / issue body formatting
+
+Do not hard-wrap the body to a fixed column. GitHub renders a single newline
+inside a paragraph as a `<br>`, so column-wrapped prose shows up as broken
+mid-sentence lines. Write each paragraph and each bullet as one line and let the
+browser soft-wrap; use blank lines only to separate paragraphs/list items. (Same
+for issue bodies and PR/issue comments — anything GitHub renders.) This is the
+opposite of the repo's `.md`/`.py` source files, which are wrapped normally.
+
 ## Essential Commands
 
 | Task | Command |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,27 @@ followed by `git reset --hard origin/amd-integration` to restore
 an abort condition too.
 Full procedure: `pr-workflow` skill.
 
+## Branch naming
+
+Topic branches are created off `origin/amd-integration` and named with **plain
+hyphenated words** describing the change:
+
+- ✅ `pr-workflow-push-safety`, `timing-torch-events`, `aiter-solution-generator`
+- ❌ **no `rocm/` prefix** — the entire fork is ROCm, so it's redundant noise.
+- ❌ **no plan-phase labels** (`p1`, `p2`, …) from `ROCM_PORT_PLAN.md` — name the
+  *change*, not the plan milestone.
+
+## CRITICAL: ask before pushing to remote (fail-closed)
+
+**Never `git push` (or `gh pr create`, which pushes) without first getting the
+user's explicit "yes" for that specific push.** It publishes to a shared repo.
+This applies to every push — the initial branch push, force-pushes after a
+rebase, and follow-up pushes addressing review comments; a prior "yes" does not
+authorize a later push. State exactly what will be pushed and where (branch →
+`AMD-Ecosystem/flashinfer`) and wait. Local-only work (commits, the quality
+gate, the local review) needs no confirmation — only the network push does. When
+in doubt, hold the push and ask.
+
 ## PR / issue body formatting
 
 Do not hard-wrap the body to a fixed column. GitHub renders a single newline


### PR DESCRIPTION
## Summary

Repo and PR-workflow documentation updates, split out of #270 so that PR stays focused on the benchmark code change.

### What changed

- **`CLAUDE.md`** — retarget the PR-target safeguard to `AMD-Ecosystem/flashinfer` (the repo moved from `ROCm/flashinfer`); add a "PR / issue body formatting" rule (GitHub renders a single newline inside a paragraph as `<br>`, so rendered bodies must not be hard-wrapped); add "Branch naming" and "CRITICAL: ask before pushing to remote" sections ported from the `AMD-Ecosystem/flashinfer-bench` pr-workflow skill.
- **`.claude/skills/pr-workflow/SKILL.md`** — retarget the repo slug, `gh repo set-default` check, `gh api` paths, and GraphQL `owner` to `AMD-Ecosystem`.

## Test plan

- [x] `pre-commit run --files CLAUDE.md .claude/skills/pr-workflow/SKILL.md` — markdownlint and the other hooks pass.
- Docs-only change; no code paths touched, so no pytest applies.