### PR TITLE
refactor(rocm): single source of truth for GPU arch normalization

### DIFF
--- a/flashinfer/aiter_utils.py
+++ b/flashinfer/aiter_utils.py
@@ -6,6 +6,7 @@ import functools
 
 import torch
 
+from .arch_caps import normalize_arch
 from .hip_utils import FLASHINFER_SUPPORTED_ROCM_ARCHS
 
 
@@ -15,7 +16,7 @@ def is_aiter_supported(device: torch.device) -> bool:
     if torch.version.hip is None:
         return False
     try:
-        arch = torch.cuda.get_device_properties(device).gcnArchName.split(":")[0]
+        arch = normalize_arch(torch.cuda.get_device_properties(device).gcnArchName)
     except Exception:
         return False
     return arch in FLASHINFER_SUPPORTED_ROCM_ARCHS

--- a/flashinfer/arch_caps.py
+++ b/flashinfer/arch_caps.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-architecture capability knowledge for the ROCm backends.
+
+This module owns *which architectures are validated for which operations*.
+That is deliberately distinct from :mod:`flashinfer.hip_utils`, which owns
+*which architectures we compile for*, and from :mod:`flashinfer.aiter_utils`,
+which owns *whether the AITER package is importable*.
+
+.. important::
+   Do not add a module-level ``import torch``; keep every torch import
+   function-local.
+
+   ``hip_utils`` imports this module at module scope, and ``hip_utils`` is used
+   very early -- ``tests/conftest.py`` calls it to pick a GPU *before* pinning
+   ``HIP_VISIBLE_DEVICES``, and it must do so without touching the HIP runtime
+   (hence its use of ``rocminfo`` rather than ``torch.cuda``). Staying torch-free
+   is what keeps this module usable on that path.
+"""
+
+__all__ = ["normalize_arch"]
+
+
+def normalize_arch(gcn_arch_name: str) -> str:
+    """Strip ROCm feature qualifiers from a GPU architecture name.
+
+    ROCm reports architectures with trailing feature flags, e.g. torch's
+    ``gcnArchName`` yields ``"gfx942:sramecc+:xnack-"``. Comparisons against
+    :data:`~flashinfer.hip_utils.FLASHINFER_SUPPORTED_ROCM_ARCHS` need the bare
+    ``"gfx942"``.
+
+    This is the single place that transformation happens. It replaces several
+    open-coded variants that did not agree; notably a ``re.match(r"(gfx\\d+)")``
+    form that truncated letter-suffixed architectures (``gfx90a`` -> ``gfx90``),
+    naming an architecture that does not exist.
+
+    Args:
+        gcn_arch_name: An architecture name, with or without qualifiers.
+
+    Returns:
+        The architecture without qualifiers, e.g. ``"gfx942"``. Input that
+        contains no qualifier is returned unchanged (modulo surrounding
+        whitespace), so this is safe to apply to already-normalized values.
+    """
+    return gcn_arch_name.split(":", 1)[0].strip()

--- a/flashinfer/compilation_context_hip.py
+++ b/flashinfer/compilation_context_hip.py
@@ -23,6 +23,7 @@ import os
 import torch
 
 from . import hip_utils
+from .arch_caps import normalize_arch
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +75,7 @@ class CompilationContext:
             indices = hip_utils.get_supported_device_indices()
             if indices:
                 archs = {
-                    torch.cuda.get_device_properties(i).gcnArchName.split(":")[0]
+                    normalize_arch(torch.cuda.get_device_properties(i).gcnArchName)
                     for i in indices
                 }
                 return ",".join(sorted(archs))

--- a/flashinfer/hip_utils.py
+++ b/flashinfer/hip_utils.py
@@ -4,6 +4,11 @@
 
 import functools
 
+# arch_caps imports nothing (in particular, not torch), so importing it here
+# keeps this module safe to import before the HIP runtime starts -- which
+# tests/conftest.py relies on to set HIP_VISIBLE_DEVICES first.
+from .arch_caps import normalize_arch
+
 # AMDGPU archs supported by amd-flashinfer
 FLASHINFER_SUPPORTED_ROCM_ARCHS = ["gfx942", "gfx950"]
 
@@ -421,7 +426,11 @@ def get_supported_device_indices() -> tuple:
     def _commit():
         nonlocal gpu_index
         if current_is_gpu:
-            if current_name in FLASHINFER_SUPPORTED_ROCM_ARCHS:
+            # rocminfo's agent-level "Name:" is normally bare ("gfx942"), but
+            # normalize defensively: an unstripped qualifier here would drop
+            # every GPU from the supported list, and callers would silently
+            # fall back to the default architecture.
+            if normalize_arch(current_name or "") in FLASHINFER_SUPPORTED_ROCM_ARCHS:
                 supported.append(gpu_index)
             gpu_index += 1
 

--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -23,6 +23,7 @@ import os
 import pathlib
 import re
 
+from ..arch_caps import normalize_arch
 from ..device_utils import IS_CUDA, IS_HIP
 
 
@@ -210,11 +211,13 @@ elif IS_HIP:
 
             props = torch.cuda.get_device_properties(torch.cuda.current_device())
             gcn_arch = props.gcnArchName
-            # Extract gfx arch (e.g., "gfx942:sramecc+:xnack-" -> "gfx942")
-            match = re.match(r"(gfx\d+)", gcn_arch)
-            if match:
-                arch = match.group(1)
-            else:
+            # Extract gfx arch (e.g., "gfx942:sramecc+:xnack-" -> "gfx942").
+            # The `gfx\d` guard only checks that this *looks* like an
+            # architecture name before trusting it; the value itself comes from
+            # normalize_arch, which keeps letter suffixes ("gfx90a") that the
+            # previous `(gfx\d+)` capture silently truncated to "gfx90".
+            arch = normalize_arch(gcn_arch)
+            if not re.match(r"gfx\d", arch):
                 from torch.utils.cpp_extension import _get_rocm_arch_flags
 
                 flags = _get_rocm_arch_flags()

--- a/flashinfer/mla_rocm.py
+++ b/flashinfer/mla_rocm.py
@@ -11,6 +11,7 @@ from typing import Optional, Tuple, Union
 import torch
 
 from .aiter_utils import is_aiter_supported
+from .arch_caps import normalize_arch
 
 
 @functools.cache
@@ -63,7 +64,7 @@ def _kv_lens_to_last_page_len_cpu(
 def _require_aiter_mla(device: torch.device) -> None:
     if not is_aiter_supported(device):
         try:
-            arch = torch.cuda.get_device_properties(device).gcnArchName.split(":")[0]
+            arch = normalize_arch(torch.cuda.get_device_properties(device).gcnArchName)
         except Exception:
             arch = "unknown"
         raise RuntimeError(f"AITER MLA requires a gfx942/gfx950 GPU; got '{arch}'.")

--- a/flashinfer/prefill_rocm.py
+++ b/flashinfer/prefill_rocm.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Union, overload
 
 import torch
 from .aiter_utils import is_aiter_supported
+from .arch_caps import normalize_arch
 from .jit.core import logger
 from .jit import (
     gen_batch_prefill_module,
@@ -312,7 +313,7 @@ def _require_aiter_runtime(device: torch.device) -> None:
     if not is_aiter_supported(device):
         try:
             arch = (
-                torch.cuda.get_device_properties(device).gcnArchName.split(":")[0]
+                normalize_arch(torch.cuda.get_device_properties(device).gcnArchName)
                 if torch.version.hip
                 else "non-ROCm"
             )

--- a/tests/rocm_tests/test_arch_caps_hip.py
+++ b/tests/rocm_tests/test_arch_caps_hip.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for flashinfer.arch_caps.
+
+Deliberately GPU-free: every assertion here holds on any machine, so this file
+protects the architectures we cannot physically test against as well as the one
+we can.
+"""
+
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+from flashinfer import arch_caps
+from flashinfer.arch_caps import normalize_arch
+
+
+class TestNormalizeArch:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            # The forms torch's gcnArchName actually produces.
+            ("gfx942:sramecc+:xnack-", "gfx942"),
+            ("gfx950:sramecc+:xnack-", "gfx950"),
+            # Already-normalized input must round-trip, so the helper is safe to
+            # apply twice.
+            ("gfx942", "gfx942"),
+            ("gfx950", "gfx950"),
+            # A single qualifier, and one with no value.
+            ("gfx942:xnack-", "gfx942"),
+            ("gfx90a:sramecc+", "gfx90a"),
+        ],
+    )
+    def test_strips_qualifiers(self, raw, expected):
+        assert normalize_arch(raw) == expected
+
+    @pytest.mark.parametrize("arch", ["gfx90a", "gfx1201", "gfx1100"])
+    def test_preserves_letter_suffixes_and_four_digit_archs(self, arch):
+        """Regression: the previous ``re.match(r"(gfx\\d+)")`` form truncated
+        ``gfx90a`` to ``gfx90``, naming an architecture that does not exist."""
+        assert normalize_arch(arch) == arch
+
+    def test_strips_surrounding_whitespace(self):
+        assert normalize_arch("  gfx942  ") == "gfx942"
+
+    @pytest.mark.parametrize("raw", ["", "   ", ":"])
+    def test_degenerate_input_does_not_raise(self, raw):
+        """Callers gate on the result rather than on an exception, so empty
+        input must come back empty instead of blowing up."""
+        assert normalize_arch(raw) == ""
+
+
+def test_module_does_not_import_torch():
+    """arch_caps.py must not import torch.
+
+    hip_utils imports this module at module scope, and hip_utils is imported
+    early -- tests/conftest.py uses it to choose a GPU *before* pinning
+    HIP_VISIBLE_DEVICES. Keeping this module torch-free is what lets it sit on
+    that path without dragging torch into it.
+
+    The module is loaded directly from its file rather than as
+    ``flashinfer.arch_caps``, because importing anything from the package runs
+    flashinfer/__init__.py, which pulls in torch via device_utils. Going through
+    the package would therefore prove nothing about this module. Run in a
+    subprocess so the result does not depend on what this session imported.
+    """
+    module_path = pathlib.Path(arch_caps.__file__).resolve()
+    code = f"""
+import importlib.util, sys
+assert "torch" not in sys.modules, "torch preloaded; test would be meaningless"
+spec = importlib.util.spec_from_file_location("_arch_caps_isolated", r"{module_path}")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+assert mod.normalize_arch("gfx950:sramecc+:xnack-") == "gfx950"
+assert "torch" not in sys.modules, "arch_caps.py imported torch"
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=60
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Introduces `flashinfer/arch_caps.py` with a single `normalize_arch()` helper and adopts it at the six sites that strip ROCm architecture qualifiers, replacing several open-coded variants that did not agree with each other.

Split into two commits so the risk is visible: the first is a **pure substitution** (identical output for every input), the second isolates the two sites where behaviour genuinely changes.

## Why

ROCm reports architectures with trailing feature flags (`"gfx942:sramecc+:xnack-"`), so every consumer comparing against `FLASHINFER_SUPPORTED_ROCM_ARCHS` must strip them first. That transformation was open-coded in several places, and two variants were wrong:

- **`jit/env.py`** matched `re.match(r"(gfx\d+)", gcn_arch)`, whose capture group stops at the first non-digit. On a letter-suffixed architecture this yields `"gfx90"` from `"gfx90a"` — an architecture that does not exist — which then fails the supported-arch check and reports the truncated name in the error.
- **`hip_utils.get_supported_device_indices()`** compared rocminfo's agent-level `Name:` against the supported list with **no normalization at all**. That field is normally bare (`"gfx942"`), so this is defensive rather than a live bug — but had a ROCm build ever emitted a qualifier there, every GPU would have dropped out of the supported list and callers would have silently fallen back to the default architecture.

Divergent resolvers disagreeing about what architecture a device is is the root cause behind several open arch-handling issues, so this consolidates the primitive first.

## Design note

`arch_caps.py` is where the per-op/per-arch capability model will live. It deliberately imports nothing — torch included — because `hip_utils` imports it at module scope, and `hip_utils` is used very early: `tests/conftest.py` calls it to pick a GPU *before* pinning `HIP_VISIBLE_DEVICES`, and must do so without touching the HIP runtime (hence its use of `rocminfo` rather than `torch.cuda`).

A test enforces this by loading the module straight from its file path. Going through `flashinfer.arch_caps` would prove nothing, since importing anything from the package runs `flashinfer/__init__.py`, which pulls in torch via `device_utils`.

## CDNA3 impact

**None.** Every touched site returns byte-identical results on gfx942:

- The four substitution sites return exactly what `.split(":")[0]` returned.
- gfx942 has no letter suffix, so the `env.py` capture already produced `"gfx942"`.
- rocminfo reports `"gfx942"` bare, which normalizes to itself.

The behaviour change is confined to letter-suffixed architectures (`gfx90a`) and to qualifier-bearing rocminfo output, neither of which occurs on CDNA3 or CDNA4.

## Test plan

Verified on an MI350X (gfx950), ROCm 7.2.0, torch 2.9.1+rocm7.2.0:

- [x] `pytest tests/rocm_tests/test_arch_caps_hip.py tests/rocm_tests/test_hip_utils.py` — 83 passed.
- [x] `test_hip_utils.py` passes **unchanged**, including `test_defaults_to_gfx942_*`, which pin the gfx942 default.
- [x] New `tests/rocm_tests/test_arch_caps_hip.py` is GPU-free, so it protects architectures we cannot physically test as well as the one we can.
- [x] Live device check: `gcnArchName='gfx950:sramecc+:xnack-'` normalizes to `'gfx950'`; rocminfo detection still returns `(0,)`; `is_aiter_supported` still True.
- [x] `pre-commit run -a` — all 17 hooks pass.
