### PR TITLE
fix(hip,aiter): probe AITER native paging instead of trusting the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ kernel for non-attention ops). **AITER** = ROCm AITER backend.
 | **Single decode attention** | ✅ `fa2` | — | HIP | MHA / GQA / MQA |
 | **Batch decode attention (paged)** | ✅ `fa2` | ✅ | **AITER** when `fp16/bf16` + `NHD` + `pos_encoding_mode="NONE"` + no CUDA-graph + `use_tensor_cores=False`; else **HIP** | MHA / GQA / MQA; **fp8 KV-cache (E4M3FNUZ)** on the HIP path; sliding-window on the AITER path; CUDA-graph capture on the AITER path is **opt-in via `backend="aiter"`** (grid + `.so` fixed at capture-time shapes — capture at max seq len); `backend="auto"` uses HIP `fa2` under capture |
 | **Single prefill attention** | ✅ `fa2` | ✅ | **AITER** when `fp16/bf16` + `NHD` + no custom mask + equal Q/KV dtypes & head dims + `pos_encoding_mode="NONE"`; else **HIP** | MHA / GQA / MQA; fp8 WIP |
-| **Batch prefill attention (paged + ragged)** | ✅ `fa2` | ✅ | Same auto criteria as single prefill | MHA / GQA / MQA; fp8 WIP. AITER native page sizes: `{16, 1024}` (`{128, 256, 1024}` on `amd-aiter==0.1.10`); other sizes go through a gather on the AITER path |
+| **Batch prefill attention (paged + ragged)** | ✅ `fa2` | ✅ | Same auto criteria as single prefill | MHA / GQA / MQA; fp8 WIP. AITER native page sizes: `{16, 1024}` (`{128, 256, 1024}` on `amd-aiter >= 0.1.10`); other sizes — and any "native" size the installed AITER turns out not to serve — go through a gather on the AITER path |
 | **Cascade attention** | ✅ | — | HIP | Two-level shared-prefix attention; a fused single-kernel HIP variant is gated behind `FLASHINFER_HIP_FUSED_CASCADE=1` |
 | **MLA (Multi-Latent Attention)** | — | ✅ | **AITER** (no HIP fallback) | DeepSeek-style 192/128 head-dim split; bf16 + `page_size=1`; `backend="auto"` (default) resolves to `"aiter"` |
 | **POD attention** | ✅ `fa2` | — | HIP | MHA / GQA / MQA; single + batch variants (`PODWithPagedKVCacheWrapper`, `BatchPODWithPagedKVCacheWrapper`); JIT-only (excluded from AOT, same as upstream CUDA) |
@@ -422,9 +422,14 @@ wrong results):
 **Other notes:**
 
 * Batch prefill: AITER's CK FMHA kernels natively support page sizes
-  `{16, 1024}` (or `{128, 256, 1024}` on `amd-aiter==0.1.10`). Other page
+  `{16, 1024}` (or `{128, 256, 1024}` on `amd-aiter >= 0.1.10`). Other page
   sizes still work but go through an extra GPU gather to flatten paged KV
-  before the AITER call.
+  before the AITER call. That list is a starting point, not a guarantee —
+  `plan()` confirms it by building the kernel, and a page size the installed
+  AITER cannot actually serve also falls back to the gather, with a warning
+  naming the reason. Builds installed from an AITER source commit (as SGLang
+  and vLLM do) are the usual case where a "native" page size is rejected. Set
+  `FLASHINFER_AITER_STRICT=1` to raise instead of falling back.
 * Ragged (non-paged) batch prefill via AITER is supported through
   `BatchPrefillWithRaggedKVCacheWrapper`. The wrapper auto-routes to
   AITER under `backend="auto"` when the standard AITER compatibility
@@ -443,6 +448,7 @@ documented in [CLAUDE.md](CLAUDE.md).
 | :--- | :--- | :--- |
 | `FLASHINFER_USE_TORCH_CUSTOM_OPS` | `0` | Set to `1` **before** importing `flashinfer` to wrap kernels in `torch.library.custom_op` so `torch.compile` / Dynamo can trace them. Requires PyTorch ≥ 2.4. Adds a small per-call dispatch overhead. |
 | `FLASHINFER_HIP_FUSED_CASCADE` | `0` | Set to `1` to use a fused single-kernel HIP cascade attention path instead of the default two-level merge-based path. Experimental on ROCm. |
+| `FLASHINFER_AITER_STRICT` | `0` | Set to `1` to raise instead of degrading when AITER cannot serve a page size natively. By default batch prefill falls back to the slower flat-gather path (with a warning); set this in CI to catch AITER kernel-coverage regressions rather than absorb them as a slowdown. |
 | `FLASHINFER_LOGGING_LEVEL` | `INFO` | Logger verbosity (e.g. `DEBUG`, `INFO`, `WARNING`). Affects AITER auto-fallback warnings and JIT build messages. |
 | `FLASHINFER_DISABLE_JIT` | unset | Set to any non-empty value to skip JIT compilation. Useful when running an AOT-built wheel and you want to fail loudly on missing kernels rather than trigger a build. |
 | `ROCM_PATH` / `ROCM_HOME` | `/opt/rocm` | Used by `flashinfer.hip_utils` to locate the ROCm install. Override only for non-standard ROCm layouts. |

--- a/flashinfer/prefill_rocm.py
+++ b/flashinfer/prefill_rocm.py
@@ -56,11 +56,11 @@ from .utils import (
 )
 
 
-# Newest amd-aiter release whose native paged-prefill coverage we have validated.
-# This is a *hint*, not a guarantee: serving stacks (SGLang, vLLM) install AITER
-# from a source commit rather than the released wheel, and those builds dispatch
-# differently. Anything above this version is treated as unverified and is
-# confirmed at plan() time by _aiter_native_paging_available().
+# Two independent versions — do not merge them. The first is the release that
+# widened native paged-prefill to {128, 256, 1024}; changing it changes which page
+# sizes we try. The second is the newest release we have actually validated against;
+# bumping it must not silently move the support boundary.
+_AITER_NATIVE_PAGING_SINCE = "0.1.10"
 _AITER_LAST_VALIDATED = "0.1.10"
 
 
@@ -77,14 +77,16 @@ def _aiter_native_page_sizes() -> frozenset:
 
         installed = Version(version("amd-aiter"))
         if installed > Version(_AITER_LAST_VALIDATED):
-            logger.warning(
-                "amd-aiter %s is newer than the last version validated with this "
-                "FlashInfer build (%s); native paged-prefill support will be probed "
-                "at plan() time and may fall back to the slower flat-gather path.",
+            # Debug, not a warning: this fires for every build newer than the pin,
+            # which is the common case going forward, and it is speculative — the
+            # probe warns with the real error if support is actually missing.
+            logger.debug(
+                "amd-aiter %s is newer than the last validated version (%s); "
+                "native paged-prefill support will be probed at plan() time.",
                 installed,
                 _AITER_LAST_VALIDATED,
             )
-        if installed >= Version(_AITER_LAST_VALIDATED):
+        if installed >= Version(_AITER_NATIVE_PAGING_SINCE):
             return frozenset({128, 256, 1024})
         return frozenset({16, 1024})
     except (PackageNotFoundError, ValueError):
@@ -576,18 +578,36 @@ def _aiter_native_paging_available(
     than trust the predicate, run the bootstrap — which launches the real kernel —
     and treat a failure as "not available".
 
+    The bootstrap is more than a proxy for what run() does: it is what *produces*
+    the mha_batch_prefill_*.so that the C++ path later dlopens. If it cannot build,
+    the native path definitionally cannot work — forcing it anyway just trades this
+    error for ``AITER .so not found`` inside run().
+
     Falling back is always correct: the flat-gather path serves every page size.
     It is not free, though — it materializes a contiguous copy of K and V on each
     run() — so the fallback is warned about rather than taken silently. Set
     FLASHINFER_AITER_STRICT=1 to re-raise instead of degrading.
 
     Bootstraps both has_lse variants, since plan() cannot know which run() needs.
+    This is a separate cached function rather than a try/except inlined into plan()
+    because functools.lru_cache does not memoize exceptions: inlining would re-launch
+    a known-failing kernel, and re-warn, on every plan() call.
     """
+    # Drain any pending async error from earlier work *outside* the try, so it is
+    # not mistaken for an AITER capability failure and cached as "unsupported".
+    torch.cuda.synchronize(device_idx)
     try:
         for has_lse in (True, False):
             _aiter_bootstrap_batch_prefill(
                 dtype, has_logits_cap, causal, has_lse, page_size, head_dim, device_idx
             )
+        # HIP launches are async, so a device-side failure would otherwise land
+        # somewhere unrelated and leave us wrongly committed to the native path.
+        torch.cuda.synchronize(device_idx)
+    except torch.cuda.OutOfMemoryError:
+        # Transient and unrelated to kernel availability — never cache it as
+        # "unsupported", or one OOM would downgrade this config for the process.
+        raise
     except Exception as e:
         if os.environ.get("FLASHINFER_AITER_STRICT", "0") == "1":
             raise

--- a/flashinfer/prefill_rocm.py
+++ b/flashinfer/prefill_rocm.py
@@ -18,6 +18,7 @@ limitations under the License.
 import functools
 import logging
 import math
+import os
 import threading
 from importlib.metadata import PackageNotFoundError
 from types import SimpleNamespace
@@ -55,13 +56,35 @@ from .utils import (
 )
 
 
+# Newest amd-aiter release whose native paged-prefill coverage we have validated.
+# This is a *hint*, not a guarantee: serving stacks (SGLang, vLLM) install AITER
+# from a source commit rather than the released wheel, and those builds dispatch
+# differently. Anything above this version is treated as unverified and is
+# confirmed at plan() time by _aiter_native_paging_available().
+_AITER_LAST_VALIDATED = "0.1.10"
+
+
 @functools.cache
 def _aiter_native_page_sizes() -> frozenset:
+    """Page sizes AITER is *expected* to serve without a flat-gather.
+
+    Only a hint — the caller must confirm with _aiter_native_paging_available()
+    before relying on it. Every page size works via flat-gather regardless.
+    """
     try:
         from importlib.metadata import version
         from packaging.version import Version
 
-        if Version(version("amd-aiter")) >= Version("0.1.10"):
+        installed = Version(version("amd-aiter"))
+        if installed > Version(_AITER_LAST_VALIDATED):
+            logger.warning(
+                "amd-aiter %s is newer than the last version validated with this "
+                "FlashInfer build (%s); native paged-prefill support will be probed "
+                "at plan() time and may fall back to the slower flat-gather path.",
+                installed,
+                _AITER_LAST_VALIDATED,
+            )
+        if installed >= Version(_AITER_LAST_VALIDATED):
             return frozenset({128, 256, 1024})
         return frozenset({16, 1024})
     except (PackageNotFoundError, ValueError):
@@ -533,6 +556,54 @@ def _aiter_bootstrap_batch_prefill(
         return_lse=has_lse,
         kv_last_page_lens=kv_last_page_lens,
     )
+
+
+@functools.lru_cache(maxsize=None)
+def _aiter_native_paging_available(
+    dtype: torch.dtype,
+    has_logits_cap: bool,
+    causal: bool,
+    page_size: int,
+    head_dim: int,
+    device_idx: int,
+) -> bool:
+    """Probe whether AITER really dispatches a native paged kernel for this config.
+
+    _aiter_native_page_sizes() can only report what the *validated* amd-aiter
+    release supported. Serving stacks pin an AITER source commit instead, and such
+    a build can reject a page size the version predicate claims is native, e.g.
+    ``no matching kernel found. page_size=128, num_pages=1, dtype=bf16``. Rather
+    than trust the predicate, run the bootstrap — which launches the real kernel —
+    and treat a failure as "not available".
+
+    Falling back is always correct: the flat-gather path serves every page size.
+    It is not free, though — it materializes a contiguous copy of K and V on each
+    run() — so the fallback is warned about rather than taken silently. Set
+    FLASHINFER_AITER_STRICT=1 to re-raise instead of degrading.
+
+    Bootstraps both has_lse variants, since plan() cannot know which run() needs.
+    """
+    try:
+        for has_lse in (True, False):
+            _aiter_bootstrap_batch_prefill(
+                dtype, has_logits_cap, causal, has_lse, page_size, head_dim, device_idx
+            )
+    except Exception as e:
+        if os.environ.get("FLASHINFER_AITER_STRICT", "0") == "1":
+            raise
+        logger.warning(
+            "AITER has no native paged-prefill kernel for page_size=%d "
+            "(dtype=%s, causal=%s, logits_cap=%s): %s. Falling back to the "
+            "flat-gather path, which copies K/V per run(). Set "
+            "FLASHINFER_AITER_STRICT=1 to raise instead.",
+            page_size,
+            dtype,
+            causal,
+            has_logits_cap,
+            e,
+        )
+        return False
+    return True
 
 
 @functools.cache
@@ -2091,47 +2162,47 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._seq_lens_kv = seq_lens
         self._seq_lens_q = seq_lens_q if seq_lens_q is not None else seq_lens
 
-        # Bootstrap AITER's lazy JIT for native-paged variants so the C++ dlopen
-        # can find the compiled .so.  The flat-gather path is bootstrapped below.
-        if self._backend == "aiter" and page_size in _aiter_native_page_sizes():
+        # Decide native-paged vs flat-gather ONCE. run() dispatches on whether
+        # self._aiter_flat_gather_idx is set, so a single decision here is what
+        # keeps the bootstrapped .so and the kernel run() reaches in agreement.
+        # Bootstrapping AITER's lazy JIT is also the probe: it launches the real
+        # kernel, so a config the installed AITER cannot serve fails here, at
+        # plan() time, and degrades to flat-gather instead of killing run().
+        use_native_paging = False
+        if self._backend == "aiter":
             dev_idx = self.device.index if self.device.index is not None else 0
             has_logits = logits_soft_cap > 0
             with _aiter_bootstrap_lock:
-                # Bootstrap only the (causal, lse) variants that may actually be used.
-                # We don't know at plan() time whether run() will request lse, so compile
-                # both has_lse=True/False; but causal is fixed per plan() call.
-                for _lse_v in (True, False):
-                    _aiter_bootstrap_batch_prefill(
+                if page_size in _aiter_native_page_sizes():
+                    use_native_paging = _aiter_native_paging_available(
                         q_data_type,
                         has_logits,
                         causal,
-                        _lse_v,
                         page_size,
                         head_dim_qk,
                         dev_idx,
                     )
+                if not use_native_paging:
+                    # The flat-gather route dispatches through
+                    # get_aiter_mha_varlen_fwd_handle, whose .so variant is keyed on
+                    # (dtype, causal, has_lse, has_logits_cap).  AITER pre-ships only
+                    # a subset of that family, so bootstrap the rest here rather than
+                    # let the C++ dlopen fail inside run().  The helper compiles both
+                    # has_lse variants because plan() can't know which one run() will
+                    # request; causal is fixed per plan() call.
+                    _aiter_bootstrap_batch_ragged_prefill(
+                        q_data_type,
+                        has_logits,
+                        causal,
+                        head_dim_qk,
+                        dev_idx,
+                    )
 
-        # Pre-compute flat-KV gather indices for the AITER backend when the
-        # page size is not natively supported.  These are stored as GPU
-        # tensors so that the ``run()`` path (which may be inside a CUDA graph
-        # capture) can use them without any host-side operations.
-        if self._backend == "aiter" and page_size not in _aiter_native_page_sizes():
-            # The flat-gather route dispatches through get_aiter_mha_varlen_fwd_handle,
-            # whose .so variant is keyed on (dtype, causal, has_lse, has_logits_cap).
-            # AITER pre-ships only a subset of that family, so bootstrap the rest here
-            # rather than let the C++ dlopen fail inside run().  The helper compiles
-            # both has_lse variants because plan() can't know which one run() will
-            # request; causal is fixed per plan() call.
-            dev_idx = self.device.index if self.device.index is not None else 0
-            with _aiter_bootstrap_lock:
-                _aiter_bootstrap_batch_ragged_prefill(
-                    q_data_type,
-                    logits_soft_cap > 0,
-                    causal,
-                    head_dim_qk,
-                    dev_idx,
-                )
-
+        # Pre-compute flat-KV gather indices whenever AITER is not serving this
+        # page size natively.  These are stored as GPU tensors so that the
+        # ``run()`` path (which may be inside a CUDA graph capture) can use them
+        # without any host-side operations.
+        if self._backend == "aiter" and not use_native_paging:
             kv_indptr_h = paged_kv_indptr.cpu()
             kv_indices_h = paged_kv_indices.cpu()
             kv_lpl_h = paged_kv_last_page_len.cpu()

--- a/tests/rocm_tests/test_batch_prefill_kernels_hip.py
+++ b/tests/rocm_tests/test_batch_prefill_kernels_hip.py
@@ -9,7 +9,11 @@ from jit_utils import gen_prefill_attention_modules
 import flashinfer
 from flashinfer.jit.core import logger
 from flashinfer.aiter_utils import is_aiter_supported
-from flashinfer.prefill_rocm import _aiter_ops_importable
+from flashinfer.prefill_rocm import (
+    _aiter_native_page_sizes,
+    _aiter_native_paging_available,
+    _aiter_ops_importable,
+)
 import logging
 
 logger.setLevel(logging.ERROR)
@@ -810,6 +814,106 @@ def test_batch_prefill_aiter_flat_gather_bf16(page_size, causal, return_lse):
     # bf16 tolerance: AITER and FA2 accumulate in a different order, which shows up as
     # occasional 1-ULP (0.0078) differences at this magnitude.
     torch.testing.assert_close(o, o_ref, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("page_size", [128, 256])
+def test_batch_prefill_aiter_falls_back_when_native_paging_missing(
+    page_size, monkeypatch
+):
+    """A native page size AITER cannot actually serve must degrade to flat-gather.
+
+    _aiter_native_page_sizes() only reflects the validated amd-aiter release;
+    serving stacks build AITER from source and such a build can reject a page size
+    the predicate calls native ("no matching kernel found"). Simulate that by making
+    the bootstrap raise, and require plan() to fall back rather than propagate.
+    """
+    device = torch.device("cuda:0")
+    if not is_aiter_supported(device) or not _aiter_ops_importable():
+        pytest.skip("AITER requires a gfx942/gfx950 GPU and the aiter package")
+    if page_size not in _aiter_native_page_sizes():
+        pytest.skip(f"page_size={page_size} is not native on this amd-aiter build")
+
+    def _reject(*args, **kwargs):
+        raise RuntimeError(
+            f"invalid argument for batch_prefill: no matching kernel found. "
+            f"page_size={page_size}, num_pages=1, dtype=bf16"
+        )
+
+    # The probe is cached, so clear it to keep this test independent of ordering.
+    _aiter_native_paging_available.cache_clear()
+    monkeypatch.setattr(
+        flashinfer.prefill_rocm, "_aiter_bootstrap_batch_prefill", _reject
+    )
+
+    batch_size, qo_len, kv_len = 2, 16, 256
+    num_qo_heads, num_kv_heads, head_dim = 8, 8, 128
+    dtype = torch.bfloat16
+
+    q = torch.randn(
+        batch_size * qo_len, num_qo_heads, head_dim, device=device, dtype=dtype
+    )
+    num_pages = (kv_len + page_size - 1) // page_size
+    total_pages = num_pages * batch_size
+    kv_data = torch.randn(
+        total_pages, 2, page_size, num_kv_heads, head_dim, device=device, dtype=dtype
+    )
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * qo_len
+    )
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * num_pages
+    )
+    kv_indices = torch.arange(0, total_pages, dtype=torch.int32, device=device)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device=device
+    )
+    workspace = torch.empty(512 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    try:
+        wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+            workspace, "NHD", backend="aiter"
+        )
+        wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            causal=True,
+            q_data_type=dtype,
+            kv_data_type=dtype,
+        )
+
+        # Degraded to flat-gather instead of raising out of plan().
+        assert wrapper._aiter_flat_gather_idx is not None, (
+            "plan() kept the native paged path despite the kernel being unavailable"
+        )
+
+        o = wrapper.run(q, kv_data)
+    finally:
+        _aiter_native_paging_available.cache_clear()
+
+    wrapper_ref = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace, "NHD", backend="fa2"
+    )
+    wrapper_ref.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=True,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    # The fallback must be correct, not merely non-crashing.
+    torch.testing.assert_close(o, wrapper_ref.run(q, kv_data), rtol=2e-2, atol=2e-2)
 
 
 if __name__ == "__main__":

--- a/tests/rocm_tests/test_batch_prefill_kernels_hip.py
+++ b/tests/rocm_tests/test_batch_prefill_kernels_hip.py
@@ -916,6 +916,58 @@ def test_batch_prefill_aiter_falls_back_when_native_paging_missing(
     torch.testing.assert_close(o, wrapper_ref.run(q, kv_data), rtol=2e-2, atol=2e-2)
 
 
+def test_batch_prefill_aiter_strict_mode_raises(monkeypatch):
+    """FLASHINFER_AITER_STRICT=1 must surface the AITER failure instead of degrading."""
+    device = torch.device("cuda:0")
+    if not is_aiter_supported(device) or not _aiter_ops_importable():
+        pytest.skip("AITER requires a gfx942/gfx950 GPU and the aiter package")
+    page_size = 128
+    if page_size not in _aiter_native_page_sizes():
+        pytest.skip(f"page_size={page_size} is not native on this amd-aiter build")
+
+    def _reject(*args, **kwargs):
+        raise RuntimeError("no matching kernel found. page_size=128")
+
+    _aiter_native_paging_available.cache_clear()
+    monkeypatch.setattr(
+        flashinfer.prefill_rocm, "_aiter_bootstrap_batch_prefill", _reject
+    )
+    monkeypatch.setenv("FLASHINFER_AITER_STRICT", "1")
+
+    batch_size, qo_len, kv_len = 1, 16, 128
+    num_qo_heads, num_kv_heads, head_dim = 8, 8, 128
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * qo_len
+    )
+    kv_indptr = torch.arange(0, batch_size + 1, dtype=torch.int32, device=device)
+    kv_indices = torch.arange(0, batch_size, dtype=torch.int32, device=device)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device=device
+    )
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace, "NHD", backend="aiter"
+    )
+    try:
+        with pytest.raises(RuntimeError, match="no matching kernel found"):
+            wrapper.plan(
+                qo_indptr,
+                kv_indptr,
+                kv_indices,
+                kv_last_page_len,
+                num_qo_heads,
+                num_kv_heads,
+                head_dim,
+                page_size,
+                causal=True,
+                q_data_type=torch.bfloat16,
+                kv_data_type=torch.bfloat16,
+            )
+    finally:
+        _aiter_native_paging_available.cache_clear()
+
+
 if __name__ == "__main__":
     test_batch_prefill_with_paged_kv_cache(
         12, 54, 37, 16, 8, 8, 128, True, "HND", "NONE", True, 0.0, False, True, "fa2"


### PR DESCRIPTION
## Summary

FlashInfer inferred an AITER capability from a version number and treated it as fact. `_aiter_native_page_sizes()` returns `{128, 256, 1024}` for any `amd-aiter >= 0.1.10`, and `plan()` trusted it. The predicate is open-ended, so every future version inherits 0.1.10's claim — but serving stacks install AITER from a source commit rather than the released wheel. SGLang's build reports `0.1.20.dev12`, satisfies `>= 0.1.10`, and then rejects `page_size=128` with `no matching kernel found`, killing `plan()`.

This establishes the capability instead of assuming it. It is the same root cause as #275: there, FlashInfer assumed a `.so` was pre-shipped; here, it assumes a kernel exists.

### What changed

- **`flashinfer/prefill_rocm.py`** — add `_aiter_native_paging_available()`, a cached capability probe; collapse `plan()`'s two complementary page-size branches into one `use_native_paging` decision; split the AITER version constant in two.
- **`tests/rocm_tests/test_batch_prefill_kernels_hip.py`** — cover both the degradation path and `FLASHINFER_AITER_STRICT=1`.
- **`README.md`** — document `FLASHINFER_AITER_STRICT`; correct two statements that only *non-native* page sizes take the gather, which is no longer true.

### Architecture / design notes

**The bootstrap is the probe.** It already launches the real kernel, so no new machinery is needed — a config the installed AITER cannot serve now fails at `plan()` time and degrades, rather than killing `run()`.

It is more than a proxy for what `run()` does: the bootstrap *produces* the `mha_batch_prefill_*.so` that the C++ path dlopens. Verified by bypassing the probe and forcing the native path on `0.1.20.dev` — `run()` then fails with `AITER .so not found: mha_batch_prefill_bf16_...`. So a bootstrap failure means the native path **cannot** work, not merely that it might not.

**Falling back is always correct** — flat-gather serves every page size. Confirmed directly: forced through flat-gather at page sizes 128 and 256, output matches fa2. Note the fallback stays on **AITER** (`mha_varlen_fwd`); it is not a fa2 fallback.

**It warns rather than degrading silently**, because flat-gather materializes a contiguous copy of K and V on every `run()`. That is a real cost a serving stack should be told about. `FLASHINFER_AITER_STRICT=1` turns the degradation into a raise — intended for CI, so a kernel-coverage regression surfaces as a failure instead of being absorbed as a slowdown.

**One decision, not two.** `run()` dispatches on whether `_aiter_flat_gather_idx` is set, so deciding once in `plan()` is what keeps the bootstrapped `.so` and the kernel `run()` reaches from drifting apart. The previous code evaluated `page_size in / not in _aiter_native_page_sizes()` in two separate `if` blocks.

### Known limitation

For a CUDA-graph-enabled wrapper, `use_native_paging` now depends on `causal` / `logits_soft_cap` / dtype / head-dim, not just `page_size`. If those change between `plan()` calls the wrapper can flip between native and flat-gather, and the `else` branch drops the max-size gather buffer that graph capture relies on. Changing `causal` already invalidates a captured graph on semantic grounds, so this is not reachable in a correct capture/replay flow — recording it because the pre-change branch was a pure function of `page_size` and this one is not.

## Test plan

gfx942 (MI300X), against **two** AITER builds.

- [x] `amd-aiter 0.1.20.dev12+gd9e5ef7ce` (SGLang image), `page_size=128`: was a hard `RuntimeError`; now warns, probes, degrades to flat-gather, and succeeds. With `FLASHINFER_AITER_STRICT=1` it still raises.
- [x] `amd-aiter 0.1.10`, page sizes 128/256: probe passes, native path unchanged (`flat_gather=False`).
- [x] Forced flat-gather at 128/256 matches fa2 — the fallback is correct, not merely non-crashing.
- [x] New tests: fallback-on-probe-failure (asserts output matches fa2, not just that it ran) and strict-mode-raises.
- [x] Full file: `pytest tests/rocm_tests/test_batch_prefill_kernels_hip.py -n auto --reruns 2 -m "not slow"` → 5566 passed, 2136 skipped, 0 failed.
- [x] `pre-commit run -a`

### Review fixes folded in (`634526e3`)

- Synchronize around the probe — HIP launches are async, so the original `try/except` could only catch host-side errors. Drain *outside* the try, so a pre-existing async error is not misattributed and cached as missing AITER support.
- Re-raise `torch.cuda.OutOfMemoryError`. It subclasses `RuntimeError`, so it was being caught and memoized — one transient OOM would have downgraded a config to flat-gather for the life of the process.
- Split `_AITER_LAST_VALIDATED` into `_AITER_NATIVE_PAGING_SINCE` + `_AITER_LAST_VALIDATED`. They coincided by accident, so bumping the one constant after validating a newer AITER would have silently dropped 0.1.10 users to `{16, 1024}`.
- Demote the "newer than validated" message to `debug` — it fired for every build above the pin and was speculative.
