### PR TITLE
feat(rocm): declarative per-op/per-arch capability table

### DIFF
--- a/flashinfer/arch_caps.py
+++ b/flashinfer/arch_caps.py
@@ -31,6 +31,7 @@ __all__ = [
     "ArchCapabilityError",
     "ArchSupport",
     "CAPABILITIES",
+    "Capability",
     "KnownBad",
     "Support",
     "capability_available",
@@ -116,6 +117,27 @@ def _version_tuple(text: str) -> Tuple[int, ...]:
     return tuple(parts)
 
 
+def _compare(left: str, right: str) -> int:
+    """Three-way compare two version strings, zero-padding absent components.
+
+    ``"7.2"`` and ``"7.2.0"`` name the same release and must compare equal.
+    Comparing raw tuples would make ``(7, 2) < (7, 2, 0)``, so a window written
+    as ``rocm_min="7.2.0"`` would silently fail to gate a machine reporting
+    ``"7.2"`` -- a reachable state, not a hypothetical:
+    ``hip_utils.get_system_rocm_version_from_hipconfig`` matches
+    ``\\d+\\.\\d+(?:\\.\\d+)?``, so the patch component is optional, and on
+    TheRock builds it is the *only* detection method consulted.
+
+    The current table writes ``rocm_min="7.2"`` and is unaffected either way;
+    this keeps the next window from having to know about the quirk.
+    """
+    a, b = _version_tuple(left), _version_tuple(right)
+    width = max(len(a), len(b))
+    a += (0,) * (width - len(a))
+    b += (0,) * (width - len(b))
+    return (a > b) - (a < b)
+
+
 @dataclass(frozen=True)
 class KnownBad:
     """A toolchain window in which an otherwise-supported op is broken.
@@ -151,10 +173,9 @@ class KnownBad:
                 continue
             if value is None:
                 return False
-            v = _version_tuple(value)
-            if low is not None and v < _version_tuple(low):
+            if low is not None and _compare(value, low) < 0:
                 return False
-            if high is not None and v >= _version_tuple(high):
+            if high is not None and _compare(value, high) >= 0:
                 return False
         return True
 

--- a/flashinfer/arch_caps.py
+++ b/flashinfer/arch_caps.py
@@ -294,7 +294,25 @@ CAPABILITIES: Tuple[Capability, ...] = (
     Capability("quantization", "hip", _archs(_HIP_942, _HIP_950)),
 )
 
-_BY_KEY = {(c.op, c.backend): c for c in CAPABILITIES}
+
+def _index(caps: Tuple[Capability, ...]) -> Mapping[Tuple[str, str], Capability]:
+    """Index rows by ``(op, backend)``, refusing duplicates.
+
+    A dict comprehension lets the later of two contradictory rows win silently,
+    which is exactly the unearned claim this table exists to remove.
+    ``test_keys_are_unique`` covers it, but raising at import puts the error next
+    to the edit that caused it instead of in a later CI run.
+    """
+    index = {}
+    for cap in caps:
+        key = (cap.op, cap.backend)
+        if key in index:
+            raise ValueError(f"duplicate capability row for {key} in CAPABILITIES")
+        index[key] = cap
+    return MappingProxyType(index)
+
+
+_BY_KEY = _index(CAPABILITIES)
 
 
 @lru_cache(maxsize=1)

--- a/flashinfer/arch_caps.py
+++ b/flashinfer/arch_caps.py
@@ -23,6 +23,8 @@ which owns *whether the AITER package is importable*.
 import os
 from dataclasses import dataclass, field
 from enum import Enum
+from functools import lru_cache
+from types import MappingProxyType
 from typing import Mapping, Optional, Tuple
 
 __all__ = [
@@ -174,10 +176,26 @@ class ArchSupport:
 
 @dataclass(frozen=True)
 class Capability:
+    """One ``(op, backend)`` row of the table.
+
+    ``frozen=True`` only stops the *fields* being rebound; a plain dict in
+    ``archs`` would still let a caller edit the global table in place
+    (``CAPABILITIES[0].archs["gfx942"] = ...``). ``__post_init__`` wraps it in a
+    :class:`~types.MappingProxyType` so the whole structure is read-only:
+    ``ArchSupport`` and ``KnownBad`` are frozen with tuple fields, so nothing
+    below this point is mutable either.
+
+    The coercion lives here rather than in the construction helper so it holds
+    for every row however it was built.
+    """
+
     op: str
     backend: str
     archs: Mapping[str, ArchSupport] = field(default_factory=dict)
     note: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "archs", MappingProxyType(dict(self.archs)))
 
 
 # --------------------------------------------------------------------------
@@ -222,7 +240,8 @@ _ROCM72_CAUSAL_PREFILL = KnownBad(
 )
 
 
-def _aiter(gfx942: ArchSupport, gfx950: ArchSupport) -> Mapping[str, ArchSupport]:
+def _archs(gfx942: ArchSupport, gfx950: ArchSupport) -> Mapping[str, ArchSupport]:
+    """Positional shorthand for the two architectures every row must declare."""
     return {"gfx942": gfx942, "gfx950": gfx950}
 
 
@@ -236,12 +255,12 @@ _HIP_950 = ArchSupport(Support.SUPPORTED)
 
 CAPABILITIES: Tuple[Capability, ...] = (
     # --- AITER backends: measured on both architectures --------------------
-    Capability("batch_decode", "aiter", _aiter(_OK_942, _OK_950)),
-    Capability("single_prefill", "aiter", _aiter(_OK_942, _OK_950)),
+    Capability("batch_decode", "aiter", _archs(_OK_942, _OK_950)),
+    Capability("single_prefill", "aiter", _archs(_OK_942, _OK_950)),
     Capability(
         "batch_prefill",
         "aiter",
-        _aiter(
+        _archs(
             _OK_942,
             ArchSupport(
                 Support.SUPPORTED,
@@ -251,35 +270,43 @@ CAPABILITIES: Tuple[Capability, ...] = (
             ),
         ),
     ),
-    Capability("mla", "aiter", _aiter(_OK_942, _OK_950)),
-    Capability("rope", "aiter", _aiter(_OK_942, _OK_950)),
-    Capability("append_paged_kv_cache", "aiter", _aiter(_OK_942, _OK_950)),
-    Capability("rmsnorm", "aiter", _aiter(_OK_942, _OK_950)),
-    Capability("fused_add_rmsnorm", "aiter", _aiter(_OK_942, _OK_950)),
-    Capability("activation", "aiter", _aiter(_OK_942, _OK_950)),
+    Capability("mla", "aiter", _archs(_OK_942, _OK_950)),
+    Capability("rope", "aiter", _archs(_OK_942, _OK_950)),
+    Capability("append_paged_kv_cache", "aiter", _archs(_OK_942, _OK_950)),
+    Capability("rmsnorm", "aiter", _archs(_OK_942, _OK_950)),
+    Capability("fused_add_rmsnorm", "aiter", _archs(_OK_942, _OK_950)),
+    Capability("activation", "aiter", _archs(_OK_942, _OK_950)),
     # --- HIP backends: declared; per-op evidence not yet recorded ----------
-    Capability("single_decode", "hip", _aiter(_HIP_942, _HIP_950)),
-    Capability("batch_decode", "hip", _aiter(_HIP_942, _HIP_950)),
-    Capability("single_prefill", "hip", _aiter(_HIP_942, _HIP_950)),
-    Capability("batch_prefill", "hip", _aiter(_HIP_942, _HIP_950)),
-    Capability("cascade", "hip", _aiter(_HIP_942, _HIP_950)),
-    Capability("pod", "hip", _aiter(_HIP_942, _HIP_950)),
-    Capability("rope", "hip", _aiter(_HIP_942, _HIP_950)),
-    Capability("append_paged_kv_cache", "hip", _aiter(_HIP_942, _HIP_950)),
-    Capability("rmsnorm", "hip", _aiter(_HIP_942, _HIP_950)),
-    Capability("fused_add_rmsnorm", "hip", _aiter(_HIP_942, _HIP_950)),
-    Capability("layernorm", "hip", _aiter(_HIP_942, _HIP_950)),
-    Capability("sampling", "hip", _aiter(_HIP_942, _HIP_950)),
-    Capability("logits_processor", "hip", _aiter(_HIP_942, _HIP_950)),
-    Capability("activation", "hip", _aiter(_HIP_942, _HIP_950)),
-    Capability("quantization", "hip", _aiter(_HIP_942, _HIP_950)),
+    Capability("single_decode", "hip", _archs(_HIP_942, _HIP_950)),
+    Capability("batch_decode", "hip", _archs(_HIP_942, _HIP_950)),
+    Capability("single_prefill", "hip", _archs(_HIP_942, _HIP_950)),
+    Capability("batch_prefill", "hip", _archs(_HIP_942, _HIP_950)),
+    Capability("cascade", "hip", _archs(_HIP_942, _HIP_950)),
+    Capability("pod", "hip", _archs(_HIP_942, _HIP_950)),
+    Capability("rope", "hip", _archs(_HIP_942, _HIP_950)),
+    Capability("append_paged_kv_cache", "hip", _archs(_HIP_942, _HIP_950)),
+    Capability("rmsnorm", "hip", _archs(_HIP_942, _HIP_950)),
+    Capability("fused_add_rmsnorm", "hip", _archs(_HIP_942, _HIP_950)),
+    Capability("layernorm", "hip", _archs(_HIP_942, _HIP_950)),
+    Capability("sampling", "hip", _archs(_HIP_942, _HIP_950)),
+    Capability("logits_processor", "hip", _archs(_HIP_942, _HIP_950)),
+    Capability("activation", "hip", _archs(_HIP_942, _HIP_950)),
+    Capability("quantization", "hip", _archs(_HIP_942, _HIP_950)),
 )
 
 _BY_KEY = {(c.op, c.backend): c for c in CAPABILITIES}
 
 
+@lru_cache(maxsize=1)
 def _live_versions() -> Tuple[Optional[str], Optional[str]]:
-    """``(rocm_version, aiter_version)``, either ``None`` when undetectable."""
+    """``(rocm_version, aiter_version)``, either ``None`` when undetectable.
+
+    Cached for the process lifetime because it is not cheap:
+    ``get_system_rocm_version`` walks up to four detection methods, three of
+    which shell out (``amd-smi``, ``dpkg``, ``hipconfig``) with timeouts. Neither
+    version can change under a running process, so probing once is sufficient
+    even though ``_blocking_reason`` may be called per routing decision.
+    """
     rocm = aiter = None
     try:
         import contextlib
@@ -322,6 +349,10 @@ def _blocking_reason(op: str, backend: str, arch: str) -> Optional[str]:
         )
     if entry.support is Support.UNSUPPORTED:
         return f"{backend} {op} is not supported on {arch}"
+    if not entry.known_bad:
+        # The common case: 23 of 24 rows have no window, so they never pay for
+        # version detection at all.
+        return None
 
     rocm, aiter = _live_versions()
     for bad in entry.known_bad:
@@ -338,20 +369,24 @@ def _blocking_reason(op: str, backend: str, arch: str) -> Optional[str]:
     return None
 
 
-def capability_available(op: str, backend: str, device) -> bool:
+def capability_available(device, op: str, backend: str) -> bool:
     """Whether ``auto`` may route ``op`` to ``backend`` on ``device``.
 
-    Mirrors ``aiter_utils.is_aiter_available`` so it slots underneath the
-    existing selectors without changing their shape.
+    ``device`` leads to match the gating helpers this is meant to replace
+    (``aiter_utils.is_aiter_available(device)``,
+    ``aiter_utils.require_aiter(device, op)``), so migrating a call site is
+    appending ``backend`` rather than reordering. ``op`` and ``backend`` are both
+    ``str``, so an argument-order slip between them would be silent -- keeping
+    the shared prefix identical is what stops one happening.
     """
     return _blocking_reason(op, backend, _device_arch(device)) is None
 
 
-def require_capability(op: str, backend: str, device) -> None:
+def require_capability(device, op: str, backend: str) -> None:
     """Raise :class:`ArchCapabilityError` if ``backend`` cannot serve ``op`` here.
 
-    Mirrors ``aiter_utils.require_aiter`` -- same ``(device, op)`` information,
-    one exception type instead of three.
+    Mirrors ``aiter_utils.require_aiter(device, op)`` -- same information plus
+    the backend, one exception type instead of three.
     """
     reason = _blocking_reason(op, backend, _device_arch(device))
     if reason is not None:

--- a/flashinfer/arch_caps.py
+++ b/flashinfer/arch_caps.py
@@ -20,7 +20,21 @@ which owns *whether the AITER package is importable*.
    is what keeps this module usable on that path.
 """
 
-__all__ = ["normalize_arch"]
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Mapping, Optional, Tuple
+
+__all__ = [
+    "ArchCapabilityError",
+    "ArchSupport",
+    "CAPABILITIES",
+    "KnownBad",
+    "Support",
+    "capability_available",
+    "normalize_arch",
+    "require_capability",
+]
 
 
 def normalize_arch(gcn_arch_name: str) -> str:
@@ -45,3 +59,313 @@ def normalize_arch(gcn_arch_name: str) -> str:
         whitespace), so this is safe to apply to already-normalized values.
     """
     return gcn_arch_name.split(":", 1)[0].strip()
+
+
+class ArchCapabilityError(ValueError, RuntimeError):
+    """Raised when an op is not usable on the running GPU architecture.
+
+    Both bases keep an existing caller working, so routing the three divergent
+    ROCm arch checks through one type churns no call sites:
+
+    - ``ValueError`` -- ``aiter_utils.require_aiter`` raised ``ValueError``, and
+      ``tests/rocm_tests/test_activation_aiter_hip.py:67`` asserts on it.
+    - ``RuntimeError`` -- ``prefill_rocm`` and ``mla_rocm`` raised
+      ``RuntimeError``, and
+      ``tests/rocm_tests/test_batch_prefill_bf16_custom_mask_hip.py:157``
+      catches it.
+
+    Deliberately *not* an ``ImportError``: a missing ``aiter`` package is a
+    different condition from an unsupported architecture, and the import probes
+    that raise ``ImportError`` are left alone.
+
+    Deliberately *not* a :class:`flashinfer.utils.GPUArchitectureError` either,
+    though that would be the tidier hierarchy. That class lives in
+    ``flashinfer/utils.py``, which imports torch at module scope, and this module
+    must stay torch-free -- ``hip_utils`` imports it at module scope, and
+    ``tests/conftest.py`` uses ``hip_utils`` to choose a GPU *before* pinning
+    ``HIP_VISIBLE_DEVICES``. Inheriting would drag torch onto that path and
+    silently defeat the pinning. Re-declaring the base locally was considered and
+    rejected: a same-named copy is a different class, so ``except
+    GPUArchitectureError`` would not catch it -- worse than not claiming the
+    relationship at all. No ROCm path raised ``GPUArchitectureError`` before this
+    change, so nothing regresses; ``skip_on_gpu_arch_error`` remains CUDA-only.
+    """
+
+
+class Support(Enum):
+    """Whether an (op, backend) pair may run on an architecture at all."""
+
+    SUPPORTED = "supported"
+    UNSUPPORTED = "unsupported"
+
+
+def _version_tuple(text: str) -> Tuple[int, ...]:
+    """``"7.2.4"`` -> ``(7, 2, 4)``; non-numeric trailing parts are dropped."""
+    parts = []
+    for chunk in text.split("."):
+        digits = ""
+        for ch in chunk:
+            if not ch.isdigit():
+                break
+            digits += ch
+        if not digits:
+            break
+        parts.append(int(digits))
+    return tuple(parts)
+
+
+@dataclass(frozen=True)
+class KnownBad:
+    """A toolchain window in which an otherwise-supported op is broken.
+
+    Support is not purely a property of ``(op, backend, arch)``: the one CDNA4
+    defect we have is a *compiler* bug, correct on ROCm 7.1 and wrong on 7.2.x
+    with everything else held constant. Bounds are literal version strings
+    rather than a predicate so the window is inspectable, renderable into docs,
+    and testable without a GPU.
+
+    Bounds are half-open: ``rocm_min`` inclusive, ``rocm_max`` exclusive.
+    """
+
+    rocm_min: Optional[str] = None
+    rocm_max: Optional[str] = None
+    aiter_min: Optional[str] = None
+    aiter_max: Optional[str] = None
+    detail: str = ""
+    url: str = ""
+
+    def matches(self, rocm: Optional[str], aiter: Optional[str]) -> bool:
+        """True when the live toolchain falls inside this window.
+
+        An unknown version does **not** match: refusing to route on a version we
+        could not read would break machines that are probably fine, and the
+        failure mode we are guarding against is already loud in the header.
+        """
+        for value, low, high in (
+            (rocm, self.rocm_min, self.rocm_max),
+            (aiter, self.aiter_min, self.aiter_max),
+        ):
+            if low is None and high is None:
+                continue
+            if value is None:
+                return False
+            v = _version_tuple(value)
+            if low is not None and v < _version_tuple(low):
+                return False
+            if high is not None and v >= _version_tuple(high):
+                return False
+        return True
+
+
+@dataclass(frozen=True)
+class ArchSupport:
+    """How one ``(op, backend)`` behaves on one architecture.
+
+    ``evidence`` records *what was actually run* -- board, ROCm, AITER, date --
+    rather than a bare "validated" flag. An empty string means the row is a
+    declaration nobody has measured, which is a fact worth being able to render.
+    """
+
+    support: Support
+    evidence: str = ""
+    caveat: str = ""
+    known_bad: Tuple[KnownBad, ...] = ()
+
+
+@dataclass(frozen=True)
+class Capability:
+    op: str
+    backend: str
+    archs: Mapping[str, ArchSupport] = field(default_factory=dict)
+    note: str = ""
+
+
+# --------------------------------------------------------------------------
+# The table.
+#
+# Keyed by (op, backend) because every call site already passes both halves
+# separately -- `require_aiter(input.device, "rmsnorm")` (norm.py:116) -- so
+# routing them through here changes no signatures.
+#
+# `evidence` is only filled in where a suite was actually run on that board. An
+# empty string means "declared, nobody measured it", which is a distinct and
+# useful thing for the docs to be able to say. The AITER rows carry evidence
+# from the runs below; the HIP rows deliberately do not yet.
+#
+#   gfx950  MI350X   27517 passed / 3585 skipped / 3 failed   (49a8cdd8)
+#   gfx942  MI300X   27520 passed / 3585 skipped / 0 failed   (49a8cdd8)
+#
+# both on torch 2.9.1+rocm7.2.0, HIP 7.2.26015, amd-aiter 0.1.10.
+# --------------------------------------------------------------------------
+
+_MEASURED_950 = "MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-19"
+_MEASURED_942 = "MI300X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-19"
+
+# The one defect measured so far. Upstream calls it a compiler bug and gates
+# their own test skips on exactly (major, minor) == (7, 2) with gfx950
+# (aiter op_tests/test_batch_prefill.py::should_skip_rocm72_issue, still present
+# at v0.1.20 -- so no amd-aiter upgrade avoids it).
+#
+# Confirmed here rather than taken on trust, torch and aiter held constant:
+#   ROCm 7.2.0  max_abs_err vs fp32 reference 0.595268   3/12 tests fail
+#   ROCm 7.2.4  max_abs_err vs fp32 reference 0.595268   (bit-identical)
+#   ROCm 7.1    max_abs_err vs fp32 reference 0.000250   12/12 tests pass
+_ROCM72_CAUSAL_PREFILL = KnownBad(
+    rocm_min="7.2",
+    rocm_max="7.3",
+    detail=(
+        "ROCm 7.2.x miscompiles AITER's causal batch-prefill kernel on gfx950: "
+        "causal=True with logits_soft_cap=0.0 returns wrong numbers (not an "
+        "error), 97.6% of elements off. Use ROCm 7.1, or backend='fa2'"
+    ),
+    url="https://github.com/ROCm/aiter/blob/main/op_tests/test_batch_prefill.py",
+)
+
+
+def _aiter(gfx942: ArchSupport, gfx950: ArchSupport) -> Mapping[str, ArchSupport]:
+    return {"gfx942": gfx942, "gfx950": gfx950}
+
+
+_OK_942 = ArchSupport(Support.SUPPORTED, evidence=_MEASURED_942)
+_OK_950 = ArchSupport(Support.SUPPORTED, evidence=_MEASURED_950)
+# HIP rows: declared, not yet individually attributed. The suites above cover
+# them, but no per-op HIP measurement has been recorded, so the evidence field
+# stays empty rather than borrowing the AITER runs' credibility.
+_HIP_942 = ArchSupport(Support.SUPPORTED)
+_HIP_950 = ArchSupport(Support.SUPPORTED)
+
+CAPABILITIES: Tuple[Capability, ...] = (
+    # --- AITER backends: measured on both architectures --------------------
+    Capability("batch_decode", "aiter", _aiter(_OK_942, _OK_950)),
+    Capability("single_prefill", "aiter", _aiter(_OK_942, _OK_950)),
+    Capability(
+        "batch_prefill",
+        "aiter",
+        _aiter(
+            _OK_942,
+            ArchSupport(
+                Support.SUPPORTED,
+                evidence=_MEASURED_950,
+                caveat=("causal=True is miscompiled on ROCm 7.2.x; correct on 7.1"),
+                known_bad=(_ROCM72_CAUSAL_PREFILL,),
+            ),
+        ),
+    ),
+    Capability("mla", "aiter", _aiter(_OK_942, _OK_950)),
+    Capability("rope", "aiter", _aiter(_OK_942, _OK_950)),
+    Capability("append_paged_kv_cache", "aiter", _aiter(_OK_942, _OK_950)),
+    Capability("rmsnorm", "aiter", _aiter(_OK_942, _OK_950)),
+    Capability("fused_add_rmsnorm", "aiter", _aiter(_OK_942, _OK_950)),
+    Capability("activation", "aiter", _aiter(_OK_942, _OK_950)),
+    # --- HIP backends: declared; per-op evidence not yet recorded ----------
+    Capability("single_decode", "hip", _aiter(_HIP_942, _HIP_950)),
+    Capability("batch_decode", "hip", _aiter(_HIP_942, _HIP_950)),
+    Capability("single_prefill", "hip", _aiter(_HIP_942, _HIP_950)),
+    Capability("batch_prefill", "hip", _aiter(_HIP_942, _HIP_950)),
+    Capability("cascade", "hip", _aiter(_HIP_942, _HIP_950)),
+    Capability("pod", "hip", _aiter(_HIP_942, _HIP_950)),
+    Capability("rope", "hip", _aiter(_HIP_942, _HIP_950)),
+    Capability("append_paged_kv_cache", "hip", _aiter(_HIP_942, _HIP_950)),
+    Capability("rmsnorm", "hip", _aiter(_HIP_942, _HIP_950)),
+    Capability("fused_add_rmsnorm", "hip", _aiter(_HIP_942, _HIP_950)),
+    Capability("layernorm", "hip", _aiter(_HIP_942, _HIP_950)),
+    Capability("sampling", "hip", _aiter(_HIP_942, _HIP_950)),
+    Capability("logits_processor", "hip", _aiter(_HIP_942, _HIP_950)),
+    Capability("activation", "hip", _aiter(_HIP_942, _HIP_950)),
+    Capability("quantization", "hip", _aiter(_HIP_942, _HIP_950)),
+)
+
+_BY_KEY = {(c.op, c.backend): c for c in CAPABILITIES}
+
+
+def _live_versions() -> Tuple[Optional[str], Optional[str]]:
+    """``(rocm_version, aiter_version)``, either ``None`` when undetectable."""
+    rocm = aiter = None
+    try:
+        import contextlib
+        import io
+
+        from .hip_utils import get_system_rocm_version
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            rocm = get_system_rocm_version()
+    except Exception:
+        pass
+    try:
+        import importlib.metadata as _md
+
+        aiter = _md.version("amd-aiter")
+    except Exception:
+        pass
+    return rocm, aiter
+
+
+def _lookup(op: str, backend: str, arch: str) -> Optional[ArchSupport]:
+    cap = _BY_KEY.get((op, backend))
+    if cap is None:
+        return None
+    return cap.archs.get(arch)
+
+
+def _blocking_reason(op: str, backend: str, arch: str) -> Optional[str]:
+    """Why this combination must not run, or ``None`` if it may.
+
+    An architecture absent from a row resolves to unsupported: adding an entry
+    to ``FLASHINFER_SUPPORTED_ROCM_ARCHS`` then grants nothing until someone
+    declares it here, which closes the "any new arch is AITER-supported for
+    free" hole.
+    """
+    entry = _lookup(op, backend, arch)
+    if entry is None:
+        return (
+            f"{backend} {op} is not declared for {arch} (see flashinfer/arch_caps.py)"
+        )
+    if entry.support is Support.UNSUPPORTED:
+        return f"{backend} {op} is not supported on {arch}"
+
+    rocm, aiter = _live_versions()
+    for bad in entry.known_bad:
+        if bad.matches(rocm, aiter):
+            where = f"rocm={rocm or 'unknown'} aiter={aiter or 'unknown'}"
+            detail = f": {bad.detail}" if bad.detail else ""
+            link = f" ({bad.url})" if bad.url else ""
+            if os.environ.get("FLASHINFER_ARCH_ALLOW_KNOWN_BAD", "0") == "1":
+                return None
+            return (
+                f"{backend} {op} is known-broken on {arch} with {where}{detail}"
+                f"{link}. Set FLASHINFER_ARCH_ALLOW_KNOWN_BAD=1 to run anyway"
+            )
+    return None
+
+
+def capability_available(op: str, backend: str, device) -> bool:
+    """Whether ``auto`` may route ``op`` to ``backend`` on ``device``.
+
+    Mirrors ``aiter_utils.is_aiter_available`` so it slots underneath the
+    existing selectors without changing their shape.
+    """
+    return _blocking_reason(op, backend, _device_arch(device)) is None
+
+
+def require_capability(op: str, backend: str, device) -> None:
+    """Raise :class:`ArchCapabilityError` if ``backend`` cannot serve ``op`` here.
+
+    Mirrors ``aiter_utils.require_aiter`` -- same ``(device, op)`` information,
+    one exception type instead of three.
+    """
+    reason = _blocking_reason(op, backend, _device_arch(device))
+    if reason is not None:
+        raise ArchCapabilityError(reason)
+
+
+def _device_arch(device) -> str:
+    """Normalized architecture of ``device``, or ``"unknown"``.
+
+    torch is imported lazily; see the module docstring.
+    """
+    try:
+        import torch
+
+        return normalize_arch(torch.cuda.get_device_properties(device).gcnArchName)
+    except Exception:
+        return "unknown"

--- a/tests/rocm_tests/test_arch_caps_hip.py
+++ b/tests/rocm_tests/test_arch_caps_hip.py
@@ -17,6 +17,7 @@ import pytest
 
 from flashinfer import arch_caps
 from flashinfer.arch_caps import normalize_arch
+from flashinfer.hip_utils import FLASHINFER_SUPPORTED_ROCM_ARCHS
 
 
 class TestNormalizeArch:
@@ -93,7 +94,11 @@ assert "torch" not in sys.modules, "arch_caps.py imported torch"
 # gfx950 on a CDNA3 box; today it is the reverse.
 # --------------------------------------------------------------------------
 
-SUPPORTED_ARCHS = ("gfx942", "gfx950")
+# Derived, not hard-coded: adding an arch to the allowlist must automatically
+# start exercising it in the routing tests below, not merely in the
+# declaration check. hip_utils is torch-free at module scope, and this file
+# already imports the package, so hoisting the import costs nothing.
+SUPPORTED_ARCHS = tuple(FLASHINFER_SUPPORTED_ROCM_ARCHS)
 
 
 @pytest.fixture
@@ -121,6 +126,17 @@ class TestTableWellFormed:
         keys = [(c.op, c.backend) for c in arch_caps.CAPABILITIES]
         assert len(keys) == len(set(keys)), "duplicate (op, backend) row"
 
+    def test_duplicate_rows_are_refused_at_index_time(self):
+        """A dict comprehension would let the later of two contradictory rows
+        win silently. Raising means a duplicate cannot reach a routing decision
+        even if it somehow reaches an interpreter without this suite."""
+        rows = (
+            arch_caps.Capability("rmsnorm", "aiter", {"gfx942": arch_caps._OK_942}),
+            arch_caps.Capability("rmsnorm", "aiter", {"gfx942": arch_caps._OK_950}),
+        )
+        with pytest.raises(ValueError, match="duplicate capability row"):
+            arch_caps._index(rows)
+
     def test_backends_are_known(self):
         assert {c.backend for c in arch_caps.CAPABILITIES} == {"aiter", "hip"}
 
@@ -128,15 +144,11 @@ class TestTableWellFormed:
         """The guard rail: adding an arch to FLASHINFER_SUPPORTED_ROCM_ARCHS
         must fail here until each op declares it, rather than silently
         inheriting support."""
-        from flashinfer.hip_utils import FLASHINFER_SUPPORTED_ROCM_ARCHS
-
         for cap in arch_caps.CAPABILITIES:
             missing = set(FLASHINFER_SUPPORTED_ROCM_ARCHS) - set(cap.archs)
             assert not missing, f"{cap.op}/{cap.backend} does not declare {missing}"
 
     def test_no_arch_keys_outside_the_supported_list(self):
-        from flashinfer.hip_utils import FLASHINFER_SUPPORTED_ROCM_ARCHS
-
         for cap in arch_caps.CAPABILITIES:
             extra = set(cap.archs) - set(FLASHINFER_SUPPORTED_ROCM_ARCHS)
             assert not extra, f"{cap.op}/{cap.backend} declares unknown {extra}"

--- a/tests/rocm_tests/test_arch_caps_hip.py
+++ b/tests/rocm_tests/test_arch_caps_hip.py
@@ -12,6 +12,7 @@ we can.
 import pathlib
 import subprocess
 import sys
+import types
 
 import pytest
 
@@ -137,6 +138,23 @@ class TestTableWellFormed:
         with pytest.raises(ValueError, match="duplicate capability row"):
             arch_caps._index(rows)
 
+    def test_all_lists_every_public_name(self):
+        """A public name absent from ``__all__`` is invisible to ``import *``
+        and to doc tooling. ``Capability`` was, even though ``CAPABILITIES`` is
+        exported and every element of it is one."""
+        defined_here = {
+            name
+            for name, obj in vars(arch_caps).items()
+            if not name.startswith("_")
+            and not isinstance(obj, types.ModuleType)
+            # Classes and functions carry __module__; module-level constants
+            # do not, so admit those by their naming convention.
+            and (
+                getattr(obj, "__module__", None) == arch_caps.__name__ or name.isupper()
+            )
+        }
+        assert defined_here == set(arch_caps.__all__)
+
     def test_backends_are_known(self):
         assert {c.backend for c in arch_caps.CAPABILITIES} == {"aiter", "hip"}
 
@@ -195,6 +213,30 @@ class TestVersionWindow:
     def test_rocm_window_is_half_open(self, rocm, expected):
         bad = arch_caps.KnownBad(rocm_min="7.2", rocm_max="7.3")
         assert bad.matches(rocm, None) is expected
+
+    @pytest.mark.parametrize(
+        "low,high,reported,expected",
+        [
+            # "7.2" and "7.2.0" name the same release, so the window must not
+            # care which form the machine reports. Raw tuple comparison makes
+            # (7, 2) < (7, 2, 0), which would drop the gate for the first row.
+            ("7.2.0", "7.3.0", "7.2", True),
+            ("7.2", "7.3", "7.2.0", True),
+            ("7.2.0", "7.3.0", "7.2.0", True),
+            # Padding must not blur the exclusive upper bound.
+            ("7.2.0", "7.3", "7.3.0", False),
+            ("7.2.0", "7.3.0", "7.3", False),
+            # ...nor the inclusive lower one.
+            ("7.2.0", "7.3.0", "7.1", False),
+        ],
+    )
+    def test_absent_components_are_zero_not_lower(self, low, high, reported, expected):
+        """`get_system_rocm_version_from_hipconfig` matches
+        ``\\d+\\.\\d+(?:\\.\\d+)?`` -- the patch component is optional, and on
+        TheRock builds that is the only detection method consulted, so a bare
+        "7.2" is a state we can actually be handed."""
+        bad = arch_caps.KnownBad(rocm_min=low, rocm_max=high)
+        assert bad.matches(reported, None) is expected
 
     def test_unknown_version_does_not_match(self):
         """Refusing to route because a version could not be read would break

--- a/tests/rocm_tests/test_arch_caps_hip.py
+++ b/tests/rocm_tests/test_arch_caps_hip.py
@@ -141,6 +141,24 @@ class TestTableWellFormed:
             extra = set(cap.archs) - set(FLASHINFER_SUPPORTED_ROCM_ARCHS)
             assert not extra, f"{cap.op}/{cap.backend} declares unknown {extra}"
 
+    def test_table_is_immutable(self):
+        """``frozen=True`` only stops fields being rebound -- a plain dict in
+        ``archs`` would still let any importer edit the global table in place and
+        silently change what every later caller is allowed to route."""
+        cap = arch_caps.CAPABILITIES[0]
+        arch = next(iter(cap.archs))
+        with pytest.raises(TypeError):
+            cap.archs[arch] = None
+        with pytest.raises(TypeError):
+            del cap.archs[arch]
+
+    def test_immutability_does_not_depend_on_the_construction_helper(self):
+        """The coercion lives on ``Capability`` rather than on ``_archs`` so a
+        row built any other way is protected too."""
+        cap = arch_caps.Capability("op", "hip", {"gfx942": arch_caps._OK_942})
+        with pytest.raises(TypeError):
+            cap.archs["gfx950"] = arch_caps._OK_950
+
     def test_known_bad_rows_explain_themselves(self):
         """A gate with no detail is unactionable for whoever hits it."""
         for cap in arch_caps.CAPABILITIES:
@@ -184,21 +202,21 @@ class TestGating:
         for cap in arch_caps.CAPABILITIES:
             if cap.backend != backend:
                 continue
-            assert arch_caps.capability_available(cap.op, cap.backend, None), (
+            assert arch_caps.capability_available(None, cap.op, cap.backend), (
                 f"{cap.op}/{cap.backend} unexpectedly gated on {arch}"
             )
 
     def test_undeclared_arch_is_refused(self, as_arch):
         """An arch nobody declared grants nothing, even for a real op."""
         as_arch("gfx90a")
-        assert not arch_caps.capability_available("rmsnorm", "aiter", None)
+        assert not arch_caps.capability_available(None, "rmsnorm", "aiter")
         with pytest.raises(arch_caps.ArchCapabilityError, match="gfx90a"):
-            arch_caps.require_capability("rmsnorm", "aiter", None)
+            arch_caps.require_capability(None, "rmsnorm", "aiter")
 
     def test_unknown_op_is_refused(self, as_arch):
         as_arch("gfx950")
         with pytest.raises(arch_caps.ArchCapabilityError, match="not declared"):
-            arch_caps.require_capability("no_such_op", "aiter", None)
+            arch_caps.require_capability(None, "no_such_op", "aiter")
 
 
 class TestRocm72CausalPrefill:
@@ -208,40 +226,75 @@ class TestRocm72CausalPrefill:
     def test_gated_on_gfx950_under_rocm_72(self, as_arch, as_toolchain):
         as_arch("gfx950")
         as_toolchain("7.2.0")
-        assert not arch_caps.capability_available("batch_prefill", "aiter", None)
+        assert not arch_caps.capability_available(None, "batch_prefill", "aiter")
         with pytest.raises(arch_caps.ArchCapabilityError, match="known-broken"):
-            arch_caps.require_capability("batch_prefill", "aiter", None)
+            arch_caps.require_capability(None, "batch_prefill", "aiter")
 
     def test_still_gated_on_the_latest_affected_patch(self, as_arch, as_toolchain):
         as_arch("gfx950")
         as_toolchain("7.2.4")
-        assert not arch_caps.capability_available("batch_prefill", "aiter", None)
+        assert not arch_caps.capability_available(None, "batch_prefill", "aiter")
 
     def test_open_on_gfx950_under_rocm_71(self, as_arch, as_toolchain):
         """Measured clean: max_abs_err 0.000250, 12/12 parametrizations pass."""
         as_arch("gfx950")
         as_toolchain("7.1")
-        assert arch_caps.capability_available("batch_prefill", "aiter", None)
+        assert arch_caps.capability_available(None, "batch_prefill", "aiter")
 
     def test_gfx942_unaffected_on_the_same_toolchain(self, as_arch, as_toolchain):
         """This is the whole point of keying on arch as well as version."""
         as_arch("gfx942")
         as_toolchain("7.2.0")
-        assert arch_caps.capability_available("batch_prefill", "aiter", None)
+        assert arch_caps.capability_available(None, "batch_prefill", "aiter")
 
     def test_hip_fallback_stays_open_where_aiter_is_gated(self, as_arch, as_toolchain):
         """The gate is only useful if `auto` has somewhere correct to fall back
         to -- fa2 was measured correct on the same hardware (2.6e-4)."""
         as_arch("gfx950")
         as_toolchain("7.2.0")
-        assert arch_caps.capability_available("batch_prefill", "hip", None)
+        assert arch_caps.capability_available(None, "batch_prefill", "hip")
 
     def test_escape_hatch_opts_in_to_danger(self, as_arch, as_toolchain, monkeypatch):
         """Opt in to the broken path, never opt in to safety."""
         as_arch("gfx950")
         as_toolchain("7.2.0")
         monkeypatch.setenv("FLASHINFER_ARCH_ALLOW_KNOWN_BAD", "1")
-        assert arch_caps.capability_available("batch_prefill", "aiter", None)
+        assert arch_caps.capability_available(None, "batch_prefill", "aiter")
+
+
+class TestVersionProbeIsCheap:
+    """Version detection shells out (``amd-smi``, ``dpkg``, ``hipconfig``, each
+    with a timeout). A per-routing-decision query must not pay that repeatedly."""
+
+    def test_rows_without_a_window_never_probe(self, as_arch, monkeypatch):
+        """23 of 24 rows have no ``known_bad``, so the probe is skipped outright
+        rather than merely being fast the second time."""
+        calls = []
+
+        def counted():
+            calls.append(1)
+            return ("7.2.0", "0.1.10")
+
+        monkeypatch.setattr(arch_caps, "_live_versions", counted)
+        as_arch("gfx950")
+        assert arch_caps.capability_available(None, "rmsnorm", "aiter")
+        assert calls == []
+
+        # ...but a row that does carry a window still consults it.
+        assert not arch_caps.capability_available(None, "batch_prefill", "aiter")
+        assert calls == [1]
+
+    def test_detection_runs_once_per_process(self):
+        """Guards the ``lru_cache``: without it every gated query would re-run
+        the subprocess probes."""
+        arch_caps._live_versions.cache_clear()
+        try:
+            first = arch_caps._live_versions()
+            second = arch_caps._live_versions()
+            assert first == second
+            assert arch_caps._live_versions.cache_info().misses == 1
+        finally:
+            arch_caps._live_versions.cache_clear()
 
 
 class TestArchCapabilityError:

--- a/tests/rocm_tests/test_arch_caps_hip.py
+++ b/tests/rocm_tests/test_arch_caps_hip.py
@@ -82,3 +82,181 @@ assert "torch" not in sys.modules, "arch_caps.py imported torch"
         [sys.executable, "-c", code], capture_output=True, text=True, timeout=60
     )
     assert result.returncode == 0, result.stderr
+
+
+# --------------------------------------------------------------------------
+# Capability table
+#
+# Everything below is GPU-free by construction: the arch is monkeypatched.
+# That is the point -- it lets the architecture we cannot physically reach be
+# tested on whichever one we happen to have. Historically that meant simulating
+# gfx950 on a CDNA3 box; today it is the reverse.
+# --------------------------------------------------------------------------
+
+SUPPORTED_ARCHS = ("gfx942", "gfx950")
+
+
+@pytest.fixture
+def as_arch(monkeypatch):
+    """Pretend the running device is a given architecture."""
+
+    def _set(arch):
+        monkeypatch.setattr(arch_caps, "_device_arch", lambda _device=None: arch)
+
+    return _set
+
+
+@pytest.fixture
+def as_toolchain(monkeypatch):
+    """Pretend a given (rocm, aiter) pair is installed."""
+
+    def _set(rocm, aiter="0.1.10"):
+        monkeypatch.setattr(arch_caps, "_live_versions", lambda: (rocm, aiter))
+
+    return _set
+
+
+class TestTableWellFormed:
+    def test_keys_are_unique(self):
+        keys = [(c.op, c.backend) for c in arch_caps.CAPABILITIES]
+        assert len(keys) == len(set(keys)), "duplicate (op, backend) row"
+
+    def test_backends_are_known(self):
+        assert {c.backend for c in arch_caps.CAPABILITIES} == {"aiter", "hip"}
+
+    def test_every_supported_arch_declared_in_every_row(self):
+        """The guard rail: adding an arch to FLASHINFER_SUPPORTED_ROCM_ARCHS
+        must fail here until each op declares it, rather than silently
+        inheriting support."""
+        from flashinfer.hip_utils import FLASHINFER_SUPPORTED_ROCM_ARCHS
+
+        for cap in arch_caps.CAPABILITIES:
+            missing = set(FLASHINFER_SUPPORTED_ROCM_ARCHS) - set(cap.archs)
+            assert not missing, f"{cap.op}/{cap.backend} does not declare {missing}"
+
+    def test_no_arch_keys_outside_the_supported_list(self):
+        from flashinfer.hip_utils import FLASHINFER_SUPPORTED_ROCM_ARCHS
+
+        for cap in arch_caps.CAPABILITIES:
+            extra = set(cap.archs) - set(FLASHINFER_SUPPORTED_ROCM_ARCHS)
+            assert not extra, f"{cap.op}/{cap.backend} declares unknown {extra}"
+
+    def test_known_bad_rows_explain_themselves(self):
+        """A gate with no detail is unactionable for whoever hits it."""
+        for cap in arch_caps.CAPABILITIES:
+            for arch, entry in cap.archs.items():
+                for bad in entry.known_bad:
+                    assert bad.detail, f"{cap.op}/{cap.backend}/{arch}: empty detail"
+
+
+class TestVersionWindow:
+    @pytest.mark.parametrize(
+        "rocm,expected",
+        [
+            ("7.1", False),
+            ("7.1.1", False),
+            ("7.2", True),
+            ("7.2.0", True),
+            ("7.2.4", True),  # measured: bit-identical failure to 7.2.0
+            ("7.3", False),
+            ("7.14", False),  # (7,14) > (7,3): a later release, not 7.1.4
+        ],
+    )
+    def test_rocm_window_is_half_open(self, rocm, expected):
+        bad = arch_caps.KnownBad(rocm_min="7.2", rocm_max="7.3")
+        assert bad.matches(rocm, None) is expected
+
+    def test_unknown_version_does_not_match(self):
+        """Refusing to route because a version could not be read would break
+        machines that are probably fine."""
+        bad = arch_caps.KnownBad(rocm_min="7.2", rocm_max="7.3")
+        assert bad.matches(None, None) is False
+
+
+class TestGating:
+    @pytest.mark.parametrize("arch", SUPPORTED_ARCHS)
+    @pytest.mark.parametrize("backend", ["aiter", "hip"])
+    def test_declared_rows_are_routable_on_a_clean_toolchain(
+        self, as_arch, as_toolchain, arch, backend
+    ):
+        as_arch(arch)
+        as_toolchain("7.1")  # outside every known_bad window
+        for cap in arch_caps.CAPABILITIES:
+            if cap.backend != backend:
+                continue
+            assert arch_caps.capability_available(cap.op, cap.backend, None), (
+                f"{cap.op}/{cap.backend} unexpectedly gated on {arch}"
+            )
+
+    def test_undeclared_arch_is_refused(self, as_arch):
+        """An arch nobody declared grants nothing, even for a real op."""
+        as_arch("gfx90a")
+        assert not arch_caps.capability_available("rmsnorm", "aiter", None)
+        with pytest.raises(arch_caps.ArchCapabilityError, match="gfx90a"):
+            arch_caps.require_capability("rmsnorm", "aiter", None)
+
+    def test_unknown_op_is_refused(self, as_arch):
+        as_arch("gfx950")
+        with pytest.raises(arch_caps.ArchCapabilityError, match="not declared"):
+            arch_caps.require_capability("no_such_op", "aiter", None)
+
+
+class TestRocm72CausalPrefill:
+    """The one measured defect: gfx950 + ROCm 7.2.x miscompiles AITER causal
+    batch prefill. gfx942 is fine on the same toolchain."""
+
+    def test_gated_on_gfx950_under_rocm_72(self, as_arch, as_toolchain):
+        as_arch("gfx950")
+        as_toolchain("7.2.0")
+        assert not arch_caps.capability_available("batch_prefill", "aiter", None)
+        with pytest.raises(arch_caps.ArchCapabilityError, match="known-broken"):
+            arch_caps.require_capability("batch_prefill", "aiter", None)
+
+    def test_still_gated_on_the_latest_affected_patch(self, as_arch, as_toolchain):
+        as_arch("gfx950")
+        as_toolchain("7.2.4")
+        assert not arch_caps.capability_available("batch_prefill", "aiter", None)
+
+    def test_open_on_gfx950_under_rocm_71(self, as_arch, as_toolchain):
+        """Measured clean: max_abs_err 0.000250, 12/12 parametrizations pass."""
+        as_arch("gfx950")
+        as_toolchain("7.1")
+        assert arch_caps.capability_available("batch_prefill", "aiter", None)
+
+    def test_gfx942_unaffected_on_the_same_toolchain(self, as_arch, as_toolchain):
+        """This is the whole point of keying on arch as well as version."""
+        as_arch("gfx942")
+        as_toolchain("7.2.0")
+        assert arch_caps.capability_available("batch_prefill", "aiter", None)
+
+    def test_hip_fallback_stays_open_where_aiter_is_gated(self, as_arch, as_toolchain):
+        """The gate is only useful if `auto` has somewhere correct to fall back
+        to -- fa2 was measured correct on the same hardware (2.6e-4)."""
+        as_arch("gfx950")
+        as_toolchain("7.2.0")
+        assert arch_caps.capability_available("batch_prefill", "hip", None)
+
+    def test_escape_hatch_opts_in_to_danger(self, as_arch, as_toolchain, monkeypatch):
+        """Opt in to the broken path, never opt in to safety."""
+        as_arch("gfx950")
+        as_toolchain("7.2.0")
+        monkeypatch.setenv("FLASHINFER_ARCH_ALLOW_KNOWN_BAD", "1")
+        assert arch_caps.capability_available("batch_prefill", "aiter", None)
+
+
+class TestArchCapabilityError:
+    def test_satisfies_every_existing_catcher(self):
+        """Routing three divergent exception types through one class only works
+        if the old ones still catch it.
+
+        ValueError: test_activation_aiter_hip.py:67 asserts on it.
+        RuntimeError: test_batch_prefill_bf16_custom_mask_hip.py:157 catches it.
+        """
+        err = arch_caps.ArchCapabilityError("boom")
+        assert isinstance(err, ValueError)
+        assert isinstance(err, RuntimeError)
+
+    def test_is_not_an_import_error(self):
+        """A missing aiter package is a different condition and keeps its own
+        exception type."""
+        assert not isinstance(arch_caps.ArchCapabilityError("x"), ImportError)


### PR DESCRIPTION
## Summary

Architecture gating today is a single boolean allowlist — `FLASHINFER_SUPPORTED_ROCM_ARCHS` — so no code path distinguishes gfx942 from gfx950, and that same list is reused by `is_aiter_supported()`. Any architecture added for in-tree HIP kernels silently becomes "AITER-supported" too. This adds the table that makes support explicit per `(op, backend, arch)`.

**No behaviour change.** Nothing consumes the table yet; routing the three divergent AITER validators through it is a follow-up.

### What changed

- **`flashinfer/arch_caps.py`** — `Support`, `KnownBad`, `ArchSupport`, `Capability`, the `CAPABILITIES` table (24 rows), `ArchCapabilityError`, and the query API (`capability_available` / `require_capability`).
- **`tests/rocm_tests/test_arch_caps_hip.py`** — 53 tests across table well-formedness, immutability, version-window arithmetic, gating, version-probe cost, and the exception contract.

### Architecture / design notes

**Support is not a per-arch enum, because the defect we have is not architectural.** The one measured CDNA4 problem is a *compiler* bug: same architecture, same amd-aiter, correct on ROCm 7.1 and wrong on 7.2.x. A per-arch status can only record one of those. So a row carries a binary gate plus optional `KnownBad` version windows, with literal bounds so the window is inspectable, renderable into docs, and testable without a GPU.

Measured on an MI350X, torch and amd-aiter held constant, ROCm the only variable:

```
ROCm 7.2.0   max_abs_err vs fp32 reference 0.595268   3/12 tests fail
ROCm 7.2.4   max_abs_err vs fp32 reference 0.595268   bit-identical, four patches later
ROCm 7.1     max_abs_err vs fp32 reference 0.000250   12/12 tests pass
```

Upstream calls this a compiler bug and gates their own test skips on exactly `(major, minor) == (7, 2)` with gfx950 (`op_tests/test_batch_prefill.py::should_skip_rocm72_issue`), still present at aiter **v0.1.20** — so no amd-aiter upgrade avoids it. The window here was confirmed by measurement rather than taken from that comment.

**Rows carry `evidence`, not a "validated" flag.** Each entry names what was actually run — board / ROCm / AITER / torch / date. The AITER rows are populated from full-suite runs on both architectures at `49a8cdd8`: gfx942 **27520 passed / 0 failed**, gfx950 **27517 passed / 3 failed** (those 3 being the defect above). HIP rows are declared but their evidence is deliberately **left empty** — the suites cover them, but no per-op HIP attribution was recorded, and borrowing the AITER runs' credibility would be exactly the unearned claim this table exists to remove.

**An architecture absent from a row resolves to unsupported**, so adding one to the allowlist grants nothing until it is declared. A conformance test enforces the converse — every allowlisted architecture must appear in every row — so adding e.g. gfx1200 fails CI until someone states what it can do. That closes the "any new arch is AITER-supported for free" hole.

**`ArchCapabilityError` subclasses `ValueError` and `RuntimeError`** so the three divergent exception types can collapse to one without breaking either existing catcher (`test_activation_aiter_hip.py:67` asserts `ValueError`; `test_batch_prefill_bf16_custom_mask_hip.py:157` catches `RuntimeError`).

It is deliberately **not** a `utils.GPUArchitectureError`, though that is the tidier hierarchy. That class lives in `flashinfer/utils.py`, which imports torch at module scope, and this module must stay torch-free — `hip_utils` imports it before `tests/conftest.py` pins `HIP_VISIBLE_DEVICES`. Re-declaring the base locally was tried and rejected: a same-named copy is a different class, so `except GPUArchitectureError` would not catch it, which is worse than not claiming the relationship at all. No ROCm path raised that type before, so nothing regresses and `skip_on_gpu_arch_error` remains CUDA-only.

**The table is immutable, and `device` leads the query signature.** `frozen=True` on `Capability` only stops the fields being rebound — a plain dict in `archs` would still let any importer edit the global table in place, so `__post_init__` coerces it to a `MappingProxyType`. The coercion sits on the class rather than on the row-construction helper, so it holds however a row is built. `ArchSupport` and `KnownBad` are already frozen with tuple fields, so nothing below that point is mutable either. Separately, `capability_available` / `require_capability` take `device` first to share a prefix with `aiter_utils.require_aiter(device, op)`: `op` and `backend` are both `str`, so a slip between them would be silent, and this keeps every migration to "append `backend`".

**Version detection is probed at most once.** `get_system_rocm_version()` walks up to four methods, three of which shell out (`amd-smi`, `dpkg`, `hipconfig`) with timeouts — too expensive to repeat per routing decision. It is now `lru_cache`d, and `_blocking_reason` skips it entirely for rows with no `known_bad` window, which is 23 of the 24 rows. Only the one gated row pays anything at all.

**The escape hatch is `FLASHINFER_ARCH_ALLOW_KNOWN_BAD=1`** — opt in to danger, never opt in to safety. An unreadable version does not match a window, so a machine whose ROCm we cannot detect is not gated on a guess.

### CDNA3 impact

None. Nothing calls into the table yet, and gfx942 is `SUPPORTED` for every declared row with no `known_bad` window.

## Test plan

Verified on gfx950 (MI350X, ROCm 7.2.0, torch 2.9.1+rocm7.2.0, amd-aiter 0.1.10):

- [x] 53 new tests pass.
- [x] `test_hip_utils.py` passes unchanged (69 tests).
- [x] The gating tests monkeypatch the architecture, so **gfx942 behaviour is exercised on a machine that has no gfx942** — including that gfx942 stays open on ROCm 7.2 where gfx950 is gated, which is the whole reason the window keys on both.
- [x] The module remains torch-free, enforced by a subprocess test that loads it by file path (importing via the package would run `flashinfer/__init__.py`, which pulls in torch, and prove nothing).
- [x] `pre-commit run -a`