### PR TITLE
fix(aiter): build the AITER shim for the device's own architecture

### DIFF
--- a/flashinfer/jit/aiter_source.py
+++ b/flashinfer/jit/aiter_source.py
@@ -24,7 +24,83 @@ import shutil
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
+from ..arch_caps import normalize_arch
 from . import env as jit_env
+from .core import logger
+
+
+_DEFAULT_BUILD_ARCH = "gfx942"
+
+
+def _env_arch_list() -> List[str]:
+    """FLASHINFER_ROCM_ARCH_LIST as a normalized list, accepting ',' or ';'."""
+    import re
+
+    raw = os.environ.get("FLASHINFER_ROCM_ARCH_LIST", "")
+    return [normalize_arch(a) for a in re.split(r"[;,]", raw) if a.strip()]
+
+
+def _detected_device_arch() -> Optional[str]:
+    """The running device's architecture, or None if no GPU is visible.
+
+    torch is imported lazily: this module is imported during JIT setup, and a
+    GPU-less wheel build must not require a working HIP runtime.
+    """
+    try:
+        import torch
+
+        if torch.cuda.device_count() == 0:
+            return None
+        props = torch.cuda.get_device_properties(torch.cuda.current_device())
+        return normalize_arch(props.gcnArchName)
+    except Exception:
+        return None
+
+
+@functools.lru_cache(maxsize=1)
+def resolve_aiter_build_arch() -> str:
+    """Return the **single** GPU architecture to build the AITER shim for.
+
+    Deliberately one architecture, never a list. AITER's ``get_gfx()`` resolves
+    to the *last* ``GPU_ARCHS`` entry rather than the running device, so a
+    multi-arch value makes AITER's Python-level dispatch believe it is on that
+    architecture no matter what the hardware is -- and it also flips global
+    compile flags. One entry makes that failure mode unreachable.
+
+    Resolution order: ``FLASHINFER_ROCM_ARCH_LIST`` -> detected device ->
+    ``gfx942``. When the environment names several architectures, the running
+    device's is preferred among them; when the environment names architectures
+    that exclude the running device, the environment still wins (cross-compiling
+    is legitimate) but the mismatch is reported, because the resulting shim will
+    fault on this machine.
+    """
+    env_archs = _env_arch_list()
+    device_arch = _detected_device_arch()
+
+    if env_archs:
+        if device_arch and device_arch in env_archs:
+            return device_arch
+        if device_arch:
+            logger.warning(
+                "FLASHINFER_ROCM_ARCH_LIST=%s does not include this device's "
+                "architecture (%s); building the AITER shim for %s. It will not "
+                "run on this GPU.",
+                ",".join(env_archs),
+                device_arch,
+                env_archs[0],
+            )
+        return env_archs[0]
+
+    if device_arch:
+        return device_arch
+
+    logger.warning(
+        "No ROCm device detected and FLASHINFER_ROCM_ARCH_LIST is unset; "
+        "building the AITER shim for %s. Set FLASHINFER_ROCM_ARCH_LIST to "
+        "target a different architecture.",
+        _DEFAULT_BUILD_ARCH,
+    )
+    return _DEFAULT_BUILD_ARCH
 
 
 def _aiter_cache_tag() -> str:
@@ -34,9 +110,11 @@ def _aiter_cache_tag() -> str:
     on a machine with a different arch. Without the version component, an AITER
     upgrade (which can change the C++ ABI the FlashInfer shim links against) would
     silently reuse the stale .so. The FlashInfer JIT dir already keys by its own
-    version+arch, but this cache sits outside it."""
-    arch = os.environ.get("FLASHINFER_ROCM_ARCH_LIST", "gfx942").replace(";", ",")
-    arch = arch.replace(",", "_")
+    version+arch, but this cache sits outside it.
+
+    Keyed on the *resolved* architecture -- the one actually compiled for -- so
+    the tag cannot disagree with the contents of the directory it names."""
+    arch = resolve_aiter_build_arch()
     try:
         import importlib.metadata as _md
 
@@ -90,7 +168,6 @@ def ensure_aiter_lib(module_name: str) -> Path:
     # AITER reads these from the environment at build time.
     from ..hip_utils import get_rocm_home
 
-    arch_list = os.environ.get("FLASHINFER_ROCM_ARCH_LIST", "gfx942")
     prev = {
         "AITER_SYMBOL_VISIBLE": os.environ.get("AITER_SYMBOL_VISIBLE"),
         "AITER_JIT_DIR": os.environ.get("AITER_JIT_DIR"),
@@ -99,7 +176,11 @@ def ensure_aiter_lib(module_name: str) -> Path:
     }
     os.environ["AITER_SYMBOL_VISIBLE"] = "1"
     os.environ["AITER_JIT_DIR"] = str(aiter_build_dir)
-    os.environ["GPU_ARCHS"] = arch_list.replace(";", ",")
+    # AITER splits GPU_ARCHS on ';' and validates each entry, so a comma-joined
+    # list reaches it as one unparseable token. A single architecture sidesteps
+    # the separator entirely -- and is required regardless; see
+    # resolve_aiter_build_arch.
+    os.environ["GPU_ARCHS"] = resolve_aiter_build_arch()
     os.environ["ROCM_HOME"] = get_rocm_home()
 
     built: Optional[Path] = None

--- a/flashinfer/jit/aiter_source.py
+++ b/flashinfer/jit/aiter_source.py
@@ -20,6 +20,7 @@ hands back the include/link flags for ``gen_jit_spec``.
 
 import functools
 import os
+import re
 import shutil
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
@@ -31,20 +32,47 @@ from .core import logger
 
 _DEFAULT_BUILD_ARCH = "gfx942"
 
+# An architecture name and nothing else: "gfx942", "gfx950", "gfx90a". Anchored
+# so a token that merely starts with "gfx" cannot smuggle in a path separator.
+_ARCH_RE = re.compile(r"^gfx[0-9a-f]+$")
+
 
 def _env_arch_list() -> List[str]:
     """FLASHINFER_ROCM_ARCH_LIST as a normalized list, accepting ',' or ';'.
 
-    Tokens are dropped *after* normalization, not before. A token that is all
-    qualifier and no architecture (``":sramecc+"``, or a bare ``":"``) is
-    non-empty as written but normalizes to ``""``, which would otherwise become
-    the build architecture and name a cache directory ``__aiter-<version>``.
-    """
-    import re
+    Tokens are checked *after* normalization, and anything that is not an
+    architecture name is dropped with a warning. Two reachable reasons, both of
+    which end up naming a directory:
 
+    - A token that is all qualifier and no architecture (``":sramecc+"``, or a
+      bare ``":"``) is non-empty as written but normalizes to ``""``, which
+      would become the build architecture and name a cache directory
+      ``__aiter-<version>``.
+    - An arbitrary string reaches that same directory name, so ``"../../tmp"``
+      escapes the cache root once the tag is joined onto it.
+
+    ``validate_rocm_arch`` already rejects such a token for the main JIT, but it
+    only *warns and excludes* unless every entry is bad -- so in a mixed list the
+    bad entry survives to here.
+
+    Empty tokens are dropped silently: a trailing separator is benign, not a typo
+    worth reporting.
+    """
     raw = os.environ.get("FLASHINFER_ROCM_ARCH_LIST", "")
-    archs = (normalize_arch(a) for a in re.split(r"[;,]", raw))
-    return [a for a in archs if a]
+    archs = []
+    for token in re.split(r"[;,]", raw):
+        arch = normalize_arch(token)
+        if not arch:
+            continue
+        if not _ARCH_RE.match(arch):
+            logger.warning(
+                "Ignoring %r in FLASHINFER_ROCM_ARCH_LIST: not a GPU architecture "
+                "name (expected e.g. 'gfx942').",
+                token,
+            )
+            continue
+        archs.append(arch)
+    return archs
 
 
 def _detected_device_arch() -> Optional[str]:
@@ -122,6 +150,18 @@ def _aiter_cache_tag() -> str:
     Keyed on the *resolved* architecture -- the one actually compiled for -- so
     the tag cannot disagree with the contents of the directory it names."""
     arch = resolve_aiter_build_arch()
+    # The tag is joined onto the cache root to create a directory, so
+    # "filesystem-safe" above has to be enforced, not just asserted in prose.
+    # _env_arch_list already rejects anything that is not an architecture name;
+    # this keeps the guarantee true for the other two sources of `arch` (the
+    # device probe and the default) and for any future caller. Loud rather than
+    # silently sanitized: an arch that needs rewriting means the resolver is
+    # wrong, and a quietly renamed cache directory would hide that.
+    if not arch or arch != Path(arch).name or arch.startswith("."):
+        raise ValueError(
+            f"refusing to build a cache directory name from architecture "
+            f"{arch!r}: not a single safe path component"
+        )
     try:
         import importlib.metadata as _md
 

--- a/flashinfer/jit/aiter_source.py
+++ b/flashinfer/jit/aiter_source.py
@@ -33,11 +33,18 @@ _DEFAULT_BUILD_ARCH = "gfx942"
 
 
 def _env_arch_list() -> List[str]:
-    """FLASHINFER_ROCM_ARCH_LIST as a normalized list, accepting ',' or ';'."""
+    """FLASHINFER_ROCM_ARCH_LIST as a normalized list, accepting ',' or ';'.
+
+    Tokens are dropped *after* normalization, not before. A token that is all
+    qualifier and no architecture (``":sramecc+"``, or a bare ``":"``) is
+    non-empty as written but normalizes to ``""``, which would otherwise become
+    the build architecture and name a cache directory ``__aiter-<version>``.
+    """
     import re
 
     raw = os.environ.get("FLASHINFER_ROCM_ARCH_LIST", "")
-    return [normalize_arch(a) for a in re.split(r"[;,]", raw) if a.strip()]
+    archs = (normalize_arch(a) for a in re.split(r"[;,]", raw))
+    return [a for a in archs if a]
 
 
 def _detected_device_arch() -> Optional[str]:

--- a/tests/rocm_tests/test_aiter_build_arch_hip.py
+++ b/tests/rocm_tests/test_aiter_build_arch_hip.py
@@ -16,10 +16,12 @@ from flashinfer.jit import aiter_source
 
 @pytest.fixture(autouse=True)
 def _clear_resolver_cache():
-    """resolve_aiter_build_arch is lru_cached; each case needs a clean slate."""
-    aiter_source.resolve_aiter_build_arch.cache_clear()
+    """These are lru_cached; each case needs a clean slate."""
+    for fn in (aiter_source.resolve_aiter_build_arch, aiter_source._aiter_libs_dir):
+        fn.cache_clear()
     yield
-    aiter_source.resolve_aiter_build_arch.cache_clear()
+    for fn in (aiter_source.resolve_aiter_build_arch, aiter_source._aiter_libs_dir):
+        fn.cache_clear()
 
 
 @pytest.fixture
@@ -126,6 +128,53 @@ class TestResolveBuildArch:
         device_arch("gfx950")
         assert "" not in aiter_source._env_arch_list()
         assert aiter_source.resolve_aiter_build_arch() in ("gfx942", "gfx950")
+
+    @pytest.mark.parametrize(
+        "env", ["../../tmp", "..", "garbage", "../../tmp,gfx942", "gfx942,/etc"]
+    )
+    def test_non_architecture_tokens_are_dropped(
+        self, monkeypatch, device_arch, env, warnings_logged
+    ):
+        """The resolved arch names a cache directory, so an arbitrary string
+        escapes the cache root: '../../tmp,gfx942' created
+        ``<cache>/aiter_libs/../../tmp/pwned__aiter-0.1.10``.
+
+        Upstream validate_rocm_arch warns and excludes such a token but only
+        raises when *every* entry is bad, so a mixed list still reached here.
+        """
+        monkeypatch.setenv("FLASHINFER_ROCM_ARCH_LIST", env)
+        device_arch("gfx950")
+        assert all(a.startswith("gfx") for a in aiter_source._env_arch_list())
+        assert aiter_source.resolve_aiter_build_arch() in ("gfx942", "gfx950")
+        assert any("not a GPU architecture" in w for w in warnings_logged)
+
+
+class TestCacheTagIsAPathComponent:
+    """The tag is joined onto the cache root, so it must stay one component."""
+
+    @pytest.mark.parametrize("arch", ["../../tmp", "..", "a/b", ""])
+    def test_unsafe_resolved_arch_is_refused(self, monkeypatch, arch):
+        """Defense in depth for the resolver's other two sources -- the device
+        probe and the default -- and for future callers. Loud, not sanitized:
+        a silently renamed cache directory would hide the resolver bug."""
+        monkeypatch.setattr(aiter_source, "resolve_aiter_build_arch", lambda: arch)
+        with pytest.raises(ValueError, match="safe path component"):
+            aiter_source._aiter_cache_tag()
+
+    def test_libs_dir_stays_under_the_cache_root(
+        self, monkeypatch, device_arch, tmp_path
+    ):
+        """End to end: the traversal that this guards against created a real
+        directory outside the cache root before the fix."""
+        from flashinfer.jit import env as jit_env
+
+        monkeypatch.setattr(jit_env, "FLASHINFER_CACHE_DIR", tmp_path)
+        monkeypatch.setenv("FLASHINFER_ROCM_ARCH_LIST", "../../tmp,gfx942")
+        device_arch("gfx950")
+
+        libs_dir = aiter_source._aiter_libs_dir().resolve()
+        assert (tmp_path / "aiter_libs").resolve() in libs_dir.parents
+        assert list(tmp_path.parent.glob("tmp*__aiter-*")) == []
 
 
 class TestCacheTag:

--- a/tests/rocm_tests/test_aiter_build_arch_hip.py
+++ b/tests/rocm_tests/test_aiter_build_arch_hip.py
@@ -174,7 +174,6 @@ class TestCacheTagIsAPathComponent:
 
         libs_dir = aiter_source._aiter_libs_dir().resolve()
         assert (tmp_path / "aiter_libs").resolve() in libs_dir.parents
-        assert list(tmp_path.parent.glob("tmp*__aiter-*")) == []
 
 
 class TestCacheTag:

--- a/tests/rocm_tests/test_aiter_build_arch_hip.py
+++ b/tests/rocm_tests/test_aiter_build_arch_hip.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for AITER shim build-architecture resolution.
+
+GPU-free by construction: the device probe is monkeypatched, so both CDNA3 and
+CDNA4 behaviour is exercised on whichever card happens to be present -- including
+the architecture the host does not have.
+"""
+
+import pytest
+
+from flashinfer.jit import aiter_source
+
+
+@pytest.fixture(autouse=True)
+def _clear_resolver_cache():
+    """resolve_aiter_build_arch is lru_cached; each case needs a clean slate."""
+    aiter_source.resolve_aiter_build_arch.cache_clear()
+    yield
+    aiter_source.resolve_aiter_build_arch.cache_clear()
+
+
+@pytest.fixture
+def warnings_logged(monkeypatch):
+    """Capture logger.warning calls from this module.
+
+    caplog cannot see them: FlashInferJITLogger does not propagate to the root
+    logger, so intercepting the call is both simpler and independent of how
+    logging happens to be configured.
+    """
+    recorded = []
+
+    def _warn(msg, *args, **kwargs):
+        recorded.append(msg % args if args else msg)
+
+    monkeypatch.setattr(aiter_source.logger, "warning", _warn)
+    return recorded
+
+
+@pytest.fixture
+def device_arch(monkeypatch):
+    """Pretend the machine has a given architecture (or none)."""
+
+    def _set(arch):
+        monkeypatch.setattr(aiter_source, "_detected_device_arch", lambda: arch)
+
+    return _set
+
+
+class TestResolveBuildArch:
+    @pytest.mark.parametrize("arch", ["gfx942", "gfx950"])
+    def test_follows_the_device_when_env_unset(self, monkeypatch, device_arch, arch):
+        """The bug this fixes: an unset env built for a hardcoded gfx942 on any
+        machine, so a gfx950 host silently produced CDNA3 code objects."""
+        monkeypatch.delenv("FLASHINFER_ROCM_ARCH_LIST", raising=False)
+        device_arch(arch)
+        assert aiter_source.resolve_aiter_build_arch() == arch
+
+    def test_defaults_when_no_device_and_no_env(self, monkeypatch, device_arch):
+        """GPU-less wheel builds are real, so a last-resort default is kept."""
+        monkeypatch.delenv("FLASHINFER_ROCM_ARCH_LIST", raising=False)
+        device_arch(None)
+        assert aiter_source.resolve_aiter_build_arch() == "gfx942"
+
+    @pytest.mark.parametrize("sep", [",", ";"])
+    @pytest.mark.parametrize("arch", ["gfx942", "gfx950"])
+    def test_multi_arch_env_resolves_to_the_running_device(
+        self, monkeypatch, device_arch, sep, arch
+    ):
+        """Both separators are accepted, and the result is a single architecture.
+
+        AITER splits GPU_ARCHS on ';' -- a comma-joined list reaches it as one
+        unparseable token and it raises. Accept either form from the user.
+        """
+        monkeypatch.setenv("FLASHINFER_ROCM_ARCH_LIST", sep.join(["gfx942", "gfx950"]))
+        device_arch(arch)
+        assert aiter_source.resolve_aiter_build_arch() == arch
+
+    def test_env_wins_but_warns_when_it_excludes_the_device(
+        self, monkeypatch, device_arch, warnings_logged
+    ):
+        """Cross-compiling is legitimate, so the environment is honoured -- but
+        the resulting shim will fault here, so say so."""
+        monkeypatch.setenv("FLASHINFER_ROCM_ARCH_LIST", "gfx942")
+        device_arch("gfx950")
+        assert aiter_source.resolve_aiter_build_arch() == "gfx942"
+        assert any("gfx950" in w for w in warnings_logged), warnings_logged
+
+    def test_no_warning_when_env_matches_the_device(
+        self, monkeypatch, device_arch, warnings_logged
+    ):
+        monkeypatch.setenv("FLASHINFER_ROCM_ARCH_LIST", "gfx942,gfx950")
+        device_arch("gfx950")
+        assert aiter_source.resolve_aiter_build_arch() == "gfx950"
+        assert warnings_logged == []
+
+    def test_result_is_never_a_list(self, monkeypatch, device_arch):
+        """AITER's get_gfx() takes the *last* GPU_ARCHS entry rather than the
+        running device, so more than one entry is never safe to pass."""
+        monkeypatch.setenv("FLASHINFER_ROCM_ARCH_LIST", "gfx942,gfx950")
+        device_arch(None)
+        resolved = aiter_source.resolve_aiter_build_arch()
+        assert "," not in resolved and ";" not in resolved
+        assert resolved in ("gfx942", "gfx950")
+
+    def test_qualifiers_in_env_are_normalized(self, monkeypatch, device_arch):
+        monkeypatch.setenv("FLASHINFER_ROCM_ARCH_LIST", "gfx950:sramecc+:xnack-")
+        device_arch(None)
+        assert aiter_source.resolve_aiter_build_arch() == "gfx950"
+
+
+class TestCacheTag:
+    @pytest.mark.parametrize("arch", ["gfx942", "gfx950"])
+    def test_tag_follows_the_resolved_arch(self, monkeypatch, device_arch, arch):
+        """The tag must name what was actually compiled.
+
+        Previously it re-read the environment independently of the build, so an
+        unset env tagged the directory 'gfx942' on a gfx950 machine -- and that
+        wrong-architecture .so was then reused on every later run.
+        """
+        monkeypatch.delenv("FLASHINFER_ROCM_ARCH_LIST", raising=False)
+        device_arch(arch)
+        assert aiter_source._aiter_cache_tag().startswith(f"{arch}__aiter-")
+
+    def test_tag_is_filesystem_safe(self, monkeypatch, device_arch):
+        monkeypatch.setenv("FLASHINFER_ROCM_ARCH_LIST", "gfx950:sramecc+:xnack-")
+        device_arch(None)
+        tag = aiter_source._aiter_cache_tag()
+        assert not (set(tag) & set("/:;, "))

--- a/tests/rocm_tests/test_aiter_build_arch_hip.py
+++ b/tests/rocm_tests/test_aiter_build_arch_hip.py
@@ -110,6 +110,23 @@ class TestResolveBuildArch:
         device_arch(None)
         assert aiter_source.resolve_aiter_build_arch() == "gfx950"
 
+    @pytest.mark.parametrize("env", [":", ":sramecc+", ":,gfx942", "gfx942,:", ",,"])
+    def test_qualifier_only_tokens_never_become_the_arch(
+        self, monkeypatch, device_arch, env
+    ):
+        """A token that is all qualifier is non-empty as written but normalizes
+        to '', so filtering the raw token is not enough.
+
+        Left unfiltered it is returned verbatim -- ':,gfx942' on a gfx950 host
+        resolved to '' and tagged the cache directory '__aiter-<version>'. The
+        upstream arch validation warns about such a token and drops it rather
+        than raising, so it does reach this resolver.
+        """
+        monkeypatch.setenv("FLASHINFER_ROCM_ARCH_LIST", env)
+        device_arch("gfx950")
+        assert "" not in aiter_source._env_arch_list()
+        assert aiter_source.resolve_aiter_build_arch() in ("gfx942", "gfx950")
+
 
 class TestCacheTag:
     @pytest.mark.parametrize("arch", ["gfx942", "gfx950"])


### PR DESCRIPTION
## Summary

On a gfx950 host with `FLASHINFER_ROCM_ARCH_LIST` unset, the AITER C++ shim builds **CDNA3 code objects and runs them on CDNA4**. Measured on an MI350X: `rmsnorm(backend="aiter")` spends ~42 minutes building `module_rmsnorm` and then **segfaults** — not a clean `hipErrorNoBinaryForGpu`, a core dump with no diagnostic.

Reduced to a minimal case on the same box:

```
$ hipcc --offload-arch=gfx942 -o a a.hip && ./a
Segmentation fault (core dumped)        # exit 139

$ llvm-objdump --offloading a
Extracting offload bundle: a.0.hipv4-amdgcn-amd-amdhsa--gfx942     # only bundle
```

So torch's own `--offload-arch` does **not** rescue it — this was the open question, and the answer is the bad one.

## Root cause

`aiter_source.py` resolved `GPU_ARCHS` by reading `FLASHINFER_ROCM_ARCH_LIST` with a hardcoded `"gfx942"` default and **no device detection**, bypassing `CompilationContext` entirely. The main JIT compiled for gfx950 while the AITER library it links against was gfx942.

The cache tag was derived the same way, so the wrong-architecture `.so` was cached under a directory literally named `gfx942__aiter-0.1.10` **on a gfx950 machine** — and reused on every subsequent run.

Four README features route through this path: RMSNorm, fused-add-RMSNorm, SiLU-and-mul, and RoPE.

## Fix

`resolve_aiter_build_arch()` resolves env → detected device → `gfx942`, and returns **exactly one** architecture.

One entry is a requirement, not a simplification: AITER's `get_gfx()` reads the **last** `GPU_ARCHS` entry rather than the running device, so a multi-arch value makes AITER's Python-level dispatch believe it is on that architecture regardless of the hardware, and flips global compile flags with it.

Passing a single entry also makes the separator bug unreachable. AITER splits `GPU_ARCHS` on `;` while this code joined on `,`, so the setup documented in `CLAUDE.md` (`FLASHINFER_ROCM_ARCH_LIST="gfx942,gfx950"`) reached AITER as one unparseable token and raised `AssertionError` on the first shim build. Both separators are now accepted on input; neither can reach AITER.

Env tokens are validated **after** normalization, and anything that is not an architecture name is dropped with a warning. The resolved architecture names a cache directory, so an unchecked token lands in a path: `":sramecc+"` normalizes to `""` and named a directory `__aiter-<version>`, and `"../../../tmp/pwned"` escaped the cache root outright — `<cache>/aiter_libs/../../../tmp/pwned__aiter-0.1.10`, created on disk.

`validate_rocm_arch` already rejects both, but it only *raises* when every entry is bad; in a mixed list such as `"../../../tmp/pwned,gfx942"` it warns, excludes the bad entry from the main JIT, and the entry still reached this resolver, which re-read the raw environment. `_aiter_cache_tag()` now also refuses an architecture that is not a single safe path component, covering the resolver's other two sources and any future caller — raising rather than sanitizing, since a tag that needs rewriting means the resolver is wrong.

The cache tag is keyed on the **resolved** architecture, so it can no longer disagree with the contents of the directory it names.

A last-resort `gfx942` default is kept, with a warning — GPU-less wheel builds are real (`amd-flashinfer-jit-cache` never sets the env). Cross-compiling still wins over detection, but a mismatch against the running device is reported, because that shim will fault on this machine.

## CDNA3 impact

**None.** On gfx942 the chain resolves to `gfx942` whether the env is set or unset — identical to the previous hardcoded default.

The only inputs whose behaviour changes are a **gfx950 device** (previously mis-built, now correct), a **multi-arch env value** (previously an `AssertionError`, now the device's architecture), and a **malformed env token** (previously an empty architecture or a path, now dropped with a warning).

The tests monkeypatch the device probe and run both architectures parametrized, so **gfx942 resolution is verified on a machine that has no gfx942**.

## Test plan

Verified on MI350X (gfx950), ROCm 7.2.0, torch 2.9.1+rocm7.2.0, amd-aiter 0.1.10:

- [x] With the env unset, the resolver returns `gfx950` and the cache tag is `gfx950__aiter-0.1.10` (was `gfx942__aiter-0.1.10`).
- [x] With `FLASHINFER_ROCM_ARCH_LIST=":,gfx942"` the resolver returned `''` and tagged the cache `__aiter-0.1.10` before the fix; it now returns `gfx942` and tags `gfx942__aiter-0.1.10`.
- [x] With `FLASHINFER_ROCM_ARCH_LIST="../../../tmp/pwned,gfx942"` the resolver returned that path and `_aiter_libs_dir()` created a directory outside the cache root; it now warns, drops the token, and stays at `<cache>/aiter_libs/gfx942__aiter-0.1.10`.
- [x] New `tests/rocm_tests/test_aiter_build_arch_hip.py` — 29 cases, GPU-free: device-follows-env-unset (both arches), GPU-less default, both separators, cross-compile mismatch warns, result is never a list, qualifiers normalized, qualifier-only and non-architecture tokens dropped, cache-tag path-component guard, cache tag follows the resolved arch.
- [x] 112 tests pass across the three GPU-free suites; `test_hip_utils.py` unchanged and green.
- [x] `pre-commit run -a` clean.

Not yet verified on gfx942 hardware — the resolution logic is covered by the monkeypatched tests, and a CDNA3 run is planned before this merges.
