### PR TITLE
fix(aiter): route the arch validators through the capability table

### DIFF
--- a/benchmarks/rocm_benchmarks/bench_rope.py
+++ b/benchmarks/rocm_benchmarks/bench_rope.py
@@ -130,7 +130,7 @@ def _run_fn(op_mode, positions, query, key, cos_sin_cache, backend):
 
 @torch.inference_mode()
 def _make_configs(op_modes: list[str]) -> list[KernelConfig]:
-    aiter_ok = is_aiter_available(torch.device("cuda"))
+    aiter_ok = is_aiter_available(torch.device("cuda"), "rope")
     if not aiter_ok:
         print(
             "[bench_rope] AITER unavailable on this device; benchmarking native only."
@@ -177,7 +177,7 @@ def _make_configs(op_modes: list[str]) -> list[KernelConfig]:
 def _accuracy() -> None:
     """Print max abs error of AITER vs the native kernel (the auto policy's
     precision axis): bf16 sits near the tolerance edge, fp16 is comfortably safe."""
-    if not is_aiter_available(torch.device("cuda")):
+    if not is_aiter_available(torch.device("cuda"), "rope"):
         print("[bench_rope] AITER unavailable; cannot run accuracy comparison.")
         return
     print(f"{'dtype':>6s} {'nnz':>7s} {'max_abs_err':>14s}")

--- a/flashinfer/aiter_utils.py
+++ b/flashinfer/aiter_utils.py
@@ -47,6 +47,15 @@ def is_aiter_available(device: torch.device, op: str) -> bool:
     native kernel (rather than raising at build time) when the AITER package is not
     installed or not importable. Explicit ``backend="aiter"`` still surfaces a clear
     error via :func:`require_aiter`.
+
+    Args:
+        device: The device the op would run on.
+        op: The capability-table op name, e.g. ``"rmsnorm"``. Required, and it
+            changes the answer: support is per ``(op, arch)``, so one op can be
+            gated on a toolchain where another is fine -- AITER batch prefill is
+            gated on gfx950 under ROCm 7.2.x while every other op stays open.
+            The name must match a row in :data:`flashinfer.arch_caps.CAPABILITIES`
+            or the lookup treats it as undeclared and returns False.
     """
     return capability_available(device, op, "aiter") and _aiter_importable()
 

--- a/flashinfer/aiter_utils.py
+++ b/flashinfer/aiter_utils.py
@@ -6,7 +6,7 @@ import functools
 
 import torch
 
-from .arch_caps import normalize_arch
+from .arch_caps import capability_available, normalize_arch, require_capability
 from .hip_utils import FLASHINFER_SUPPORTED_ROCM_ARCHS
 
 
@@ -40,7 +40,7 @@ def _aiter_importable() -> bool:
     return True
 
 
-def is_aiter_available(device: torch.device) -> bool:
+def is_aiter_available(device: torch.device, op: str) -> bool:
     """Return True when ``backend="auto"`` may route to AITER for ``device``.
 
     Combines the arch check with an import probe so ``auto`` falls back to the
@@ -48,21 +48,23 @@ def is_aiter_available(device: torch.device) -> bool:
     installed or not importable. Explicit ``backend="aiter"`` still surfaces a clear
     error via :func:`require_aiter`.
     """
-    return is_aiter_supported(device) and _aiter_importable()
+    return capability_available(device, op, "aiter") and _aiter_importable()
 
 
 def require_aiter(device: torch.device, op: str) -> None:
     """Validate the explicit ``backend="aiter"`` opt-in, raising a clear error.
 
-    Surfaces a ``ValueError`` (rather than a raw ``ImportError`` from the JIT module
-    loader) when the device is unsupported or the AITER package is missing/broken,
-    matching the public-API docs that say this mode "requires the aiter package".
+    The architecture half is delegated to the capability table, so this op can be
+    gated on more than "is the arch in the allowlist" -- e.g. a toolchain in which
+    the kernel is known to be miscompiled. ``ArchCapabilityError`` subclasses
+    ``ValueError``, so the previous contract is unchanged for callers.
+
+    The package check stays here: a missing ``aiter`` is a different condition
+    from an unusable architecture, and it keeps raising a ``ValueError`` rather
+    than a raw ``ImportError`` from the JIT loader, matching the public-API docs
+    that say this mode "requires the aiter package".
     """
-    if not is_aiter_supported(device):
-        raise ValueError(
-            f"AITER {op} requires an AMD gfx942/gfx950 device; got {device}. "
-            "Use backend='native' instead."
-        )
+    require_capability(device, op, "aiter")
     if not _aiter_importable():
         raise ValueError(
             f"backend='aiter' for {op} requires the aiter package, which is not "

--- a/flashinfer/arch_caps.py
+++ b/flashinfer/arch_caps.py
@@ -215,6 +215,13 @@ class Capability:
     backend: str
     archs: Mapping[str, ArchSupport] = field(default_factory=dict)
     note: str = ""
+    # The public ``backend=`` string to suggest when this row is unavailable.
+    # Declared per row because it is not derivable: the table keys backends as
+    # "aiter"/"hip", but the user-facing argument spells the HIP path "native"
+    # for rope/norm/activation/page-append and "fa2" for prefill and decode.
+    # Empty means no alternative exists -- ``mla`` accepts only 'auto'/'aiter',
+    # so suggesting anything there would send the user into a ValueError.
+    fallback: str = ""
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "archs", MappingProxyType(dict(self.archs)))
@@ -277,8 +284,8 @@ _HIP_950 = ArchSupport(Support.SUPPORTED)
 
 CAPABILITIES: Tuple[Capability, ...] = (
     # --- AITER backends: measured on both architectures --------------------
-    Capability("batch_decode", "aiter", _archs(_OK_942, _OK_950)),
-    Capability("single_prefill", "aiter", _archs(_OK_942, _OK_950)),
+    Capability("batch_decode", "aiter", _archs(_OK_942, _OK_950), fallback="fa2"),
+    Capability("single_prefill", "aiter", _archs(_OK_942, _OK_950), fallback="fa2"),
     Capability(
         "batch_prefill",
         "aiter",
@@ -291,13 +298,18 @@ CAPABILITIES: Tuple[Capability, ...] = (
                 known_bad=(_ROCM72_CAUSAL_PREFILL,),
             ),
         ),
+        fallback="fa2",
     ),
-    Capability("mla", "aiter", _archs(_OK_942, _OK_950)),
-    Capability("rope", "aiter", _archs(_OK_942, _OK_950)),
-    Capability("append_paged_kv_cache", "aiter", _archs(_OK_942, _OK_950)),
-    Capability("rmsnorm", "aiter", _archs(_OK_942, _OK_950)),
-    Capability("fused_add_rmsnorm", "aiter", _archs(_OK_942, _OK_950)),
-    Capability("silu_and_mul", "aiter", _archs(_OK_942, _OK_950)),
+    Capability("mla", "aiter", _archs(_OK_942, _OK_950)),  # no alternative backend
+    Capability("rope", "aiter", _archs(_OK_942, _OK_950), fallback="native"),
+    Capability(
+        "append_paged_kv_cache", "aiter", _archs(_OK_942, _OK_950), fallback="native"
+    ),
+    Capability("rmsnorm", "aiter", _archs(_OK_942, _OK_950), fallback="native"),
+    Capability(
+        "fused_add_rmsnorm", "aiter", _archs(_OK_942, _OK_950), fallback="native"
+    ),
+    Capability("silu_and_mul", "aiter", _archs(_OK_942, _OK_950), fallback="native"),
     # --- HIP backends: declared; per-op evidence not yet recorded ----------
     Capability("single_decode", "hip", _archs(_HIP_942, _HIP_950)),
     Capability("batch_decode", "hip", _archs(_HIP_942, _HIP_950)),
@@ -391,10 +403,14 @@ def _blocking_reason(op: str, backend: str, arch: str) -> Optional[str]:
         # a CPU tensor or a non-ROCm device, where "not declared for unknown"
         # would be accurate and useless.
         supported = "/".join(sorted(cap.archs))
-        return (
-            f"{backend} {op} requires an AMD {supported} device; got {arch!r}. "
-            f"Use backend='native' instead"
-        )
+        msg = f"{backend} {op} requires an AMD {supported} device; got {arch!r}"
+        # Only suggest a fallback the op actually accepts. A blanket
+        # "use backend='native'" is wrong for prefill and decode (they take
+        # 'fa2') and impossible for mla, which accepts only 'auto'/'aiter' --
+        # following it would trade this error for an "Unknown backend" one.
+        if cap.fallback:
+            msg += f". Use backend={cap.fallback!r} instead"
+        return msg
     if entry.support is Support.UNSUPPORTED:
         return f"{backend} {op} is not supported on {arch}"
     if not entry.known_bad:
@@ -432,12 +448,12 @@ def capability_reason(device, op: str, backend: str) -> Optional[str]:
 def capability_available(device, op: str, backend: str) -> bool:
     """Whether ``auto`` may route ``op`` to ``backend`` on ``device``.
 
-    ``device`` leads to match the gating helpers this is meant to replace
-    (``aiter_utils.is_aiter_available(device)``,
-    ``aiter_utils.require_aiter(device, op)``), so migrating a call site is
-    appending ``backend`` rather than reordering. ``op`` and ``backend`` are both
-    ``str``, so an argument-order slip between them would be silent -- keeping
-    the shared prefix identical is what stops one happening.
+    ``device`` leads to match the gating helpers this backs
+    (``aiter_utils.is_aiter_available(device, op)``,
+    ``aiter_utils.require_aiter(device, op)``), so those delegate by appending
+    ``backend`` rather than reordering. ``op`` and ``backend`` are both ``str``,
+    so an argument-order slip between them would be silent -- keeping the shared
+    prefix identical is what stops one happening.
     """
     return _blocking_reason(op, backend, _device_arch(device)) is None
 

--- a/flashinfer/arch_caps.py
+++ b/flashinfer/arch_caps.py
@@ -35,6 +35,7 @@ __all__ = [
     "KnownBad",
     "Support",
     "capability_available",
+    "capability_reason",
     "normalize_arch",
     "require_capability",
 ]
@@ -296,7 +297,7 @@ CAPABILITIES: Tuple[Capability, ...] = (
     Capability("append_paged_kv_cache", "aiter", _archs(_OK_942, _OK_950)),
     Capability("rmsnorm", "aiter", _archs(_OK_942, _OK_950)),
     Capability("fused_add_rmsnorm", "aiter", _archs(_OK_942, _OK_950)),
-    Capability("activation", "aiter", _archs(_OK_942, _OK_950)),
+    Capability("silu_and_mul", "aiter", _archs(_OK_942, _OK_950)),
     # --- HIP backends: declared; per-op evidence not yet recorded ----------
     Capability("single_decode", "hip", _archs(_HIP_942, _HIP_950)),
     Capability("batch_decode", "hip", _archs(_HIP_942, _HIP_950)),
@@ -311,7 +312,7 @@ CAPABILITIES: Tuple[Capability, ...] = (
     Capability("layernorm", "hip", _archs(_HIP_942, _HIP_950)),
     Capability("sampling", "hip", _archs(_HIP_942, _HIP_950)),
     Capability("logits_processor", "hip", _archs(_HIP_942, _HIP_950)),
-    Capability("activation", "hip", _archs(_HIP_942, _HIP_950)),
+    Capability("silu_and_mul", "hip", _archs(_HIP_942, _HIP_950)),
     Capability("quantization", "hip", _archs(_HIP_942, _HIP_950)),
 )
 
@@ -383,8 +384,16 @@ def _blocking_reason(op: str, backend: str, arch: str) -> Optional[str]:
     """
     entry = _lookup(op, backend, arch)
     if entry is None:
+        cap = _BY_KEY.get((op, backend))
+        if cap is None:
+            return f"{backend} {op} is not a declared capability"
+        # Name the architectures that would work. The common way to land here is
+        # a CPU tensor or a non-ROCm device, where "not declared for unknown"
+        # would be accurate and useless.
+        supported = "/".join(sorted(cap.archs))
         return (
-            f"{backend} {op} is not declared for {arch} (see flashinfer/arch_caps.py)"
+            f"{backend} {op} requires an AMD {supported} device; got {arch!r}. "
+            f"Use backend='native' instead"
         )
     if entry.support is Support.UNSUPPORTED:
         return f"{backend} {op} is not supported on {arch}"
@@ -406,6 +415,18 @@ def _blocking_reason(op: str, backend: str, arch: str) -> Optional[str]:
                 f"{link}. Set FLASHINFER_ARCH_ALLOW_KNOWN_BAD=1 to run anyway"
             )
     return None
+
+
+def capability_reason(device, op: str, backend: str) -> Optional[str]:
+    """Why ``backend`` cannot serve ``op`` on ``device``, or ``None`` if it can.
+
+    The ``auto`` selectors already build a human-readable ``reason`` string per
+    unmet constraint and warn once per ``(device, reason)``. Returning the reason
+    rather than a bare bool lets a capability gate slot into that machinery as
+    one more reason, so a user whose batch prefill silently dropped to ``fa2``
+    can find out why.
+    """
+    return _blocking_reason(op, backend, _device_arch(device))
 
 
 def capability_available(device, op: str, backend: str) -> bool:

--- a/flashinfer/decode_rocm.py
+++ b/flashinfer/decode_rocm.py
@@ -1149,6 +1149,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     head_dim_qk=head_dim,
                     head_dim_vo=head_dim,
                     pos_encoding_mode=pos_encoding_mode,
+                    # Decode borrows the prefill selector, but it is a distinct
+                    # capability row -- the gates are not the same op.
+                    op="batch_decode",
                 )
         if self._backend == "aiter":
             if self.use_tensor_cores:

--- a/flashinfer/mla_rocm.py
+++ b/flashinfer/mla_rocm.py
@@ -10,8 +10,7 @@ from typing import Optional, Tuple, Union
 
 import torch
 
-from .aiter_utils import is_aiter_supported
-from .arch_caps import normalize_arch
+from .arch_caps import require_capability
 
 
 @functools.cache
@@ -62,12 +61,13 @@ def _kv_lens_to_last_page_len_cpu(
 
 
 def _require_aiter_mla(device: torch.device) -> None:
-    if not is_aiter_supported(device):
-        try:
-            arch = normalize_arch(torch.cuda.get_device_properties(device).gcnArchName)
-        except Exception:
-            arch = "unknown"
-        raise RuntimeError(f"AITER MLA requires a gfx942/gfx950 GPU; got '{arch}'.")
+    """MLA is AITER-only -- there is no HIP fallback -- so the arch gate here is
+    the only thing between a user and a kernel that cannot run.
+
+    ``ArchCapabilityError`` subclasses ``RuntimeError``, preserving the previous
+    contract.
+    """
+    require_capability(device, "mla", "aiter")
     try:
         _aiter_mla()
     except ImportError as exc:

--- a/flashinfer/norm.py
+++ b/flashinfer/norm.py
@@ -53,7 +53,7 @@ if IS_HIP:
             input.ndim == 2
             and input.dtype in (torch.float16, torch.bfloat16)
             and weight.dtype == input.dtype
-            and is_aiter_available(input.device)
+            and is_aiter_available(input.device, "rmsnorm")
         ):
             return "aiter"
         return "native"
@@ -65,7 +65,11 @@ if IS_HIP:
         # a later performance pass.)
         from .aiter_utils import is_aiter_available
 
-        return "aiter" if is_aiter_available(input.device) else "native"
+        return (
+            "aiter"
+            if is_aiter_available(input.device, "fused_add_rmsnorm")
+            else "native"
+        )
 
 
 def rmsnorm(

--- a/flashinfer/page.py
+++ b/flashinfer/page.py
@@ -30,7 +30,7 @@ from .utils import (
 )
 
 if IS_HIP:
-    from .aiter_utils import is_aiter_supported
+    from .arch_caps import capability_available
 
     @functools.cache
     def _aiter_cache_module():
@@ -49,7 +49,7 @@ if IS_HIP:
         kv_layout: str,
     ) -> str:
         """Return 'aiter' when GPU + dtype + layout meet AITER's reshape_and_cache_flash constraints."""
-        if not is_aiter_supported(device):
+        if not capability_available(device, "append_paged_kv_cache", "aiter"):
             return "native"
         if kv_layout != "NHD":
             return "native"

--- a/flashinfer/prefill_rocm.py
+++ b/flashinfer/prefill_rocm.py
@@ -25,8 +25,7 @@ from types import SimpleNamespace
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union, overload
 
 import torch
-from .aiter_utils import is_aiter_supported
-from .arch_caps import normalize_arch
+from .arch_caps import capability_reason, require_capability
 from .jit.core import logger
 from .jit import (
     gen_batch_prefill_module,
@@ -308,20 +307,15 @@ def _aiter_ops_importable() -> bool:
         return False
 
 
-def _require_aiter_runtime(device: torch.device) -> None:
-    """Raise a clear error when AITER is requested on an unsupported GPU or without the package."""
-    if not is_aiter_supported(device):
-        try:
-            arch = (
-                normalize_arch(torch.cuda.get_device_properties(device).gcnArchName)
-                if torch.version.hip
-                else "non-ROCm"
-            )
-        except Exception:
-            arch = "unknown"
-        raise RuntimeError(
-            f"The 'aiter' backend requires a gfx942/gfx950 GPU; got '{arch}'."
-        )
+def _require_aiter_runtime(device: torch.device, op: str = "batch_prefill") -> None:
+    """Raise a clear error when AITER is requested on an unsupported GPU or without the package.
+
+    ``op`` selects the capability row, so a gate that applies to batch prefill
+    (such as the ROCm 7.2 causal miscompile on gfx950) does not also block single
+    prefill. ``ArchCapabilityError`` subclasses ``RuntimeError``, so the previous
+    contract is unchanged for callers.
+    """
+    require_capability(device, op, "aiter")
     if not _aiter_ops_importable():
         raise ImportError(
             "The 'aiter' package is required for the AITER backend. "
@@ -344,30 +338,39 @@ def _auto_select_prefill_backend(
     head_dim_qk: int,
     head_dim_vo: int,
     pos_encoding_mode: str = "NONE",
+    op: str = "batch_prefill",
 ) -> str:
     """Return 'aiter' when the GPU and call parameters satisfy AITER's constraints; else 'fa2'.
 
     On gfx942/gfx950, checks NHD layout, no custom mask, fp16/bf16, equal dtypes and head dims.
     Falls back to 'fa2' with a one-time warning for each distinct skip reason.
-    """
-    if not is_aiter_supported(device):
-        return "fa2"
 
-    reason: Optional[str] = None
-    if kv_layout != "NHD":
-        reason = f"kv_layout={kv_layout!r} (AITER requires NHD)"
-    elif has_custom_mask:
-        reason = "custom mask (not supported by AITER)"
-    elif dtype_q not in (torch.float16, torch.bfloat16):
-        reason = f"dtype={dtype_q} (AITER requires fp16/bf16)"
-    elif dtype_q != dtype_kv:
-        reason = (
-            f"dtype_q={dtype_q} != dtype_kv={dtype_kv} (AITER requires equal dtypes)"
-        )
-    elif head_dim_qk != head_dim_vo:
-        reason = f"head_dim_qk={head_dim_qk} != head_dim_vo={head_dim_vo} (AITER requires equal head dims)"
-    elif pos_encoding_mode != "NONE":
-        reason = f"pos_encoding_mode={pos_encoding_mode!r} (AITER only supports NONE)"
+    ``op`` selects the capability row. It matters because the gates are not
+    uniform across ops: the ROCm 7.2 causal miscompile on gfx950 applies to batch
+    prefill only, so checking a single shared "is AITER supported here" would
+    either under- or over-block.
+    """
+    # The capability gate is just one more reason, so an architecture or
+    # toolchain that cannot serve this op warns once and falls back like any
+    # other unmet constraint. Previously an unsupported architecture returned
+    # "fa2" silently, which on CDNA4 would mean a user quietly losing the AITER
+    # path with nothing to explain it.
+    reason: Optional[str] = capability_reason(device, op, "aiter")
+    if reason is None:
+        if kv_layout != "NHD":
+            reason = f"kv_layout={kv_layout!r} (AITER requires NHD)"
+        elif has_custom_mask:
+            reason = "custom mask (not supported by AITER)"
+        elif dtype_q not in (torch.float16, torch.bfloat16):
+            reason = f"dtype={dtype_q} (AITER requires fp16/bf16)"
+        elif dtype_q != dtype_kv:
+            reason = f"dtype_q={dtype_q} != dtype_kv={dtype_kv} (AITER requires equal dtypes)"
+        elif head_dim_qk != head_dim_vo:
+            reason = f"head_dim_qk={head_dim_qk} != head_dim_vo={head_dim_vo} (AITER requires equal head dims)"
+        elif pos_encoding_mode != "NONE":
+            reason = (
+                f"pos_encoding_mode={pos_encoding_mode!r} (AITER only supports NONE)"
+            )
 
     if reason is not None:
         key = (device, reason)
@@ -1437,10 +1440,11 @@ def single_prefill_with_kv_cache(
             head_dim_qk=q.shape[-1],
             head_dim_vo=v.shape[-1],
             pos_encoding_mode=pos_encoding_mode,
+            op="single_prefill",
         )
 
     if backend == "aiter":
-        _require_aiter_runtime(q.device)
+        _require_aiter_runtime(q.device, "single_prefill")
         if pos_encoding_mode != "NONE":
             raise ValueError(
                 f"AITER backend does not support pos_encoding_mode={pos_encoding_mode!r}; "
@@ -1729,7 +1733,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
             )
             backend = "fa2"
         elif backend == "aiter":
-            _require_aiter_runtime(float_workspace_buffer.device)
+            _require_aiter_runtime(float_workspace_buffer.device, "batch_prefill")
 
         self._float_workspace_buffer = float_workspace_buffer
         self._workspace_size = (
@@ -2119,6 +2123,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     head_dim_qk=head_dim_qk,
                     head_dim_vo=head_dim_vo,
                     pos_encoding_mode=pos_encoding_mode,
+                    op="batch_prefill",
                 )
             if self._backend == "aiter" and pos_encoding_mode != "NONE":
                 raise ValueError(
@@ -2788,7 +2793,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 f"backend must be one of 'fa2', 'aiter', 'auto'; got {backend!r}"
             )
         if backend == "aiter":
-            _require_aiter_runtime(float_workspace_buffer.device)
+            _require_aiter_runtime(float_workspace_buffer.device, "batch_prefill")
         self._kv_layout = kv_layout
         self._float_workspace_buffer = float_workspace_buffer
         self.device = float_workspace_buffer.device
@@ -3077,6 +3082,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     head_dim_qk=head_dim_qk,
                     head_dim_vo=head_dim_vo,
                     pos_encoding_mode=pos_encoding_mode,
+                    op="batch_prefill",
                 )
             if self._backend == "aiter" and pos_encoding_mode != "NONE":
                 raise ValueError(

--- a/tests/rocm_tests/test_arch_caps_hip.py
+++ b/tests/rocm_tests/test_arch_caps_hip.py
@@ -202,14 +202,32 @@ class TestTableWellFormed:
         import re
 
         pkg = pathlib.Path(arch_caps.__file__).parent
+        # Both the aiter_utils wrappers and the capability API they delegate to:
+        # mla_rocm and page.py call require_capability / capability_available
+        # directly, and those op strings drift just as easily. All five take the
+        # op second, so one alternation covers them.
         pattern = re.compile(
-            r'(?:require_aiter|is_aiter_available)\([^,()]*(?:\([^()]*\))?[^,()]*,\s*"([a-z_]+)"'
+            r"(?:require_aiter|is_aiter_available|require_capability"
+            r'|capability_available|capability_reason)\([^,()]*(?:\([^()]*\))?[^,()]*,\s*"([a-z_]+)"'
         )
         used = set()
-        for src in pkg.glob("*.py"):
+        for src in pkg.rglob("*.py"):  # subpackages too, not just the top level
             used |= set(pattern.findall(src.read_text()))
 
+        # Coverage is not total, and pretending otherwise would be worse than
+        # the gap: prefill_rocm and decode_rocm pass `op` as a variable, so no
+        # literal-matching scan can see batch_prefill / batch_decode /
+        # single_prefill. Those are reached by the runtime tests instead.
         assert used, "scan found no op names; the pattern has rotted"
+        # These two are reached *only* through require_capability /
+        # capability_available (mla_rocm.py, page.py), never through the
+        # aiter_utils wrappers. Their presence is what proves the alternation
+        # still covers the capability API directly; drop it and the scan
+        # silently narrows back to the wrappers while still passing.
+        assert {"mla", "append_paged_kv_cache"} <= used, (
+            "scan no longer sees ops called through the capability API: "
+            f"{sorted({'mla', 'append_paged_kv_cache'} - used)}"
+        )
         declared = {c.op for c in arch_caps.CAPABILITIES if c.backend == "aiter"}
         assert used <= declared, (
             f"ops passed by the library but absent from the table: "

--- a/tests/rocm_tests/test_arch_caps_hip.py
+++ b/tests/rocm_tests/test_arch_caps_hip.py
@@ -189,6 +189,33 @@ class TestTableWellFormed:
         with pytest.raises(TypeError):
             cap.archs["gfx950"] = arch_caps._OK_950
 
+    def test_every_op_the_library_asks_for_is_declared(self):
+        """The table is only useful if its row names match what callers pass.
+
+        ``require_capability`` raises for an unknown op, so a mismatch turns
+        into a hard failure at the call site -- which is how the first version
+        of this table was caught declaring "activation" while
+        ``activation.py`` passes "silu_and_mul". Scan the source so that drift
+        fails here, cheaply and without a GPU, instead of in whichever op
+        happens to be exercised first.
+        """
+        import re
+
+        pkg = pathlib.Path(arch_caps.__file__).parent
+        pattern = re.compile(
+            r'(?:require_aiter|is_aiter_available)\([^,()]*(?:\([^()]*\))?[^,()]*,\s*"([a-z_]+)"'
+        )
+        used = set()
+        for src in pkg.glob("*.py"):
+            used |= set(pattern.findall(src.read_text()))
+
+        assert used, "scan found no op names; the pattern has rotted"
+        declared = {c.op for c in arch_caps.CAPABILITIES if c.backend == "aiter"}
+        assert used <= declared, (
+            f"ops passed by the library but absent from the table: "
+            f"{sorted(used - declared)}"
+        )
+
     def test_known_bad_rows_explain_themselves(self):
         """A gate with no detail is unactionable for whoever hits it."""
         for cap in arch_caps.CAPABILITIES:
@@ -269,8 +296,15 @@ class TestGating:
 
     def test_unknown_op_is_refused(self, as_arch):
         as_arch("gfx950")
-        with pytest.raises(arch_caps.ArchCapabilityError, match="not declared"):
+        with pytest.raises(arch_caps.ArchCapabilityError, match="not a declared"):
             arch_caps.require_capability(None, "no_such_op", "aiter")
+
+    def test_undeclared_arch_message_names_the_ones_that_work(self, as_arch):
+        """A CPU tensor is the common way to land here, and "not declared for
+        unknown" would be accurate but useless."""
+        as_arch("unknown")
+        reason = arch_caps.capability_reason(None, "silu_and_mul", "aiter")
+        assert "gfx942" in reason and "gfx950" in reason
 
 
 class TestRocm72CausalPrefill:

--- a/tests/rocm_tests/test_arch_caps_hip.py
+++ b/tests/rocm_tests/test_arch_caps_hip.py
@@ -306,6 +306,46 @@ class TestGating:
         reason = arch_caps.capability_reason(None, "silu_and_mul", "aiter")
         assert "gfx942" in reason and "gfx950" in reason
 
+    @pytest.mark.parametrize(
+        "op,suggested",
+        [
+            # prefill and decode reject 'native' outright -- they take 'fa2'.
+            ("batch_prefill", "fa2"),
+            ("single_prefill", "fa2"),
+            ("batch_decode", "fa2"),
+            ("rope", "native"),
+            ("rmsnorm", "native"),
+            ("silu_and_mul", "native"),
+            ("append_paged_kv_cache", "native"),
+        ],
+    )
+    def test_suggested_fallback_is_one_the_op_accepts(self, as_arch, op, suggested):
+        """The advice has to be followable. A blanket "use backend='native'"
+        would hand prefill and decode users a string their own validation
+        rejects with "Unknown backend", trading one error for a worse one."""
+        as_arch("unknown")
+        reason = arch_caps.capability_reason(None, op, "aiter")
+        assert f"backend={suggested!r}" in reason
+
+    def test_no_fallback_is_suggested_when_none_exists(self, as_arch):
+        """mla accepts only 'auto'/'aiter' (mla_rocm.py:112), so naming any
+        alternative would be a dead end. Say nothing rather than something
+        wrong."""
+        as_arch("unknown")
+        reason = arch_caps.capability_reason(None, "mla", "aiter")
+        assert "gfx942" in reason
+        assert "backend=" not in reason
+
+    def test_declared_fallbacks_are_real_backend_strings(self):
+        """Guards against a typo in the table turning into advice that cannot
+        work. 'auto' is excluded deliberately: suggesting it as the escape from
+        a gate that 'auto' itself already applied would be circular."""
+        for cap in arch_caps.CAPABILITIES:
+            if cap.fallback:
+                assert cap.fallback in {"native", "fa2"}, (
+                    f"{cap.op}/{cap.backend} suggests unknown backend {cap.fallback!r}"
+                )
+
 
 class TestRocm72CausalPrefill:
     """The one measured defect: gfx950 + ROCm 7.2.x miscompiles AITER causal

--- a/tests/rocm_tests/test_batch_prefill_kernels_hip.py
+++ b/tests/rocm_tests/test_batch_prefill_kernels_hip.py
@@ -691,7 +691,19 @@ def test_batch_prefill_auto_selects_aiter(page_size, causal, return_lse):
         causal=causal,
     )
 
-    # Verify auto resolved to aiter
+    # `auto` resolves to aiter only where the capability table allows it. On a
+    # gated toolchain -- ROCm 7.2.x on gfx950 miscompiles this kernel -- the
+    # correct behaviour is to steer away from AITER, so assert that instead and
+    # skip the numeric comparison, which would otherwise be fa2 against fa2.
+    from flashinfer.arch_caps import capability_available, capability_reason
+
+    if not capability_available(device, "batch_prefill", "aiter"):
+        assert wrapper_auto._backend != "aiter", (
+            "capability table gates AITER batch prefill here, but auto still "
+            f"chose it: {capability_reason(device, 'batch_prefill', 'aiter')}"
+        )
+        pytest.skip(capability_reason(device, "batch_prefill", "aiter"))
+
     assert wrapper_auto._backend == "aiter", (
         f"Expected backend='aiter' on gfx942/gfx950, got '{wrapper_auto._backend}'"
     )

--- a/tests/rocm_tests/test_batch_prefill_kernels_hip.py
+++ b/tests/rocm_tests/test_batch_prefill_kernels_hip.py
@@ -19,6 +19,24 @@ import logging
 logger.setLevel(logging.ERROR)
 
 
+def _skip_if_prefill_gated(device):
+    """Skip when the capability table gates AITER batch prefill on this toolchain.
+
+    A test that asks for ``backend="aiter"`` explicitly gets an
+    ``ArchCapabilityError`` out of the wrapper constructor once the gate applies
+    -- currently gfx950 on ROCm 7.2.x, where the causal kernel is miscompiled.
+    That is the gate doing its job, so a test comparing AITER output against a
+    reference has nothing left to prove and should stand down.
+
+    Use this for tests that assert *numbers*. Tests that only assert plumbing can
+    set ``FLASHINFER_ARCH_ALLOW_KNOWN_BAD=1`` instead and keep their coverage.
+    """
+    from flashinfer.arch_caps import capability_available, capability_reason
+
+    if not capability_available(device, "batch_prefill", "aiter"):
+        pytest.skip(capability_reason(device, "batch_prefill", "aiter"))
+
+
 @pytest.fixture(autouse=True, scope="module")
 def warmup_jit():
     flashinfer.jit.build_jit_specs(
@@ -77,6 +95,8 @@ def test_batch_prefill_with_paged_kv_cache(
         not is_aiter_supported(torch.device("cuda:0")) or not _aiter_ops_importable()
     ):
         pytest.skip("AITER requires a gfx942/gfx950 GPU and the aiter package")
+    if backend == "aiter":
+        _skip_if_prefill_gated(torch.device("cuda:0"))
 
     if backend == "aiter" and (causal or kv_layout != "NHD"):
         pytest.skip("Not testing for aiter backend with causal or kv_layout != NHD")
@@ -331,6 +351,8 @@ def test_batch_prefill_with_tuple_paged_kv_cache(
         not is_aiter_supported(torch.device("cuda:0")) or not _aiter_ops_importable()
     ):
         pytest.skip("AITER requires a gfx942/gfx950 GPU and the aiter package")
+    if backend == "aiter":
+        _skip_if_prefill_gated(torch.device("cuda:0"))
 
     if backend == "aiter" and (causal or kv_layout != "NHD"):
         pytest.skip("Not testing for aiter backend with causal")
@@ -567,10 +589,13 @@ def test_batch_prefill_with_ragged_kv_cache(
 ):
     if qo_len > kv_len and causal:
         pytest.skip("qo_len > kv_len and causal is not supported")
-    if backend == "aiter" and (
-        not is_aiter_supported(torch.device("cuda:0")) or not _aiter_ops_importable()
-    ):
-        pytest.skip("AITER requires a gfx942/gfx950 GPU and the aiter package")
+    if backend == "aiter":
+        if (
+            not is_aiter_supported(torch.device("cuda:0"))
+            or not _aiter_ops_importable()
+        ):
+            pytest.skip("AITER requires a gfx942/gfx950 GPU and the aiter package")
+        _skip_if_prefill_gated(torch.device("cuda:0"))
     kv_layout = "NHD"
     q = torch.randn(
         batch_size * qo_len,
@@ -749,6 +774,7 @@ def test_batch_prefill_aiter_flat_gather_bf16(page_size, causal, return_lse):
     device = torch.device("cuda:0")
     if not is_aiter_supported(device) or not _aiter_ops_importable():
         pytest.skip("AITER requires a gfx942/gfx950 GPU and the aiter package")
+    _skip_if_prefill_gated(device)
 
     batch_size, qo_len, kv_len = 4, 16, 128
     num_qo_heads, num_kv_heads, head_dim = 8, 8, 128
@@ -844,6 +870,9 @@ def test_batch_prefill_aiter_falls_back_when_native_paging_missing(
         pytest.skip("AITER requires a gfx942/gfx950 GPU and the aiter package")
     if page_size not in _aiter_native_page_sizes():
         pytest.skip(f"page_size={page_size} is not native on this amd-aiter build")
+    # Ends in an assert_close against fa2 with causal=True, so it is a numerics
+    # test despite being named for the fallback.
+    _skip_if_prefill_gated(device)
 
     def _reject(*args, **kwargs):
         raise RuntimeError(
@@ -930,6 +959,10 @@ def test_batch_prefill_aiter_falls_back_when_native_paging_missing(
 
 def test_batch_prefill_aiter_strict_mode_raises(monkeypatch):
     """FLASHINFER_AITER_STRICT=1 must surface the AITER failure instead of degrading."""
+    # Asserts plumbing and compares no numbers, so the ROCm 7.2 gfx950 causal
+    # miscompile cannot affect the outcome. Opt past the capability gate rather
+    # than skip and lose the coverage on the one architecture we can run.
+    monkeypatch.setenv("FLASHINFER_ARCH_ALLOW_KNOWN_BAD", "1")
     device = torch.device("cuda:0")
     if not is_aiter_supported(device) or not _aiter_ops_importable():
         pytest.skip("AITER requires a gfx942/gfx950 GPU and the aiter package")


### PR DESCRIPTION
## Summary

Three validators answered the same question — may AITER serve this op on this GPU — in three ways, with three exception types: `require_aiter` (`ValueError`), `_require_aiter_runtime` (`RuntimeError`), `_require_aiter_mla` (`RuntimeError`). None could express anything beyond "is the arch in the allowlist", so the ROCm 7.2 miscompile on gfx950 was unrepresentable and `backend="auto"` routed causal batch prefill straight into it, returning wrong numbers with no diagnostic.

This routes the **architecture half** of each check through the capability table added in #285. It is the first change that makes that table do anything.

### What changed

- **`flashinfer/aiter_utils.py`** — `require_aiter` and `is_aiter_available` delegate the arch check; `is_aiter_available` gains an `op`.
- **`flashinfer/prefill_rocm.py`** — `_require_aiter_runtime` and `_auto_select_prefill_backend` gain an `op`; the gate folds into the existing warn-once `reason` cascade.
- **`flashinfer/mla_rocm.py`**, **`flashinfer/page.py`**, **`flashinfer/decode_rocm.py`** — routed, with their own op names.
- **`flashinfer/arch_caps.py`** — adds `capability_reason`, and names the supported architectures when a device is undeclared.
- **`benchmarks/rocm_benchmarks/bench_rope.py`** — updated for the `is_aiter_available` signature.
- **`tests/rocm_tests/test_batch_prefill_kernels_hip.py`** — teaches the whole file about the gate, not just the `auto` test (see below).
- **`tests/rocm_tests/test_arch_caps_hip.py`** — covers the per-op fallback suggestion.

### Architecture / design notes

**Only the arch half moves.** The three import probes stay deliberately different (`aiter`+`aiter_meta`+`aiter.jit.core` for the C++ shim path; `aiter.ops`; `aiter.mla`) and keep raising `ImportError`, because a missing package is a different condition from an unusable architecture.

**The selectors gain an `op`, and this is not cosmetic.** The gates are not uniform across ops, so a single shared "is AITER supported here" would either under-block (missing the batch-prefill gate) or over-block (needlessly disabling single prefill and decode, which are fine). `_auto_select_prefill_backend` is shared by single prefill, batch prefill and batch decode, and each now selects its own capability row.

**The gate is one more `reason`, not a separate path.** Previously an unsupported architecture returned `"fa2"` *silently*; now a gated op warns once per `(device, reason)`, so a user who quietly lost the AITER path can find out why. The existing cascade is wrapped rather than extended — appending an `elif` would have let a later condition overwrite the capability reason.

**Two defects the suite caught that reasoning did not.** The table declared `activation` while `activation.py` passes `silu_and_mul`; row names must match the strings callers actually use, so a conformance test now scans the package for op strings and fails if any is undeclared. And the undeclared-arch message read *"not declared for unknown"*, which is accurate and useless for the common case of a CPU tensor — it now names the architectures that would work, which also means `test_activation_aiter_hip.py:67` passes **unchanged** rather than needing its match string retargeted.

**The suggested fallback backend is declared per op, not guessed.** The undeclared-arch diagnostic first read "Use `backend='native'` instead", which is unfollowable for most of the table: prefill and decode accept `auto`/`fa2`/`aiter` and reject `native` with `ValueError: Unknown backend`, and `mla` accepts only `auto`/`aiter`, so it has no alternative at all. It is not derivable either — the table keys backends as `aiter`/`hip`, while the public argument spells the HIP path `native` for rope/norm/activation/page-append and `fa2` for prefill and decode. So `Capability.fallback` states it per row, and an empty value means the message omits the suggestion rather than inventing one.

**Gating the op turned the prefill suite red, and the fix is not uniform.** Once the gate applies, every explicit `backend="aiter"` batch-prefill wrapper raises out of its constructor — but only `test_batch_prefill_auto_selects_aiter` (which uses `auto`) knew about it. The numerics tests now stand down through a shared `_skip_if_prefill_gated()` helper that skips with the table's own reason string; that includes `_aiter_falls_back_when_native_paging_missing`, which is named for plumbing but ends in an `assert_close` against fa2 with `causal=True`. `test_batch_prefill_aiter_strict_mode_raises` instead keeps running under `FLASHINFER_ARCH_ALLOW_KNOWN_BAD=1`: it asserts that STRICT surfaces the AITER error rather than degrading and compares no numbers, so the miscompile cannot change its outcome, and skipping it would have cost real coverage on the only architecture available to run it. Nothing that previously passed is now skipped — on a gated toolchain no aiter batch-prefill test in that file could have passed.

### Known limitation

The gate keys on `(op, backend, arch, toolchain)`, not on call parameters, so it blocks batch prefill on gfx950/ROCm 7.2 including `causal=False` — which is measured *correct*. That is conservative in the safe direction. Refining it means letting `KnownBad` carry a predicate over call parameters (upstream's own skip is `causal and logits_soft_cap == 0.0`); deferred rather than bolted on here.

### CDNA3 impact

Nothing gated. Verified directly on an MI300X with the **same ROCm 7.2.0** that gates gfx950 — all seven AITER ops remain available, so the gate is architecture-specific rather than a blanket ROCm 7.2 block:

```
arch: gfx942:sramecc+:xnack-   toolchain: ('7.2.0', '0.1.10')
batch_prefill  single_prefill  batch_decode  mla  rmsnorm  silu_and_mul  rope  ->  all available
```

## Test plan

On gfx950 (MI350X, ROCm 7.2.0, torch 2.9.1+rocm7.2.0, amd-aiter 0.1.10):

- [x] The gate fires precisely: `batch_prefill`/aiter unavailable; `single_prefill`, `batch_decode`, `mla`, `rmsnorm`, `silu_and_mul`, `rope` unaffected.
- [x] `test_batch_prefill_auto_selects_aiter`: **3 failed (wrong numbers) → 12 skipped**, with `auto` asserted to have steered away from AITER rather than merely skipping.
- [x] `test_batch_prefill_kernels_hip.py` whole file: **3493 passed, 4210 skipped, 0 failed**. Before the test fix this file had ≥25 failures on this box, reproduced at `2deb7fdf` to confirm the gate landing was the cause rather than anything later in the branch.
- [x] `test_arch_caps_hip.py`: 64 passed, covering the suggested backend per op and that `mla` suggests none.
- [x] `arch_caps`, `hip_utils`, `activation`, `rmsnorm`, `norm`, `rope` and `mla` suites pass.
- [x] `pre-commit run -a`

On gfx942 (MI300X):

- [x] No capability gate fires on the same toolchain (above).
- [x] **Full CDNA3 suite: 27557 passed, 3585 skipped, 0 failed, 0 errors** — MI300X, ROCm 7.2.0, torch 2.9.1+rocm7.2.0, amd-aiter 0.1.10, branch at `20b8b22f`, `pytest tests/rocm_tests -m "not slow" --reruns 2`, exit 0. This is the one change in the series that alters what user code observes on both architectures, so the result is measured here rather than inferred. Against `49a8cdd8` on the same host (27520 passed / 3585 skipped / 0 failed) the delta is +37 passed, all of them tests this PR adds; the skip count is unchanged, so nothing on CDNA3 became newly gated.

  <sub>Counts reconstructed by tallying pytest's progress characters: with `-q` the run logs the dot/`s` stream and the per-file warning summary but not the final `N passed` line. The same tally reproduces the numbers already reported for #283 (27505) and for `49a8cdd8` (27520) from their logs, so the method is consistent with what is recorded elsewhere in this series.</sub>
