### PR TITLE
feat(skills): add coding-guidelines skill and consolidate PR guidance

### DIFF
--- a/.claude/skills/coding-guidelines/SKILL.md
+++ b/.claude/skills/coding-guidelines/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: coding-guidelines
+description: Disciplined coding guidelines for amd-flashinfer changes — think before coding, prefer simplicity, make surgical changes, and drive execution against verifiable goals. Load when starting an implementation task or when the user asks for the coding guidelines.
+---
+
+# Coding Guidelines
+
+## 1 — Think Before Coding
+
+Before generating code, carefully reason about the problem.
+State assumptions explicitly. If the requirements, scope, or desired outcome are unclear, ask for clarification. Do not proceed with guesswork.
+Push back when a simpler approach exists.
+Stop when confused.
+
+## 2 — Simplicity First
+
+Avoid unnecessary over-engineering. Write clean, readable, and simple code.
+Choose the most straightforward implementation over complex optimizations, unless performance is strictly required.
+Do not use abstractions for single-use code.
+
+## 3 — Surgical Changes
+
+Modify only what is necessary to fulfill the goal. Do not touch or refactor surrounding code unless it directly solves the task at hand.
+Match existing style.
+Do not refactor what isn't broken.
+
+## 4 — Goal-Driven Execution
+
+Break tasks down into verifiable steps.
+Before writing code, outline the plan and define success criteria. Verify your edits against these defined goals.
+Loop until verified.

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -87,6 +87,27 @@ local-only, the topic branch already exists — STOP and report rather than
 reset. It is always better to fail to raise a PR than to push to or PR from
 `amd-integration`.
 
+## Branch naming
+
+Topic branches are created off `origin/amd-integration` and named with **plain
+hyphenated words** describing the change:
+
+- ✅ `pr-workflow-push-safety`, `timing-torch-events`, `aiter-solution-generator`
+- ❌ **no `rocm/` prefix** — the entire fork is ROCm, so it's redundant noise.
+- ❌ **no plan-phase labels** (`p1`, `p2`, …) from `ROCM_PORT_PLAN.md` — name the
+  *change*, not the plan milestone.
+
+## CRITICAL: ask before pushing to remote (fail-closed)
+
+**Never `git push` (or `gh pr create`, which pushes) without first getting the
+user's explicit "yes" for that specific push.** It publishes to a shared repo.
+This applies to every push — the initial branch push, force-pushes after a
+rebase, and follow-up pushes addressing review comments; a prior "yes" does not
+authorize a later push. State exactly what will be pushed and where (branch →
+`AMD-Ecosystem/flashinfer`) and wait. Local-only work (commits, the quality
+gate, the local review) needs no confirmation — only the network push does. When
+in doubt, hold the push and ask.
+
 ## GitHub CLI
 
 `gh pr edit` fails with a "Projects (classic) is being deprecated" GraphQL error on this repo. Use the REST API instead:
@@ -179,6 +200,15 @@ Done = no unresolved Copilot threads remain, each carrying either a fix+SHA repl
 or a won't-fix rationale.
 
 ## PR Description
+
+- **Do not hard-wrap** the body to a fixed column. GitHub renders a single
+  newline inside a paragraph as a `<br>`, so column-wrapped prose shows up as
+  broken lines. Keep each paragraph/bullet on one line and use blank lines only
+  to separate blocks. (Mirrors the `## PR / issue body formatting` rule in
+  CLAUDE.md; note this is the opposite of how the repo's `.md`/`.py` source
+  files — including this skill — are wrapped.)
+- **Do not append a "Generated with Claude Code" footer** (or any other
+  tool-authored attribution) to the body, even if a harness default suggests it.
 
 **Body** — include sections that apply, skip the rest:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,36 +24,6 @@ followed by `git reset --hard origin/amd-integration` to restore
 an abort condition too.
 Full procedure: `pr-workflow` skill.
 
-## Branch naming
-
-Topic branches are created off `origin/amd-integration` and named with **plain
-hyphenated words** describing the change:
-
-- ✅ `pr-workflow-push-safety`, `timing-torch-events`, `aiter-solution-generator`
-- ❌ **no `rocm/` prefix** — the entire fork is ROCm, so it's redundant noise.
-- ❌ **no plan-phase labels** (`p1`, `p2`, …) from `ROCM_PORT_PLAN.md` — name the
-  *change*, not the plan milestone.
-
-## CRITICAL: ask before pushing to remote (fail-closed)
-
-**Never `git push` (or `gh pr create`, which pushes) without first getting the
-user's explicit "yes" for that specific push.** It publishes to a shared repo.
-This applies to every push — the initial branch push, force-pushes after a
-rebase, and follow-up pushes addressing review comments; a prior "yes" does not
-authorize a later push. State exactly what will be pushed and where (branch →
-`AMD-Ecosystem/flashinfer`) and wait. Local-only work (commits, the quality
-gate, the local review) needs no confirmation — only the network push does. When
-in doubt, hold the push and ask.
-
-## PR / issue body formatting
-
-Do not hard-wrap the body to a fixed column. GitHub renders a single newline
-inside a paragraph as a `<br>`, so column-wrapped prose shows up as broken
-mid-sentence lines. Write each paragraph and each bullet as one line and let the
-browser soft-wrap; use blank lines only to separate paragraphs/list items. (Same
-for issue bodies and PR/issue comments — anything GitHub renders.) This is the
-opposite of the repo's `.md`/`.py` source files, which are wrapped normally.
-
 ## Essential Commands
 
 | Task | Command |


### PR DESCRIPTION
## Summary

Two skill/docs changes: adds a new `coding-guidelines` skill, and consolidates the project's PR mechanics into the `pr-workflow` skill (moving them out of CLAUDE.md) so they live in one place and are followed consistently.

### What changed

- **`.claude/skills/coding-guidelines/SKILL.md`** — new skill: YAML frontmatter (`name` / `description`) plus four numbered sections — Think Before Coding, Simplicity First, Surgical Changes, and Goal-Driven Execution. Mirrors the existing `plan-review` skill so the two read consistently.
- **`.claude/skills/pr-workflow/SKILL.md`** — absorbs the branch-naming and ask-before-pushing rules from CLAUDE.md, and gains PR body-formatting rules: do not hard-wrap PR bodies (GitHub renders a single newline as `<br>`), and do not append a "Generated with Claude Code" footer.
- **`CLAUDE.md`** — drops the now-relocated branch-naming and ask-before-pushing sections, keeping it lean and pointing at the pr-workflow skill.

## Test plan

- [x] Skill/docs-only change — no Python code paths touched, so there are no relevant pytests to run.
- [x] `pre-commit run --files` on all three changed files — all applicable hooks pass (markdownlint included). These scoped runs cover the branch's entire diff; a full `pre-commit run -a` is impractically slow over the whole repo and not meaningful for markdown-only changes.