### PR TITLE
docs: require git worktrees for branch work

### DIFF
--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -87,6 +87,59 @@ local-only, the topic branch already exists — STOP and report rather than
 reset. It is always better to fail to raise a PR than to push to or PR from
 `amd-integration`.
 
+## CRITICAL: do branch work in a git worktree, never in the main checkout
+
+**Always** do branch work in a worktree under `tmp/worktrees/<branch-name>`.
+Leave the main checkout parked on `amd-integration`. Never switch the main
+checkout to a topic branch.
+
+```bash
+git worktree add -b <branch> tmp/worktrees/<branch> origin/amd-integration  # new branch
+git worktree add tmp/worktrees/<branch> <branch>                            # existing branch
+```
+
+Why this is the rule and not a preference:
+
+- The main checkout holds the editable install, `~/.cache/flashinfer` build
+  artifacts, and compiled extensions. Switching it between branches invalidates
+  them and produces confusing stale-binary failures.
+- Multiple PRs are usually in flight at once. Worktrees keep them physically
+  separate, so an unrelated in-progress edit cannot leak into a PR.
+- `amd-integration` staying pristine is what makes the `git reset --hard`
+  recovery above safe.
+
+Exclude the worktree root **per-clone** rather than in a tracked ignore file, so
+it never appears as a diff against upstream:
+
+```bash
+printf '/tmp/\n' >> .git/info/exclude
+```
+
+### A fresh worktree is source-only
+
+Two gitignored, generated files must be recreated or the JIT will not build:
+
+```bash
+cd tmp/worktrees/<branch>
+ln -sfn ../include flashinfer/include        # MUST be relative
+cp <main-checkout>/flashinfer/_version.py flashinfer/_version.py
+```
+
+- `flashinfer/include` — `get_include_paths.get_include()` returns
+  `<pkg>/include`. Without the symlink the JIT emits `-isystem /include` and
+  every compile fails with `'flashinfer/attention/aiter/batch_prefill.cuh' file
+  not found`. Create it **relative**: the main checkout's copy may be an
+  absolute symlink into a container mount point (e.g. `-> /fi/include`), which
+  does not resolve on the host or under a different mount.
+- `flashinfer/_version.py` — setuptools-scm generated. Without it,
+  `import flashinfer` fails with `ModuleNotFoundError: No module named
+  'flashinfer._version'`.
+
+Build artifacts and editable installs stay in the main checkout. If you need to
+run tests against worktree code, bind-mount the **worktree** path into the
+container and point `PYTHONPATH` at the mount — then confirm
+`flashinfer.__file__` resolves there before trusting any result.
+
 ## Branch naming
 
 Topic branches are created off `origin/amd-integration` and named with **plain

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -94,9 +94,12 @@ Leave the main checkout parked on `amd-integration`. Never switch the main
 checkout to a topic branch.
 
 ```bash
-mkdir -p tmp/worktrees && git worktree add -b <branch-name> tmp/worktrees/<branch-name> origin/amd-integration  # new branch
-mkdir -p tmp/worktrees && git worktree add tmp/worktrees/<branch-name> <branch-name>                            # existing branch
+git worktree add -b <branch-name> tmp/worktrees/<branch-name> origin/amd-integration  # new branch
+git worktree add tmp/worktrees/<branch-name> <branch-name>                            # existing branch
 ```
+
+`git worktree add` creates the leading `tmp/worktrees/` directories itself, so
+no `mkdir -p` is needed on a fresh clone.
 
 Why this is the rule and not a preference:
 
@@ -109,18 +112,23 @@ Why this is the rule and not a preference:
   recovery above safe.
 
 Exclude the worktree root **per-clone** rather than in a tracked ignore file, so
-it never appears as a diff against upstream:
+it never appears as a diff against upstream. One run covers the whole clone,
+worktrees included:
 
 ```bash
-printf '/tmp/\n' >> .git/info/exclude
+printf '/tmp/\n' >> "$(git rev-parse --git-common-dir)/info/exclude"
 ```
+
+Use `--git-common-dir`, not a literal `.git/info/exclude`: inside a linked
+worktree `.git` is a *file* pointing at the real git dir, so the literal path
+fails with `not a directory`.
 
 ### A fresh worktree is source-only
 
 Two gitignored, generated files must be recreated or the JIT will not build:
 
 ```bash
-cd tmp/worktrees/<branch>
+cd tmp/worktrees/<branch-name>
 ln -sfn ../include flashinfer/include        # MUST be relative
 cp <main-checkout>/flashinfer/_version.py flashinfer/_version.py
 ```

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -139,7 +139,7 @@ Two gitignored, generated files must be recreated or the JIT will not build:
 cd tmp/worktrees/<branch-name>
 rm -rf flashinfer/include                    # -f alone will not clear a real dir
 ln -s ../include flashinfer/include          # MUST be relative
-cp <main-checkout>/flashinfer/_version.py flashinfer/_version.py
+cp <main-checkout>/flashinfer/_version.py flashinfer/_version.py   # see below if absent
 ```
 
 Clear the path first. `-f` replaces a dangling or stale *symlink*, but against
@@ -163,7 +163,12 @@ headers live in `include/` at the repo root.
   tree is mounted.
 - `flashinfer/_version.py` — setuptools-scm generated. Without it,
   `import flashinfer` fails with `ModuleNotFoundError: No module named
-  'flashinfer._version'`.
+  'flashinfer._version'`. If the `cp` fails because the source file is not
+  there either, the main checkout has never been built: setuptools-scm only
+  emits it during an install or build (`write_to` in `pyproject.toml`), so run
+  `python -m pip install --no-build-isolation -ve.` there first. Don't reach
+  for the `setuptools_scm` CLI — it is a build dependency and is generally not
+  present in the environment you're running from.
 
 Build artifacts and editable installs stay in the main checkout. If you need to
 run tests against worktree code, bind-mount the **worktree** path into the

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -259,6 +259,32 @@ always run this loop before considering the PR done:
      resolve the thread.
    Either way the thread ends resolved with a written rationale.
 
+**Keep replies short** — a verdict, a one-line reason, and the SHA. Reserve a
+code block for comments you are *declining*, where the evidence is the argument.
+
+### Suppressed comments have no thread
+
+Copilot folds some findings into a collapsed **"Suppressed comments (N)"**
+section of the review body. These are not review threads: there is no replies
+endpoint and nothing to resolve, so the loop above cannot close them and they
+are easy to miss entirely.
+
+They are also **not cumulative** — each review body lists only its own. Sweep
+every review, not just the latest:
+
+```bash
+gh api repos/AMD-Ecosystem/flashinfer/pulls/<PR>/reviews --paginate \
+  --jq '.[] | select(.user.login=="copilot-pull-request-reviewer[bot]")
+        | "\(.id) \(.submitted_at) \(.body)"'
+```
+
+Handle them like any other comment, then record the disposition in **one**
+top-level comment per review — `gh api repos/AMD-Ecosystem/flashinfer/issues/<PR>/comments`.
+Without it the fixes land silently and a reviewer cannot tell they were read.
+
+Each push triggers a fresh review, so repeat until a review comes back with no
+new comments *and* no suppressed block.
+
 List threads with their resolved status, and resolve them, via GraphQL. GraphQL
 is required because thread resolution and the thread-level `isResolved` flag are
 not exposed via REST (replying to a comment is available over REST — see below):

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -116,7 +116,8 @@ it never appears as a diff against upstream. One run covers the whole clone,
 worktrees included:
 
 ```bash
-printf '/tmp/\n' >> "$(git rev-parse --git-common-dir)/info/exclude"
+ex="$(git rev-parse --git-common-dir)/info/exclude"
+grep -qxF '/tmp/' "$ex" || printf '/tmp/\n' >> "$ex"
 ```
 
 Use `--git-common-dir`, not a literal `.git/info/exclude`: inside a linked
@@ -134,11 +135,18 @@ cp <main-checkout>/flashinfer/_version.py flashinfer/_version.py
 ```
 
 - `flashinfer/include` — `get_include_paths.get_include()` returns
-  `<pkg>/include`. Without the symlink the JIT emits `-isystem /include` and
-  every compile fails with `'flashinfer/attention/aiter/batch_prefill.cuh' file
-  not found`. Create it **relative**: the main checkout's copy may be an
-  absolute symlink into a container mount point (e.g. `-> /fi/include`), which
-  does not resolve on the host or under a different mount.
+  `<pkg>/include`, and the JIT passes that through `.resolve()` into
+  `-isystem`. Both failure modes emit a well-formed flag pointing at a
+  directory that isn't there, so the compile fails with
+  `'flashinfer/attention/aiter/batch_prefill.cuh' file not found` rather than
+  anything naming the include path:
+  - missing entirely → `-isystem <pkg>/include`, a path that does not exist.
+  - copied as an **absolute** symlink into a container mount point
+    (e.g. `-> /fi/include`) → `.resolve()` follows it to `-isystem /fi/include`,
+    which does not exist on the host or under a different mount.
+
+  Create it **relative** (`ln -sfn ../include flashinfer/include`) so it
+  resolves to `<worktree>/include` wherever the tree is mounted.
 - `flashinfer/_version.py` — setuptools-scm generated. Without it,
   `import flashinfer` fails with `ModuleNotFoundError: No module named
   'flashinfer._version'`.

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -94,8 +94,8 @@ Leave the main checkout parked on `amd-integration`. Never switch the main
 checkout to a topic branch.
 
 ```bash
-git worktree add -b <branch> tmp/worktrees/<branch> origin/amd-integration  # new branch
-git worktree add tmp/worktrees/<branch> <branch>                            # existing branch
+mkdir -p tmp/worktrees && git worktree add -b <branch-name> tmp/worktrees/<branch-name> origin/amd-integration  # new branch
+mkdir -p tmp/worktrees && git worktree add tmp/worktrees/<branch-name> <branch-name>                            # existing branch
 ```
 
 Why this is the rule and not a preference:

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -130,9 +130,16 @@ Two gitignored, generated files must be recreated or the JIT will not build:
 
 ```bash
 cd tmp/worktrees/<branch-name>
-ln -sfn ../include flashinfer/include        # MUST be relative
+rm -rf flashinfer/include                    # -f alone will not clear a real dir
+ln -s ../include flashinfer/include          # MUST be relative
 cp <main-checkout>/flashinfer/_version.py flashinfer/_version.py
 ```
+
+Clear the path first. `-f` replaces a dangling or stale *symlink*, but against
+a real directory `ln` silently creates `flashinfer/include/include` **inside**
+it and exits 0 — leaving a broken tree with no error to go on. Deleting
+`flashinfer/include` is safe: it is gitignored and generated, and the real
+headers live in `include/` at the repo root.
 
 - `flashinfer/include` — `get_include_paths.get_include()` returns
   `<pkg>/include`, and the JIT passes that through `.resolve()` into
@@ -145,8 +152,8 @@ cp <main-checkout>/flashinfer/_version.py flashinfer/_version.py
     (e.g. `-> /fi/include`) → `.resolve()` follows it to `-isystem /fi/include`,
     which does not exist on the host or under a different mount.
 
-  Create it **relative** (`ln -sfn ../include flashinfer/include`) so it
-  resolves to `<worktree>/include` wherever the tree is mounted.
+  Create it **relative** so it resolves to `<worktree>/include` wherever the
+  tree is mounted.
 - `flashinfer/_version.py` — setuptools-scm generated. Without it,
   `import flashinfer` fails with `ModuleNotFoundError: No module named
   'flashinfer._version'`.

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -103,13 +103,20 @@ no `mkdir -p` is needed on a fresh clone.
 
 Why this is the rule and not a preference:
 
-- The main checkout holds the editable install, `~/.cache/flashinfer` build
-  artifacts, and compiled extensions. Switching it between branches invalidates
-  them and produces confusing stale-binary failures.
+- The main checkout owns the editable install and the in-tree compiled
+  extensions. Switching it between branches invalidates them and produces
+  confusing stale-binary failures.
 - Multiple PRs are usually in flight at once. Worktrees keep them physically
   separate, so an unrelated in-progress edit cannot leak into a PR.
 - `amd-integration` staying pristine is what makes the `git reset --hard`
   recovery above safe.
+
+The JIT cache is the one thing worktrees do **not** isolate. It lives outside
+the repo at `$HOME/.cache/flashinfer/<version>/<arch>` (rooted at
+`FLASHINFER_WORKSPACE_BASE` if set) and is keyed by version and arch only — no
+branch or checkout path — so every worktree shares one cache. Clear it with
+`rm -rf ~/.cache/flashinfer/`, or point `FLASHINFER_WORKSPACE_BASE` somewhere
+per-branch, when comparing kernel changes across branches.
 
 Exclude the worktree root **per-clone** rather than in a tracked ignore file, so
 it never appears as a diff against upstream. One run covers the whole clone,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,21 @@ followed by `git reset --hard origin/amd-integration` to restore
 an abort condition too.
 Full procedure: `pr-workflow` skill.
 
+## CRITICAL: work in a git worktree
+
+Do branch work in a worktree at `tmp/worktrees/<branch-name>` and leave the main
+checkout on `amd-integration`. Never switch the main checkout to a topic branch —
+it owns the editable install and build artifacts, and switching it produces
+stale-binary failures.
+
+```bash
+git worktree add -b <branch> tmp/worktrees/<branch> origin/amd-integration
+```
+
+A fresh worktree is source-only: recreate `flashinfer/include` (as a **relative**
+symlink, `ln -sfn ../include flashinfer/include`) and copy `flashinfer/_version.py`
+from the main checkout, or the JIT will not build. Details: `pr-workflow` skill.
+
 ## Essential Commands
 
 | Task | Command |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ it owns the editable install and build artifacts, and switching it produces
 stale-binary failures.
 
 ```bash
-mkdir -p tmp/worktrees && git worktree add -b <branch-name> tmp/worktrees/<branch-name> origin/amd-integration
+git worktree add -b <branch-name> tmp/worktrees/<branch-name> origin/amd-integration
 ```
 
 A fresh worktree is source-only: recreate `flashinfer/include` (as a **relative**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,11 @@ stale-binary failures.
 git worktree add -b <branch-name> tmp/worktrees/<branch-name> origin/amd-integration
 ```
 
-A fresh worktree is source-only: recreate `flashinfer/include` (as a **relative**
-symlink, `ln -sfn ../include flashinfer/include`) and copy `flashinfer/_version.py`
-from the main checkout, or the JIT will not build. Details: `pr-workflow` skill.
+A fresh worktree is source-only: recreate `flashinfer/include` as a **relative**
+symlink (`rm -rf flashinfer/include && ln -s ../include flashinfer/include` — the
+`rm` matters, since `ln -f` will not clear a real directory) and copy
+`flashinfer/_version.py` from the main checkout, or the JIT will not build.
+Details: `pr-workflow` skill.
 
 ## Essential Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ it owns the editable install and build artifacts, and switching it produces
 stale-binary failures.
 
 ```bash
-git worktree add -b <branch> tmp/worktrees/<branch> origin/amd-integration
+mkdir -p tmp/worktrees && git worktree add -b <branch-name> tmp/worktrees/<branch-name> origin/amd-integration
 ```
 
 A fresh worktree is source-only: recreate `flashinfer/include` (as a **relative**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ A fresh worktree is source-only: recreate `flashinfer/include` as a **relative**
 symlink (`rm -rf flashinfer/include && ln -s ../include flashinfer/include` — the
 `rm` matters, since `ln -f` will not clear a real directory) and copy
 `flashinfer/_version.py` from the main checkout, or the JIT will not build.
+`_version.py` only exists there once that checkout has been installed or built.
 Details: `pr-workflow` skill.
 
 ## Essential Commands


### PR DESCRIPTION
## Summary

Branch work must happen in a git worktree under `tmp/worktrees/<branch>`, with the main checkout parked on `amd-integration`. This was an unwritten convention; this PR states it in `CLAUDE.md` and puts the full procedure in the `pr-workflow` skill.

### What changed

- **`CLAUDE.md`** — a short "work in a git worktree" section next to the existing PR-target rules, pointing at the skill for detail.
- **`.claude/skills/pr-workflow/SKILL.md`** — the full procedure: why the rule exists, the per-clone `info/exclude` setup, and the two generated files a fresh worktree needs.

### Architecture / design notes

The main checkout owns the editable install and the compiled extensions. Switching it between branches invalidates them and surfaces later as confusing stale-binary failures that look like code bugs. Multiple PRs are typically in flight at once, and worktrees keep them physically separate so an unrelated in-progress edit cannot leak into a PR. Keeping `amd-integration` pristine is also what makes the `git reset --hard origin/amd-integration` recovery already documented in the skill safe to run.

Two gitignored, generated files must be recreated before the JIT will build in a fresh worktree. `flashinfer/include` must be a **relative** symlink: the main checkout's copy can be an absolute symlink into a container mount point (e.g. `-> /fi/include`) that does not resolve on the host or under a different mount, and without a working symlink the JIT emits `-isystem /include` and every compile fails on a missing header. `flashinfer/_version.py` is setuptools-scm generated, and without it `import flashinfer` fails with `ModuleNotFoundError`.

The `info/exclude` line uses `git rev-parse --git-common-dir` rather than a literal `.git/info/exclude`, because inside a linked worktree `.git` is a file pointing at the real git dir and the literal path fails with `not a directory`.

### CDNA3 impact

None — documentation only, no library code.

## Test plan

- [x] `pre-commit run -a` (markdownlint included)
- Documentation only; no runtime surface to exercise.