### PR TITLE
docs(rocm): fix the AITER wheel install command and pin the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,11 +376,24 @@ python3 setup.py develop
 
 ### Install AITER wheel package
 
-Wheel packages are available from AMD's PyPI index: [pypi.amd.com/simple](https://pypi.amd.com/simple/).
+Wheel packages are published per ROCm release on AMD's PyPI index. `amd-aiter`
+is **not** on the top-level `pypi.amd.com/simple` index — use the ROCm-versioned
+channel:
 
 ```bash
-pip install amd-aiter --index-url https://pypi.amd.com/simple/
+pip install amd-aiter==0.1.10 --extra-index-url https://pypi.amd.com/rocm-7.1.1/simple
 ```
+
+Use `--extra-index-url`, not `--index-url`, so that AITER's own dependencies
+still resolve from PyPI.
+
+Pin `0.1.10`: it is the version this repo is built and tested against, and
+currently the only one published on that channel. FlashInfer links AITER's C++
+symbols by mangled name (`flashinfer/csrc_rocm/aiter_loader.cc`) and vendors its
+argument structs (`include/flashinfer/attention/aiter/`), so a different AITER
+build can fail at `dlsym` — or, if a struct layout changed, misinterpret kernel
+arguments silently. Both the CI image (`docker/Dockerfile.rocm_ci`) and the
+devcontainer install this exact version.
 
 ### Known Limitations
 


### PR DESCRIPTION
## Summary

The documented command for installing the AITER wheel does not work. `README.md` says:

```bash
pip install amd-aiter --index-url https://pypi.amd.com/simple/
```

which fails with `ERROR: No matching distribution found for amd-aiter` — `amd-aiter` is not published on the top-level `pypi.amd.com/simple` index. Wheels are published per ROCm release, on the channel both Dockerfiles already use.

### What changed

- **`README.md`** — correct the install command to the ROCm-versioned channel, switch `--index-url` to `--extra-index-url`, and record why the version is pinned.

### Architecture / design notes

`--extra-index-url` rather than `--index-url`: the ROCm channel carries only AMD's own wheels, so pointing pip at it exclusively leaves AITER's dependencies unresolvable. `--extra-index-url` keeps PyPI in the search path. This matches `docker/Dockerfile.rocm_ci:56` and `.devcontainer/rocm/Dockerfile:94`.

The version pin is documented because it is load-bearing, not conservatism: `flashinfer/csrc_rocm/aiter_loader.cc` resolves AITER's C++ entry points by **mangled symbol name**, and `include/flashinfer/attention/aiter/` **vendors AITER's argument structs** by value. A mismatched AITER build therefore fails at `dlsym` — or, if a struct layout changed, silently misinterprets kernel arguments. `0.1.10` is also currently the only version published on that channel.

## Test plan

Docs-only; no Python or C++ changed, so there are no covering pytests to run. Verified against the live index from a ROCm container instead:

- [x] `pip install amd-aiter --index-url https://pypi.amd.com/simple/` → `ERROR: No matching distribution found for amd-aiter` (reproduces the broken instruction).
- [x] `pip index versions amd-aiter --extra-index-url https://pypi.amd.com/rocm-7.1.1/simple` → `amd-aiter (0.1.10)`, `LATEST: 0.1.10` — the corrected channel resolves, and 0.1.10 is the only version on it.
- [x] `pip install --dry-run amd-aiter==0.1.10 --extra-index-url https://pypi.amd.com/rocm-7.1.1/simple` → resolves.
- [x] Checked the sibling ROCm channels (`rocm-7.0`, `rocm-7.1`, `rocm-7.2`, `rocm-6.4`): none resolve `amd-aiter`, so `rocm-7.1.1` is the correct one to document.
- [x] `pre-commit run -a`
