### PR TITLE
fix(hip,aiter): bootstrap varlen .so on flat-gather batch-prefill path

### DIFF
--- a/flashinfer/prefill_rocm.py
+++ b/flashinfer/prefill_rocm.py
@@ -453,12 +453,17 @@ def _aiter_bootstrap_batch_ragged_prefill(
     head_dim: int,
     device_idx: int,
 ) -> None:
-    """Trigger AITER's lazy JIT for mha_varlen_fwd_*.so variants used by ragged prefill.
+    """Trigger AITER's lazy JIT for mha_varlen_fwd_*.so variants used by batch prefill.
 
     Same .so family as single-prefill (varlen group-mode), but we parameterize causal
     and logits-cap so we can cover non-shipped combos for any (causal, logits) the
     user requests. AITER ships non-causal and no-logits variants pre-built; logits+causal
     is the combo that triggers a lazy build.
+
+    Used by both batch-prefill wrappers that reach this .so family: the ragged wrapper,
+    and the paged wrapper's flat-gather path (page sizes outside
+    ``_aiter_native_page_sizes()``). Both loop over return_lse here because the .so is
+    also split on lse, and plan() cannot know which run() will request.
     """
     device = torch.device("cuda", device_idx)
     q = torch.zeros(2, 2, head_dim, dtype=dtype, device=device)
@@ -2084,7 +2089,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._seq_lens_q = seq_lens_q if seq_lens_q is not None else seq_lens
 
         # Bootstrap AITER's lazy JIT for native-paged variants so the C++ dlopen
-        # can find the compiled .so.  Flat-gather path uses pre-built mha_varlen_fwd_*.so.
+        # can find the compiled .so.  The flat-gather path is bootstrapped below.
         if self._backend == "aiter" and page_size in _aiter_native_page_sizes():
             dev_idx = self.device.index if self.device.index is not None else 0
             has_logits = logits_soft_cap > 0
@@ -2108,6 +2113,22 @@ class BatchPrefillWithPagedKVCacheWrapper:
         # tensors so that the ``run()`` path (which may be inside a CUDA graph
         # capture) can use them without any host-side operations.
         if self._backend == "aiter" and page_size not in _aiter_native_page_sizes():
+            # The flat-gather route dispatches through get_aiter_mha_varlen_fwd_handle,
+            # whose .so variant is keyed on (dtype, causal, has_lse, has_logits_cap).
+            # AITER pre-ships only a subset of that family, so bootstrap the rest here
+            # rather than let the C++ dlopen fail inside run().  The helper compiles
+            # both has_lse variants because plan() can't know which one run() will
+            # request; causal is fixed per plan() call.
+            dev_idx = self.device.index if self.device.index is not None else 0
+            with _aiter_bootstrap_lock:
+                _aiter_bootstrap_batch_ragged_prefill(
+                    q_data_type,
+                    logits_soft_cap > 0,
+                    causal,
+                    head_dim_qk,
+                    dev_idx,
+                )
+
             kv_indptr_h = paged_kv_indptr.cpu()
             kv_indices_h = paged_kv_indices.cpu()
             kv_lpl_h = paged_kv_last_page_len.cpu()

--- a/tests/rocm_tests/test_batch_prefill_kernels_hip.py
+++ b/tests/rocm_tests/test_batch_prefill_kernels_hip.py
@@ -718,6 +718,99 @@ def test_batch_prefill_auto_selects_aiter(page_size, causal, return_lse):
     torch.testing.assert_close(o_auto, o_ref, rtol=1e-3, atol=1e-3)
 
 
+@pytest.mark.parametrize("page_size", [1, 5])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("return_lse", [False, True])
+def test_batch_prefill_aiter_flat_gather_bf16(page_size, causal, return_lse):
+    """Non-native page sizes take AITER's flat-gather route, which must bootstrap its .so.
+
+    The mha_varlen_fwd_*.so variant is keyed on (dtype, causal, has_lse, logits_cap) and
+    AITER pre-ships only a subset, so an un-bootstrapped combo fails at run() with
+    "AITER .so not found". bf16 is covered here because it is SGLang's serving dtype and
+    is a distinct .so family from the fp16 cases above.
+    """
+    device = torch.device("cuda:0")
+    if not is_aiter_supported(device) or not _aiter_ops_importable():
+        pytest.skip("AITER requires a gfx942/gfx950 GPU and the aiter package")
+
+    batch_size, qo_len, kv_len = 4, 16, 128
+    num_qo_heads, num_kv_heads, head_dim = 8, 8, 128
+    dtype = torch.bfloat16
+
+    q = torch.randn(
+        batch_size * qo_len, num_qo_heads, head_dim, device=device, dtype=dtype
+    )
+    num_pages = (kv_len + page_size - 1) // page_size
+    total_pages = num_pages * batch_size
+    kv_data = torch.randn(
+        total_pages, 2, page_size, num_kv_heads, head_dim, device=device, dtype=dtype
+    )
+
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * qo_len
+    )
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * num_pages
+    )
+    kv_indices = torch.arange(0, total_pages, dtype=torch.int32, device=device)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device=device
+    )
+
+    workspace = torch.empty(512 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace, "NHD", backend="aiter"
+    )
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=causal,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+
+    # Guard the branch under test: a native page size would take the paged kernel instead.
+    assert wrapper._aiter_flat_gather_idx is not None, (
+        f"page_size={page_size} did not take the AITER flat-gather path"
+    )
+
+    wrapper_ref = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace, "NHD", backend="fa2"
+    )
+    wrapper_ref.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=causal,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+
+    if return_lse:
+        o, lse = wrapper.run(q, kv_data, return_lse=True)
+        o_ref, lse_ref = wrapper_ref.run(q, kv_data, return_lse=True)
+        torch.testing.assert_close(lse, lse_ref, rtol=1e-2, atol=1e-2)
+    else:
+        o = wrapper.run(q, kv_data)
+        o_ref = wrapper_ref.run(q, kv_data)
+
+    # bf16 tolerance: AITER and FA2 accumulate in a different order, which shows up as
+    # occasional 1-ULP (0.0078) differences at this magnitude.
+    torch.testing.assert_close(o, o_ref, rtol=2e-2, atol=2e-2)
+
+
 if __name__ == "__main__":
     test_batch_prefill_with_paged_kv_cache(
         12, 54, 37, 16, 8, 8, 128, True, "HND", "NONE", True, 0.0, False, True, "fa2"


### PR DESCRIPTION
## Summary

`BatchPrefillWithPagedKVCacheWrapper(backend="aiter")` failed at `run()` for any page size outside `_aiter_native_page_sizes()`, because `plan()` bootstrapped AITER's lazy JIT only on the native-paged branch. `page_size=1` is SGLang's ROCm default and `backend="auto"` resolves to AITER on gfx942/gfx950, so a single prefill request from SGLang could not be served.

### What changed

- **`flashinfer/prefill_rocm.py`** — bootstrap the AITER varlen `.so` on the flat-gather branch of the paged `plan()`; correct the stale comment on the native branch; extend `_aiter_bootstrap_batch_ragged_prefill`'s docstring to name both callers.
- **`tests/rocm_tests/test_batch_prefill_kernels_hip.py`** — add `test_batch_prefill_aiter_flat_gather_bf16`, covering the flat-gather paged path in bf16 across `page_size` × `causal` × `return_lse`.

### Architecture / design notes

The old comment claimed the flat-gather route "uses pre-built `mha_varlen_fwd_*.so`". It does not. That route dispatches through `get_aiter_mha_varlen_fwd_handle`, whose variant is keyed on `(dtype, causal, has_lse, has_logits_cap)` (`aiter_loader.cc:42-54`), and AITER pre-ships only a subset of that family. Nothing built the rest, so the C++ `dlopen` failed. The bug was therefore latent-by-luck: a config worked only if some earlier call had happened to build its exact variant.

Reuses `_aiter_bootstrap_batch_ragged_prefill` rather than adding a near-duplicate — it drives the same `.so` family and already compiles both `has_lse` arms, which `plan()` needs since it cannot know which one `run()` will request. `_aiter_bootstrap_single_prefill_varlen` does not fit: it hardcodes `logits_soft_cap=0.5`, so it only builds the `_logits` arm, while the reported failure is on the `nlogits` arm.

Same class of bug as d0e4f73e (#260), which fixed single-prefill when only the causal variant was built.

### Known gaps this does not close

Both pre-exist on the native-paged and ragged paths, so they are left for a separate change:

- The deprecated `forward()` reassigns `self._causal` / `self._logits_soft_cap` *after* `plan()` has bootstrapped. `run()` reads those fields, so `forward(causal=True, logits_soft_cap=30.0)` after `plan(causal=False, logits_soft_cap=0.0)` can still request an unbootstrapped variant. `window_left` is guarded by an assert; these two are not.
- `prefix_len_ptr` rewrites `mask_mode` to `MULTIITEMSCORING`, which `batch_prefill_paged_aiter.cu:76` reads back as `causal=false` — inverting the causal axis the bootstrap compiled for.

## Test plan

Run on gfx942 (MI300X), `amd-aiter 0.1.10`, torch 2.9.1+rocm7.2.

- [x] Reproducer A/B in a **pristine** container. Only 2 of the 4 `mha_varlen_fwd_bf16_nlogits_nbias_*` variants ship prebuilt, and exactly the 2 missing ones failed before this change:

  | causal | return_lse | variant | before | after |
  |---|---|---|---|---|
  | False | False | `nmask_nlse` | `AITER .so not found` | pass |
  | False | True  | `nmask_lse`  | pass | pass |
  | True  | False | `mask_nlse`  | pass | pass |
  | True  | True  | `mask_lse`   | `AITER .so not found` | pass |

  Confirmed the two missing `.so` files are created by the bootstrap after the change.
- [x] New test: 4 failures with `AITER .so not found` at HEAD → 8/8 pass with the fix.
- [x] **`test_batch_prefill_auto_selects_aiter[False-False-1]` was already red at HEAD** for this same bug (fp16, `nmask_nlse`) — it is green now, and all 12 parametrizations pass. The path was not previously uncovered, just failing.
- [x] Full file: `pytest tests/rocm_tests/test_batch_prefill_kernels_hip.py -n auto --reruns 2 -m "not slow"` → 5564 passed, 2136 skipped, 0 failed.
- [x] `backend="fa2"` unaffected at the same shapes (page sizes 1 and 16).
- [x] `pre-commit run -a`

## Out of scope

Native page sizes 128/256 fail differently, with `invalid argument for batch_prefill: no matching kernel found. page_size=128, num_pages=1, dtype=bf16`, raised by AITER's own Python. The bootstrap does run there, so it is a separate kernel-coverage issue, not this one.

Worth noting it is **amd-aiter-version-dependent**: it reproduces on `0.1.20.dev12+gd9e5ef7ce` but *not* on `0.1.10`, where those page sizes pass at the same shapes. Not addressed here.
