### PR TITLE
test(rocm): make every ROCm test run self-describing

### DIFF
--- a/flashinfer/hip_utils.py
+++ b/flashinfer/hip_utils.py
@@ -390,21 +390,25 @@ def get_available_gpu_count() -> int:
     return torch.cuda.device_count()
 
 
-@functools.cache
-def get_supported_device_indices() -> tuple:
+def rocminfo_gpu_agents() -> tuple:
     """
-    Return the indices of AMD GPUs whose architecture is supported by FlashInfer.
+    Return ``(arch, marketing_name)`` for each GPU agent rocminfo reports.
 
-    Uses rocminfo (subprocess) rather than torch.cuda so this function is safe
-    to call before the HIP runtime is initialized (e.g. before HIP_VISIBLE_DEVICES
-    is set in xdist workers).  rocminfo enumerates GPU agents in the same order as
-    the HIP runtime, so the Nth GPU agent = HIP device index N.
+    Uses rocminfo (subprocess) rather than torch.cuda so this is safe to call
+    before the HIP runtime is initialized (e.g. before HIP_VISIBLE_DEVICES is set
+    in xdist workers).  rocminfo enumerates GPU agents in the same order as the
+    HIP runtime, so entry N corresponds to HIP device index N.
 
-    The result is cached so rocminfo is invoked at most once per process.
+    ``arch`` is normalized ("gfx942"); ``marketing_name`` is rocminfo's
+    "Marketing Name" (e.g. "AMD Instinct MI350X") or "" when absent. CPU agents
+    also carry a Marketing Name, so agents are filtered on ``Device Type: GPU``.
+
+    Not cached: the caller decides.  ``get_supported_device_indices`` caches its
+    own result, and one-shot consumers pay a single subprocess.
 
     Returns:
-        tuple[int, ...]: Device indices of supported GPUs. Empty tuple if none
-                         found or rocminfo is unavailable.
+        tuple[tuple[str, str], ...]: One (arch, marketing_name) pair per GPU
+                                     agent. Empty if rocminfo is unavailable.
     """
     import re
     import subprocess
@@ -418,35 +422,51 @@ def get_supported_device_indices() -> tuple:
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return ()
 
-    supported = []
-    gpu_index = 0
-    current_name = None
-    current_is_gpu = False
+    agents = []
+    name = marketing = None
+    is_gpu = False
 
     def _commit():
-        nonlocal gpu_index
-        if current_is_gpu:
+        if is_gpu:
             # rocminfo's agent-level "Name:" is normally bare ("gfx942"), but
-            # normalize defensively: an unstripped qualifier here would drop
-            # every GPU from the supported list, and callers would silently
-            # fall back to the default architecture.
-            if normalize_arch(current_name or "") in FLASHINFER_SUPPORTED_ROCM_ARCHS:
-                supported.append(gpu_index)
-            gpu_index += 1
+            # normalize defensively: an unstripped qualifier would drop every
+            # GPU from the supported list, and callers would silently fall back
+            # to the default architecture.
+            agents.append((normalize_arch(name or ""), marketing or ""))
 
     for line in result.stdout.splitlines():
         s = line.strip()
         if re.match(r"^Agent \d+", s):
             _commit()
-            current_name = None
-            current_is_gpu = False
-        elif s.startswith("Name:") and current_name is None:
-            current_name = s.split(":", 1)[1].strip()
+            name = marketing = None
+            is_gpu = False
+        elif s.startswith("Name:") and name is None:
+            name = s.split(":", 1)[1].strip()
+        elif s.startswith("Marketing Name:") and marketing is None:
+            marketing = s.split(":", 1)[1].strip()
         elif s.startswith("Device Type:") and "GPU" in s:
-            current_is_gpu = True
+            is_gpu = True
     _commit()  # process last agent
 
-    return tuple(supported)
+    return tuple(agents)
+
+
+@functools.cache
+def get_supported_device_indices() -> tuple:
+    """
+    Return the indices of AMD GPUs whose architecture is supported by FlashInfer.
+
+    The result is cached so rocminfo is invoked at most once per process.
+
+    Returns:
+        tuple[int, ...]: Device indices of supported GPUs. Empty tuple if none
+                         found or rocminfo is unavailable.
+    """
+    return tuple(
+        index
+        for index, (arch, _) in enumerate(rocminfo_gpu_agents())
+        if arch in FLASHINFER_SUPPORTED_ROCM_ARCHS
+    )
 
 
 # A "primary" CPX sibling reports the full physical card capacity; the other

--- a/tests/rocm_tests/conftest.py
+++ b/tests/rocm_tests/conftest.py
@@ -78,7 +78,11 @@ def _devices() -> str:
     visible = os.environ.get("HIP_VISIBLE_DEVICES", "").strip()
     if visible:
         return visible
-    return ",".join(str(i) for i in get_physical_card_device_indices())
+    indices = get_physical_card_device_indices()
+    # "none", not the "unknown" _probe would otherwise supply for an empty
+    # string: no supported GPU is a determinate answer, and a run on a host
+    # without one should not be mistaken for a run whose probe broke.
+    return ",".join(str(i) for i in indices) if indices else "none"
 
 
 def _arch_and_sku() -> tuple:

--- a/tests/rocm_tests/conftest.py
+++ b/tests/rocm_tests/conftest.py
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from flashinfer.hip_utils import get_physical_card_device_indices
+import os
+import re
+
+from flashinfer.arch_caps import normalize_arch
+from flashinfer.hip_utils import (
+    get_physical_card_device_indices,
+    get_system_rocm_version,
+    rocminfo_gpu_agents,
+)
 
 # pytest_xdist_auto_num_workers is only available when pytest-xdist is installed
 # and loaded (i.e. when -n / --dist is passed). Guard the definition so that
@@ -40,3 +48,120 @@ try:
 
 except ImportError:
     pass
+
+
+_UNKNOWN = "unknown"
+
+# "AMD Instinct MI350X" -> "MI350X".
+_SKU_RE = re.compile(r"\bMI\d+[A-Za-z]*\b")
+
+
+def _probe(fn, default=_UNKNOWN):
+    """Run a probe, degrading to ``default`` rather than failing the session.
+
+    A descriptive header must never be the reason a test run dies, so each field
+    is probed independently and a broken probe costs exactly one field.
+    """
+    try:
+        return fn() or default
+    except Exception:
+        return default
+
+
+def _devices() -> str:
+    """Device indices this session runs on.
+
+    HIP_VISIBLE_DEVICES wins when set: tests/conftest.py pins each xdist worker
+    to a single card through it before torch loads, so it -- not the full card
+    list -- is what this process can actually see.
+    """
+    visible = os.environ.get("HIP_VISIBLE_DEVICES", "").strip()
+    if visible:
+        return visible
+    return ",".join(str(i) for i in get_physical_card_device_indices())
+
+
+def _arch_and_sku() -> tuple:
+    """Return ``(arch, sku)``: architecture from torch, SKU from rocminfo.
+
+    torch reports the architecture exactly via ``gcnArchName``, but its device
+    ``name`` is not a marketing name -- on an MI350X it is the generic
+    "AMD Radeon Graphics" -- so the SKU has to come from rocminfo's
+    "Marketing Name". The two are matched on architecture so that a mixed-arch
+    host can never attribute one card's SKU to another card's architecture.
+    """
+    arch = _UNKNOWN
+    try:
+        import torch
+
+        if torch.cuda.device_count():
+            arch = normalize_arch(torch.cuda.get_device_properties(0).gcnArchName)
+    except Exception:
+        pass
+
+    agents = rocminfo_gpu_agents()
+    if arch == _UNKNOWN:
+        arch = next((a for a, _ in agents if a), _UNKNOWN)
+
+    marketing = next((m for a, m in agents if m and a == arch), "")
+    match = _SKU_RE.search(marketing)
+    # Only report a name we can actually resolve to a SKU. Some environments --
+    # this repo's own ROCm container among them -- return the generic
+    # "AMD Radeon Graphics" for an Instinct part, and echoing that would read
+    # like an answer rather than a failure to identify the board.
+    return arch, (match.group(0) if match else _UNKNOWN)
+
+
+def _header_line() -> str:
+    """Build the one-line hardware/toolchain description.
+
+    Pasted test output is otherwise not self-describing: a result or a timing
+    only means something alongside the architecture, the SKU, and the
+    ROCm/torch/AITER versions that produced it.
+
+    The SKU is named separately from the architecture on purpose. MI300X and
+    MI325X are both gfx942, and MI350X and MI355X are both gfx950 -- correctness
+    may be inherited across a shared architecture, performance may not.
+    """
+    arch, sku = _probe(_arch_and_sku, (_UNKNOWN, _UNKNOWN))
+
+    def _rocm():
+        # get_system_rocm_version narrates each detection method it falls
+        # through, which would otherwise interleave with the header.
+        import contextlib
+        import io
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            return get_system_rocm_version()
+
+    def _torch():
+        import torch
+
+        return str(torch.__version__)
+
+    def _aiter():
+        import importlib.metadata as _md
+
+        return _md.version("amd-aiter")
+
+    return (
+        f"rocm: arch={arch} sku={sku} devices={_probe(_devices)} "
+        f"rocm={_probe(_rocm)} torch={_probe(_torch)} aiter={_probe(_aiter)}"
+    )
+
+
+def pytest_report_header(config):
+    """Emit the description in pytest's session header."""
+    return _header_line()
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    """Re-emit the description at the end when the session header is suppressed.
+
+    This repo runs with ``-q`` by default (``addopts`` in pyproject.toml), and
+    quiet mode drops the session header entirely -- so pytest_report_header
+    alone would never be seen in a normal run. The terminal summary survives
+    ``-q``, which is what makes the run self-describing in practice.
+    """
+    if config.option.verbose < 0:  # quiet: the header above was suppressed
+        terminalreporter.write_line(_header_line())

--- a/tests/rocm_tests/conftest.py
+++ b/tests/rocm_tests/conftest.py
@@ -93,6 +93,13 @@ def _arch_and_sku() -> tuple:
     "AMD Radeon Graphics" -- so the SKU has to come from rocminfo's
     "Marketing Name". The two are matched on architecture so that a mixed-arch
     host can never attribute one card's SKU to another card's architecture.
+
+    Within one architecture the agents must also agree on the board. rocminfo
+    ignores HIP_VISIBLE_DEVICES -- it reports every physical agent whatever this
+    session was pinned to -- so on a host mixing boards that share an
+    architecture (MI300X and MI325X are both gfx942) there is nothing to tell us
+    which one we got. Naming either would be a guess wearing the clothes of an
+    answer, so disagreement reports ``unknown``.
     """
     arch = _UNKNOWN
     try:
@@ -107,13 +114,15 @@ def _arch_and_sku() -> tuple:
     if arch == _UNKNOWN:
         arch = next((a for a, _ in agents if a), _UNKNOWN)
 
-    marketing = next((m for a, m in agents if m and a == arch), "")
-    match = _SKU_RE.search(marketing)
-    # Only report a name we can actually resolve to a SKU. Some environments --
-    # this repo's own ROCm container among them -- return the generic
-    # "AMD Radeon Graphics" for an Instinct part, and echoing that would read
-    # like an answer rather than a failure to identify the board.
-    return arch, (match.group(0) if match else _UNKNOWN)
+    # Only report a name we can actually resolve to a SKU, and only when it is
+    # the sole candidate. Some environments -- this repo's own ROCm container
+    # among them -- return the generic "AMD Radeon Graphics" for an Instinct
+    # part, which leaves the set empty; a same-arch mix leaves it ambiguous.
+    # Either way, echoing something would read like an answer rather than a
+    # failure to identify the board.
+    matches = (_SKU_RE.search(m) for a, m in agents if a == arch)
+    skus = {m.group(0) for m in matches if m}
+    return arch, (skus.pop() if len(skus) == 1 else _UNKNOWN)
 
 
 def _header_line() -> str:

--- a/tests/rocm_tests/conftest.py
+++ b/tests/rocm_tests/conftest.py
@@ -106,7 +106,12 @@ def _arch_and_sku() -> tuple:
         import torch
 
         if torch.cuda.device_count():
-            arch = normalize_arch(torch.cuda.get_device_properties(0).gcnArchName)
+            # normalize_arch returns "" for degenerate input rather than
+            # raising. Fold that back into _UNKNOWN, or the rocminfo fallback
+            # below is skipped and the header prints a blank arch.
+            arch = normalize_arch(torch.cuda.get_device_properties(0).gcnArchName) or (
+                _UNKNOWN
+            )
     except Exception:
         pass
 

--- a/tests/rocm_tests/test_run_header_hip.py
+++ b/tests/rocm_tests/test_run_header_hip.py
@@ -138,6 +138,14 @@ class TestArchAndSku:
     def test_no_agents_at_all(self, resolve):
         assert resolve(()) == ("unknown", "unknown")
 
+    @pytest.mark.parametrize("degenerate", ["", "   ", ":"])
+    def test_unusable_torch_arch_falls_back_to_rocminfo(self, resolve, degenerate):
+        """normalize_arch returns "" for degenerate input rather than raising,
+        and "" is not _UNKNOWN -- so an unfolded empty arch would skip the
+        rocminfo fallback and print a blank arch in the header."""
+        agents = (("gfx942", "AMD Instinct MI300X"),)
+        assert resolve(agents, torch_arch=degenerate) == ("gfx942", "MI300X")
+
 
 def test_header_line_survives_every_probe_failing(rocm_conftest, monkeypatch):
     """A descriptive header must never be the reason a test session dies."""

--- a/tests/rocm_tests/test_run_header_hip.py
+++ b/tests/rocm_tests/test_run_header_hip.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ROCm run-descriptor header in tests/rocm_tests/conftest.py.
+
+GPU-free: the branch worth protecting here is the one no GPU run ever takes --
+a host with no supported card must say so, rather than reporting the same
+"unknown" a broken probe would.
+
+The conftest is loaded by path rather than imported as a module. pytest owns
+conftest import, and there is no package to import it from; loading it here
+gives a second, independent module object whose globals can be patched without
+touching the hooks pytest is actually running.
+"""
+
+import importlib.util
+import pathlib
+
+import pytest
+
+_CONFTEST = pathlib.Path(__file__).with_name("conftest.py")
+
+
+@pytest.fixture
+def rocm_conftest(monkeypatch):
+    """A private copy of the conftest module, with HIP_VISIBLE_DEVICES cleared."""
+    spec = importlib.util.spec_from_file_location("_rocm_conftest_isolated", _CONFTEST)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    monkeypatch.delenv("HIP_VISIBLE_DEVICES", raising=False)
+    return module
+
+
+class TestDevices:
+    def test_visible_devices_env_wins(self, rocm_conftest, monkeypatch):
+        """tests/conftest.py pins each xdist worker to one card through this."""
+        monkeypatch.setenv("HIP_VISIBLE_DEVICES", "3")
+        monkeypatch.setattr(
+            rocm_conftest, "get_physical_card_device_indices", lambda: (0, 1)
+        )
+        assert rocm_conftest._devices() == "3"
+
+    def test_falls_back_to_detected_cards(self, rocm_conftest, monkeypatch):
+        monkeypatch.setattr(
+            rocm_conftest, "get_physical_card_device_indices", lambda: (0, 1)
+        )
+        assert rocm_conftest._devices() == "0,1"
+
+    def test_no_supported_card_is_none_not_unknown(self, rocm_conftest, monkeypatch):
+        """An empty device list is an answer; "unknown" would read as a failure."""
+        monkeypatch.setattr(rocm_conftest, "get_physical_card_device_indices", tuple)
+        assert rocm_conftest._devices() == "none"
+        assert rocm_conftest._probe(rocm_conftest._devices) == "none"
+
+    def test_broken_probe_is_unknown(self, rocm_conftest, monkeypatch):
+        def boom():
+            raise RuntimeError("rocminfo not on PATH")
+
+        monkeypatch.setattr(rocm_conftest, "get_physical_card_device_indices", boom)
+        assert rocm_conftest._probe(rocm_conftest._devices) == "unknown"
+
+
+def test_header_line_survives_every_probe_failing(rocm_conftest, monkeypatch):
+    """A descriptive header must never be the reason a test session dies."""
+    for name in (
+        "get_physical_card_device_indices",
+        "get_system_rocm_version",
+        "rocminfo_gpu_agents",
+    ):
+        monkeypatch.setattr(
+            rocm_conftest, name, lambda: (_ for _ in ()).throw(RuntimeError("no ROCm"))
+        )
+
+    line = rocm_conftest._header_line()
+    assert line.startswith("rocm: ")
+    assert "arch=" in line and "sku=" in line and "devices=" in line

--- a/tests/rocm_tests/test_run_header_hip.py
+++ b/tests/rocm_tests/test_run_header_hip.py
@@ -16,10 +16,28 @@ touching the hooks pytest is actually running.
 
 import importlib.util
 import pathlib
+import sys
+import types
 
 import pytest
 
 _CONFTEST = pathlib.Path(__file__).with_name("conftest.py")
+
+
+def _stub_torch(gcn_arch_name: str):
+    """A torch stand-in exposing only what _arch_and_sku reads from it.
+
+    The real torch reports whichever card the runner has, which would decide
+    these cases for them.
+    """
+    return types.SimpleNamespace(
+        cuda=types.SimpleNamespace(
+            device_count=lambda: 1,
+            get_device_properties=lambda _: types.SimpleNamespace(
+                gcnArchName=gcn_arch_name
+            ),
+        )
+    )
 
 
 @pytest.fixture
@@ -59,6 +77,66 @@ class TestDevices:
 
         monkeypatch.setattr(rocm_conftest, "get_physical_card_device_indices", boom)
         assert rocm_conftest._probe(rocm_conftest._devices) == "unknown"
+
+
+class TestArchAndSku:
+    """SKU resolution from rocminfo agents.
+
+    torch is not available to these tests as a source of truth for the arch, and
+    forcing it would tie them to whatever card the runner has. Each case pins the
+    agent list instead and lets the arch fall out of it, which is the same path a
+    host with no torch takes.
+    """
+
+    @pytest.fixture
+    def resolve(self, rocm_conftest, monkeypatch):
+        def _resolve(agents, torch_arch=None):
+            monkeypatch.setattr(rocm_conftest, "rocminfo_gpu_agents", lambda: agents)
+            if torch_arch is None:
+                # sys.modules[name] = None is what makes "import torch" raise,
+                # which is the path a host without torch takes.
+                monkeypatch.setitem(sys.modules, "torch", None)
+            else:
+                monkeypatch.setitem(sys.modules, "torch", _stub_torch(torch_arch))
+            return rocm_conftest._arch_and_sku()
+
+        return _resolve
+
+    def test_single_card(self, resolve):
+        assert resolve((("gfx942", "AMD Instinct MI300X"),)) == ("gfx942", "MI300X")
+
+    def test_homogeneous_multi_card(self, resolve):
+        """The common case: eight identical boards must still name the SKU."""
+        agents = (("gfx950", "AMD Instinct MI355X"),) * 8
+        assert resolve(agents) == ("gfx950", "MI355X")
+
+    def test_mixed_arch_picks_the_matching_board(self, resolve):
+        """A card of another arch must not lend its name to this one."""
+        agents = (("gfx942", "AMD Instinct MI300X"), ("gfx90a", "AMD Instinct MI250X"))
+        assert resolve(agents) == ("gfx942", "MI300X")
+
+    def test_torch_arch_selects_the_agent_not_agent_order(self, resolve):
+        """The production path: torch names the arch this session is pinned to,
+        and the SKU follows that -- not whichever agent rocminfo listed first."""
+        agents = (("gfx942", "AMD Instinct MI300X"), ("gfx90a", "AMD Instinct MI250X"))
+        assert resolve(agents, torch_arch="gfx90a:sramecc+:xnack-") == (
+            "gfx90a",
+            "MI250X",
+        )
+
+    def test_same_arch_different_boards_is_unknown(self, resolve):
+        """MI300X and MI325X are both gfx942, and rocminfo ignores
+        HIP_VISIBLE_DEVICES -- so which board this session got is unknowable,
+        and guessing one would read as an answer."""
+        agents = (("gfx942", "AMD Instinct MI300X"), ("gfx942", "AMD Instinct MI325X"))
+        assert resolve(agents) == ("gfx942", "unknown")
+
+    def test_generic_marketing_name_is_unknown(self, resolve):
+        """Seen in this repo's own ROCm container for an Instinct part."""
+        assert resolve((("gfx950", "AMD Radeon Graphics"),)) == ("gfx950", "unknown")
+
+    def test_no_agents_at_all(self, resolve):
+        assert resolve(()) == ("unknown", "unknown")
 
 
 def test_header_line_survives_every_probe_failing(rocm_conftest, monkeypatch):


### PR DESCRIPTION
## Summary

A pasted test result or timing means little without the architecture, the board, and the ROCm/torch/AITER versions behind it — and the suite reported none of them. There was no `pytest_report_header` anywhere in the repo. This adds one:

```
rocm: arch=gfx942 sku=MI300X devices=0,1 rocm=7.2.0 torch=2.9.1+rocm7.2.0 aiter=0.1.10
```

### What changed

- **`tests/rocm_tests/conftest.py`** — builds the description and emits it from both `pytest_report_header` and `pytest_terminal_summary`. Every field is probed independently and degrades to `unknown`, so a broken probe costs one field rather than the run.
- **`flashinfer/hip_utils.py`** — extracts the existing rocminfo loop as `rocminfo_gpu_agents()`, now also capturing the marketing name; `get_supported_device_indices` becomes a filter over it and loses ~45 lines of closure bookkeeping.
- **`tests/rocm_tests/test_run_header_hip.py`** — GPU-free tests for the header's probe logic. The branches worth protecting here are the ones no GPU run ever takes: a host with no supported card, a host whose probes all fail, and boards that share an architecture.

### Architecture / design notes

Several things this had to get right, each found by running it rather than reading the docs.

**The repo runs with `-q`, and quiet mode drops the session header entirely.** `addopts = "-q ..."` in `pyproject.toml`, so a `pytest_report_header` hook alone would never be seen in a normal run. The line is therefore also emitted from `pytest_terminal_summary`, which survives `-q`, guarded on verbosity so it is not printed twice when the header is visible.

**torch's device `name` is not a marketing name.** On an MI350X it reports the generic `"AMD Radeon Graphics"`. The SKU comes from rocminfo's `Marketing Name` instead, matched to the reported architecture so a mixed-arch host can never attribute one card's SKU to another card's architecture.

**Within one architecture, the agents must agree on the board.** rocminfo ignores `HIP_VISIBLE_DEVICES` — it reports every physical agent whatever the session was pinned to, confirmed by comparing its output at unset / `0` / `1`. So on a host mixing boards that share an architecture (MI300X and MI325X are both gfx942) there is nothing to say which one this session got, and naming either would be a guess wearing the clothes of an answer. Exactly one distinct SKU among the matching agents reports it; disagreement reports `unknown`. Homogeneous nodes — every Instinct node in practice, including the two-card MI300X allocation this was verified on — are unaffected.

**Some environments cannot resolve the SKU at all.** Inside this repo's own ROCm container, rocminfo and `amd-smi` both return `"AMD Radeon Graphics"` for an Instinct part, while the host returns `"AMD Instinct MI350X"`. Rather than echo that — which reads like an answer — the SKU is reported as `unknown` unless it resolves to a recognisable Instinct part.

**`unknown` is reserved for probes that failed.** A host with no supported GPU reports `devices=none`. That is a determinate answer, and collapsing it into the same `unknown` a missing rocminfo produces would make a CPU-only run indistinguishable from a broken one.

The SKU is reported separately from the architecture because MI300X and MI325X are both gfx942, and MI350X and MI355X are both gfx950. Correctness may be inherited across a shared architecture; performance may not. Naming the board is what stops a number measured on one part being quoted for another.

Rather than add a second rocminfo parser, the existing one is shared. The new helper is deliberately uncached so the existing `@functools.cache` on `get_supported_device_indices` remains the only cache, which keeps `test_hip_utils.py`'s `cache_clear()` calls correct.

### CDNA3 impact

None. `rocminfo_gpu_agents` preserves the original agent-ordering and GPU-filtering semantics exactly, and `get_supported_device_indices` returns the same indices. `test_hip_utils.py` passes unchanged on both architectures.

## Test plan

Verified on **gfx950** (MI350X, ROCm 7.2.0, torch 2.9.1) and on **gfx942** (MI300X, 2-card allocation, ROCm 7.2.0, torch 2.9.1).

- [x] Header renders under the repo default (`-q`) via terminal summary, and at the top under non-quiet, with no duplication in either mode.
- [x] `test_hip_utils.py` passes unchanged (69 tests), including the `get_supported_device_indices` suite that mocks `subprocess.run`.
- [x] 98 tests pass across the GPU-free suites on gfx950.
- [x] **gfx942 (MI300X)**: 95 tests pass, and again under `-n auto` with the header emitted once. The SKU resolves on real CDNA3 hardware where the gfx950 container cannot — both agents report `AMD Instinct MI300X`, so the agreement rule names the board rather than blanking it on a multi-GPU node:
  ```
  rocm: arch=gfx942 sku=MI300X devices=0,1 rocm=7.2.0 torch=2.9.1+rocm7.2.0.git7e1940d4 aiter=0.1.10
  ```
- [x] `pre-commit run -a`

### Post-merge full-suite verification

Run after merge, at the merge commit `49a8cdd8`, on SHA-pinned detached worktrees with identical container stacks on both architectures — torch `2.9.1+rocm7.2.0.git7e1940d4`, HIP `7.2.26015`, amd-aiter `0.1.10`. Architecture was the only variable.

| | gfx942 (MI300X ×2) | gfx950 (MI350X) |
| :-- | --: | --: |
| passed | **27520** | 27517 |
| skipped | 3585 | 3585 |
| failed | **0** | 3 |

The three gfx950 failures are **not related to this PR**. All three are `test_batch_prefill_auto_selects_aiter` with `causal=True` and `page_size>1`, returning wrong numbers (97.6% of elements mismatched, max abs diff 0.39–0.64) from AITER's batch-prefill kernel; they are deterministic across `--reruns 2`, and all 12 parametrizations pass on gfx942 with the same toolchain. That is a pre-existing architecture-specific AITER defect on ROCm 7.2, tracked separately for the capability table.

The multi-GPU behaviour this PR changed was also checked directly on the 2-card CDNA3 node, since a single-GPU host cannot meaningfully exercise it — `get_supported_device_indices()` must preserve the rocminfo agent-order → HIP device-index mapping that xdist worker pinning depends on:

```
rocminfo_gpu_agents()             : (('gfx942','AMD Instinct MI300X'), ('gfx942','AMD Instinct MI300X'))
get_supported_device_indices()    : (0, 1)
get_physical_card_device_indices(): (0, 1)
torch.cuda.device_count()         : 2
```