### PR TITLE
docs(rocm): generate the per-architecture support matrix from the table

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,3 +85,16 @@ repos:
         language: system
         files: ^(include/flashinfer/attention/generic/|include/gpu_iface/).*\.(cuh|hpp|h)$
         pass_filenames: true
+
+  # The README's per-architecture support matrix is generated from
+  # flashinfer/arch_caps.py. Catch a table edit that did not regenerate it here,
+  # rather than after someone trusts the stale row. Imports no third-party
+  # package, so it runs anywhere pre-commit does.
+  - repo: local
+    hooks:
+      - id: arch-support-matrix
+        name: README arch support matrix is current
+        entry: python3 scripts/gen_arch_support_matrix.py --check
+        language: system
+        files: ^(flashinfer/arch_caps\.py|README\.md|scripts/gen_arch_support_matrix\.py)$
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ kernel library to AMD Instinct GPUs — currently
 [CDNA3](https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-3-white-paper.pdf)
 (gfx942 — MI300X / MI325X) and
 [CDNA4](https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-4-architecture-whitepaper.pdf)
-(gfx950 — MI355X). It ships in-tree HIP ports of the attention,
+(gfx950 — MI350X / MI355X). It ships in-tree HIP ports of the attention,
 KV-cache, RoPE, normalization, sampling, and logits-processor kernels,
 and transparently dispatches a subset of attention paths to AMD's
 [AITER](https://github.com/ROCm/aiter) backend when its compatibility
@@ -78,7 +78,7 @@ HIP is documented in [Known Limitations](#known-limitations) below.
 
 ## GPU, ROCm, and PyTorch Support
 
-**Supported GPUs:** gfx942 (CDNA3 — MI300X, MI325X), gfx950 (CDNA4 — MI355X).
+**Supported GPUs:** gfx942 (CDNA3 — MI300X, MI325X), gfx950 (CDNA4 — MI350X, MI355X).
 
 ### Per-architecture support matrix
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,57 @@ HIP is documented in [Known Limitations](#known-limitations) below.
 
 **Supported GPUs:** gfx942 (CDNA3 — MI300X, MI325X), gfx950 (CDNA4 — MI355X).
 
+### Per-architecture support matrix
+
+The two architectures are not interchangeable for every op. The table below is
+generated from [`flashinfer/arch_caps.py`](flashinfer/arch_caps.py), which is
+what `backend="auto"` actually consults at runtime — so it cannot drift from
+the routing decisions the library makes. Do not edit it by hand; run
+`python3 scripts/gen_arch_support_matrix.py`.
+
+<!-- BEGIN GENERATED: arch support matrix -- scripts/gen_arch_support_matrix.py -->
+
+| Op | Backend | gfx942 (CDNA3) | gfx950 (CDNA4) |
+| :--- | :--- | :---: | :---: |
+| `batch_decode` | `aiter` | ✅ | ✅ |
+| `single_prefill` | `aiter` | ✅ | ✅ |
+| `batch_prefill` | `aiter` | ✅ | ⚠️[^kb1] |
+| `mla` | `aiter` | ✅ | ✅ |
+| `rope` | `aiter` | ✅ | ✅ |
+| `append_paged_kv_cache` | `aiter` | ✅ | ✅ |
+| `rmsnorm` | `aiter` | ✅ | ✅ |
+| `fused_add_rmsnorm` | `aiter` | ✅ | ✅ |
+| `silu_and_mul` | `aiter` | ✅ | ✅ |
+| `single_decode` | `hip` | ◻️ | ◻️ |
+| `batch_decode` | `hip` | ◻️ | ◻️ |
+| `single_prefill` | `hip` | ◻️ | ◻️ |
+| `batch_prefill` | `hip` | ◻️ | ◻️ |
+| `cascade` | `hip` | ◻️ | ◻️ |
+| `pod` | `hip` | ◻️ | ◻️ |
+| `rope` | `hip` | ◻️ | ◻️ |
+| `append_paged_kv_cache` | `hip` | ◻️ | ◻️ |
+| `rmsnorm` | `hip` | ◻️ | ◻️ |
+| `fused_add_rmsnorm` | `hip` | ◻️ | ◻️ |
+| `layernorm` | `hip` | ◻️ | ◻️ |
+| `sampling` | `hip` | ◻️ | ◻️ |
+| `logits_processor` | `hip` | ◻️ | ◻️ |
+| `silu_and_mul` | `hip` | ◻️ | ◻️ |
+| `quantization` | `hip` | ◻️ | ◻️ |
+
+* ✅ **validated** — a suite was run on that board, and the evidence is recorded below.
+* ◻️ **declared** — supported, but no per-op measurement has been recorded on that architecture.
+* ⚠️ **broken on some toolchains** — usable, but not on every ROCm/AITER version; see the footnote.
+* ❌ **not available** on that architecture.
+
+[^kb1]: `batch_prefill/aiter` on gfx950, ROCm [7.2, 7.3): ROCm 7.2.x miscompiles AITER's causal batch-prefill kernel on gfx950: causal=True with logits_soft_cap=0.0 returns wrong numbers (not an error), 97.6% of elements off. Use ROCm 7.1, or backend='fa2'. Override with `FLASHINFER_ARCH_ALLOW_KNOWN_BAD=1` if you have validated it yourself. <https://github.com/ROCm/aiter/blob/main/op_tests/test_batch_prefill.py>
+
+Measured on:
+
+* `gfx942` — MI300X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-19
+* `gfx950` — MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-19
+
+<!-- END GENERATED: arch support matrix -->
+
 **Supported ROCm versions:** 7.0.2, 7.1.1, 7.2.
 
 **Supported PyTorch+ROCm versions:** 2.8.0, 2.9.1.

--- a/scripts/gen_arch_support_matrix.py
+++ b/scripts/gen_arch_support_matrix.py
@@ -72,7 +72,19 @@ def _load_arch_caps():
     sys.modules[pkg_name] = package
 
     qualified = f"{pkg_name}.arch_caps"
-    spec = importlib.util.spec_from_file_location(qualified, PKG_DIR / "arch_caps.py")
+    source = PKG_DIR / "arch_caps.py"
+    # Two separate failures, both of which otherwise surface inside a pre-commit
+    # hook as a traceback that does not say which file was being loaded:
+    #   - the file is missing or unreadable. spec_from_file_location happily
+    #     returns a spec for a path that does not exist, so this has to be
+    #     checked here rather than inferred from the spec.
+    #   - the spec or its loader is None, which is what happens if the module is
+    #     ever renamed to something importlib has no source loader for.
+    if not source.is_file():
+        raise SystemExit(f"cannot read the capability table at {source}")
+    spec = importlib.util.spec_from_file_location(qualified, source)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"no Python source loader for {source}")
     module = importlib.util.module_from_spec(spec)
     sys.modules[qualified] = module
     spec.loader.exec_module(module)
@@ -109,7 +121,12 @@ def _window(bad) -> str:
 
 
 def _cell(entry, footnote_ids: dict[int, int]) -> str:
-    if entry is None or entry.support is not entry.support.SUPPORTED:
+    # `type(...)` reaches the Support enum itself. Reading the member off another
+    # member (entry.support.SUPPORTED) resolves to the same object today, but
+    # only because enums still allow that lookup -- it has been on and off the
+    # deprecation list, and it reads as though SUPPORTED were an attribute of
+    # the value rather than a sibling member.
+    if entry is None or entry.support is not type(entry.support).SUPPORTED:
         return UNSUPPORTED
     if entry.known_bad:
         refs = "".join(f"[^kb{footnote_ids[id(bad)]}]" for bad in entry.known_bad)
@@ -206,7 +223,10 @@ def main() -> int:
     parser.add_argument("files", nargs="*", help=argparse.SUPPRESS)
     args = parser.parse_args()
 
-    current = README.read_text()
+    # The rendered block contains emoji, so the encoding cannot be left to the
+    # locale: a pre-commit run under LC_ALL=C would raise UnicodeDecodeError
+    # here and UnicodeEncodeError on the write below.
+    current = README.read_text(encoding="utf-8")
     updated = splice(current, render(_load_arch_caps()))
 
     if args.check:
@@ -234,7 +254,7 @@ def main() -> int:
         return 0
 
     if current != updated:
-        README.write_text(updated)
+        README.write_text(updated, encoding="utf-8")
         print(f"updated {README.relative_to(REPO_ROOT)}")
     else:
         print(f"{README.relative_to(REPO_ROOT)} already up to date")

--- a/scripts/gen_arch_support_matrix.py
+++ b/scripts/gen_arch_support_matrix.py
@@ -32,6 +32,7 @@ each has to stand alone in an environment where the other may not be importable.
 from __future__ import annotations
 
 import argparse
+import difflib
 import importlib.util
 import pathlib
 import sys
@@ -210,13 +211,25 @@ def main() -> int:
 
     if args.check:
         if current != updated:
+            # Show the diff. "Out of date" alone leaves whoever hit this
+            # guessing, and the answer is not always an arch_caps.py edit --
+            # another formatter rewriting the generated block looks identical
+            # from the outside.
+            diff = difflib.unified_diff(
+                current.splitlines(keepends=True),
+                updated.splitlines(keepends=True),
+                fromfile="README.md (committed)",
+                tofile="README.md (generated)",
+                n=1,
+            )
             print(
                 "README.md arch support matrix is out of date with "
                 "flashinfer/arch_caps.py.\n"
                 "Regenerate it with:\n"
-                "    python3 scripts/gen_arch_support_matrix.py",
+                "    python3 scripts/gen_arch_support_matrix.py\n",
                 file=sys.stderr,
             )
+            sys.stderr.writelines(diff)
             return 1
         return 0
 

--- a/scripts/gen_arch_support_matrix.py
+++ b/scripts/gen_arch_support_matrix.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Render the per-architecture support matrix in README.md from the capability table.
+
+``flashinfer/arch_caps.py`` is the single source of truth for which
+``(op, backend)`` pairs are usable on which GPU architecture, and -- through
+``evidence`` -- for which of those claims anyone has actually measured. The
+README used to restate that by hand as the string "gfx942/gfx950", which cannot
+express either an architecture-specific defect or the difference between a
+measured row and a declared one. It went stale the moment the two architectures
+stopped behaving identically.
+
+Usage::
+
+    python3 scripts/gen_arch_support_matrix.py            # rewrite README.md
+    python3 scripts/gen_arch_support_matrix.py --check     # fail if out of date
+
+``--check`` runs as a pre-commit hook, so a table edit that does not regenerate
+the README is caught before review rather than after someone trusts the wrong
+row.
+
+Deliberately imports nothing from the ``flashinfer`` package: ``__init__.py``
+raises on a CPU-only torch build, and this script must run in the same
+hardware-less environment as pre-commit. The loader below mirrors the one in
+``tests/rocm_tests/test_arch_caps_hip.py``; the duplication is intentional, as
+each has to stand alone in an environment where the other may not be importable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import pathlib
+import sys
+import types
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+PKG_DIR = REPO_ROOT / "flashinfer"
+README = REPO_ROOT / "README.md"
+
+BEGIN = "<!-- BEGIN GENERATED: arch support matrix -- scripts/gen_arch_support_matrix.py -->"
+END = "<!-- END GENERATED: arch support matrix -->"
+
+# Column headers. Plain text on purpose: markdownlint's MD033 rejects inline
+# HTML, so no <br>/<sub> here. The SKUs each architecture covers are already
+# spelled out in the "Supported GPUs" line directly above the table.
+# An arch missing from this map still renders, under its bare gfx name.
+ARCH_LABELS = {
+    "gfx942": "gfx942 (CDNA3)",
+    "gfx950": "gfx950 (CDNA4)",
+}
+
+# markdownlint's configured list style is `*`, and it rewrites `-` in place --
+# which would leave the generated block failing its own --check on the next run.
+BULLET = "*"
+
+VALIDATED = "✅"
+DECLARED = "◻️"
+KNOWN_BAD = "⚠️"
+UNSUPPORTED = "❌"
+
+
+def _load_arch_caps():
+    """Load flashinfer.arch_caps without executing the package __init__."""
+    pkg_name = "_arch_matrix_pkg"
+    package = types.ModuleType(pkg_name)
+    package.__path__ = [str(PKG_DIR)]
+    sys.modules[pkg_name] = package
+
+    qualified = f"{pkg_name}.arch_caps"
+    spec = importlib.util.spec_from_file_location(qualified, PKG_DIR / "arch_caps.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[qualified] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _archs_in_order(arch_caps) -> list[str]:
+    """Every architecture any row declares, in first-seen order.
+
+    Derived rather than hard-coded so adding an architecture to the table adds a
+    column here without anyone remembering to.
+    """
+    seen: list[str] = []
+    for cap in arch_caps.CAPABILITIES:
+        for arch in cap.archs:
+            if arch not in seen:
+                seen.append(arch)
+    return seen
+
+
+def _window(bad) -> str:
+    """Render a KnownBad's bounds as a half-open interval, e.g. ``ROCm [7.2, 7.3)``."""
+    parts = []
+    for label, low, high in (
+        ("ROCm", bad.rocm_min, bad.rocm_max),
+        ("amd-aiter", bad.aiter_min, bad.aiter_max),
+    ):
+        if low is None and high is None:
+            continue
+        left = f"[{low}" if low is not None else "(-∞"
+        right = f"{high})" if high is not None else "+∞)"
+        parts.append(f"{label} {left}, {right}")
+    return " and ".join(parts) or "all versions"
+
+
+def _cell(entry, footnote_ids: dict[int, int]) -> str:
+    if entry is None or entry.support is not entry.support.SUPPORTED:
+        return UNSUPPORTED
+    if entry.known_bad:
+        refs = "".join(f"[^kb{footnote_ids[id(bad)]}]" for bad in entry.known_bad)
+        return f"{KNOWN_BAD}{refs}"
+    return VALIDATED if entry.evidence else DECLARED
+
+
+def render(arch_caps) -> str:
+    archs = _archs_in_order(arch_caps)
+
+    # Number the known-bad windows in table order so footnote order matches
+    # reading order.
+    footnote_ids: dict[int, int] = {}
+    footnotes: list[tuple[int, object, str, str]] = []
+    for cap in arch_caps.CAPABILITIES:
+        for arch in archs:
+            entry = cap.archs.get(arch)
+            for bad in getattr(entry, "known_bad", ()) or ():
+                if id(bad) not in footnote_ids:
+                    footnote_ids[id(bad)] = len(footnote_ids) + 1
+                    footnotes.append(
+                        (footnote_ids[id(bad)], bad, f"{cap.op}/{cap.backend}", arch)
+                    )
+
+    lines = [
+        BEGIN,
+        "",
+        f"| Op | Backend | {' | '.join(ARCH_LABELS.get(a, a) for a in archs)} |",
+        f"| :--- | :--- | {' | '.join(':---:' for _ in archs)} |",
+    ]
+    for cap in arch_caps.CAPABILITIES:
+        cells = " | ".join(_cell(cap.archs.get(a), footnote_ids) for a in archs)
+        lines.append(f"| `{cap.op}` | `{cap.backend}` | {cells} |")
+
+    lines += [
+        "",
+        f"{BULLET} {VALIDATED} **validated** — a suite was run on that board, and the "
+        "evidence is recorded below.",
+        f"{BULLET} {DECLARED} **declared** — supported, but no per-op measurement has "
+        "been recorded on that architecture.",
+        f"{BULLET} {KNOWN_BAD} **broken on some toolchains** — usable, but not on every "
+        "ROCm/AITER version; see the footnote.",
+        f"{BULLET} {UNSUPPORTED} **not available** on that architecture.",
+        "",
+    ]
+
+    for number, bad, where, arch in footnotes:
+        detail = bad.detail.rstrip(".")
+        link = f" <{bad.url}>" if bad.url else ""
+        lines.append(
+            f"[^kb{number}]: `{where}` on {arch}, {_window(bad)}: {detail}. "
+            f"Override with `FLASHINFER_ARCH_ALLOW_KNOWN_BAD=1` if you have "
+            f"validated it yourself.{link}"
+        )
+
+    # Evidence lines last: they are the provenance for every ✅ above, and are
+    # what makes "validated" a checkable claim rather than a badge.
+    evidence = sorted(
+        {
+            f"`{arch}` — {entry.evidence}"
+            for cap in arch_caps.CAPABILITIES
+            for arch, entry in cap.archs.items()
+            if entry.evidence
+        }
+    )
+    if evidence:
+        lines += ["", "Measured on:", ""]
+        lines += [f"{BULLET} {item}" for item in evidence]
+
+    lines += ["", END]
+    return "\n".join(lines)
+
+
+def splice(readme_text: str, block: str) -> str:
+    start = readme_text.find(BEGIN)
+    stop = readme_text.find(END)
+    if start == -1 or stop == -1:
+        raise SystemExit(
+            f"{README}: missing generated-block markers.\n"
+            f"  expected {BEGIN}\n  ...and    {END}"
+        )
+    return readme_text[:start] + block + readme_text[stop + len(END) :]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit non-zero if README.md does not match the capability table",
+    )
+    # pre-commit passes the matched filenames; the script always regenerates the
+    # whole block, so accept and ignore them rather than failing on argv.
+    parser.add_argument("files", nargs="*", help=argparse.SUPPRESS)
+    args = parser.parse_args()
+
+    current = README.read_text()
+    updated = splice(current, render(_load_arch_caps()))
+
+    if args.check:
+        if current != updated:
+            print(
+                "README.md arch support matrix is out of date with "
+                "flashinfer/arch_caps.py.\n"
+                "Regenerate it with:\n"
+                "    python3 scripts/gen_arch_support_matrix.py",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
+    if current != updated:
+        README.write_text(updated)
+        print(f"updated {README.relative_to(REPO_ROOT)}")
+    else:
+        print(f"{README.relative_to(REPO_ROOT)} already up to date")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The README described architecture support as the literal string `gfx942/gfx950`, repeated at nine call sites. That phrasing cannot express either of the two things the capability table from #285 knows: that an op can be supported on one architecture and broken on the other, and that some rows are *measured* while others are only *declared*.

It was already wrong when I started. AITER causal batch prefill is miscompiled on gfx950 under ROCm 7.2.x — silently, wrong numbers rather than an error — and no reader of the README could have learned that from it.

This generates the matrix from [`flashinfer/arch_caps.py`](flashinfer/arch_caps.py), which is the same data `backend="auto"` consults at runtime, so the docs cannot disagree with the routing.

## What it renders

Four states rather than a checkmark:

| | meaning |
| :--- | :--- |
| ✅ validated | a suite was run on that board, and the evidence string is printed below the table |
| ◻️ declared | supported, but no per-op measurement has been recorded on that architecture |
| ⚠️ broken on some toolchains | with the half-open version window, the reason, and the override env var |
| ❌ not available | |

The first two are the honest part. **Every HIP row currently renders as declared**, because those per-op measurements genuinely have not been recorded — the suites cover them, but no per-op HIP evidence was ever attributed. A hand-written table would have given all of them a ✅.

## Drift protection

A `pre-commit` hook runs the generator with `--check`, so an `arch_caps.py` edit that does not regenerate the README fails before review rather than after someone trusts a stale row.

It rides the existing pre-commit job rather than needing a new workflow, and deliberately imports nothing from the `flashinfer` package — `__init__.py` raises on a CPU-only torch build, so the script loads `arch_caps` directly by path, the same technique the conformance suite uses. Stdlib only.

## Test plan

- [x] `--check` exits 0 on a clean tree.
- [x] `--check` exits 1 with an actionable message when a row is perturbed (flipped `rope`/`aiter` on gfx950 to `UNSUPPORTED`), and 0 again once restored — so the hook is not vacuously passing.
- [x] Full `pre-commit run` green on all three files, including the new hook.
- [x] Rendered output reviewed: the `batch_prefill`/`aiter` gfx950 cell carries the ⚠️ and the footnote reproduces the ROCm `[7.2, 7.3)` window, the 97.6% figure, the `backend='fa2'` workaround, and the upstream link.

Columns are derived from whatever architectures the table declares, not hard-coded, so adding a third architecture adds a column without anyone remembering to.

### The hook caught a real drift before I did

Not a contrived test. #286 merged while this branch was in flight, renaming the `activation` row to `silu_and_mul` so it matches the string the call sites actually pass. This branch was based on `00e93c2c`, so its generated README still said `activation` — and CI failed on my own hook:

```
--- README.md (committed)
+++ README.md (generated)
-| `activation` | `aiter` | ✅ | ✅ |
+| `silu_and_mul` | `aiter` | ✅ | ✅ |
-| `activation` | `hip` | ◻️ | ◻️ |
+| `silu_and_mul` | `hip` | ◻️ | ◻️ |
```

That is exactly the failure mode this PR exists to prevent, and it happened on the PR that introduces the prevention. A hand-maintained table would have shipped the stale op name silently. Rebased onto `4ccc4b33` and regenerated.

The second commit adds the diff output above. The first version printed only "out of date", which told me nothing — I could not reproduce the failure on either local interpreter, because the cause was the base branch moving rather than anything about the environment.

## Note for reviewers

One interaction worth knowing about, since it is the kind of thing that breaks a week later: markdownlint rewrites `-` list bullets to `*` **in place**, which would leave the generated block failing its own `--check` on the very next run — two hooks fighting each other over the same file. The generator emits markdownlint-clean output (no inline HTML in headers, `*` bullets) so they agree. That is why the column headers are plain `gfx942 (CDNA3)` rather than carrying the SKU list; the SKUs are already spelled out in the **Supported GPUs** line directly above.

This does not touch the existing per-kernel Feature Support Matrix, which documents routing conditions rather than architecture validation. The two answer different questions.

