### PR TITLE
fix(rocm): resolve the build architecture in one place, not three

### DIFF
--- a/flashinfer/aot_hip.py
+++ b/flashinfer/aot_hip.py
@@ -222,15 +222,21 @@ def compile_and_package_modules(
     # boundary. That is a wider change than this one; leaving the lifetime
     # unchanged here keeps this commit to the resolution bug it is fixing.
     from .compilation_context_hip import CompilationContext
-    from .hip_utils import resolve_target_archs
 
-    # Validate before publishing, so a failed build leaves the environment as it
-    # found it. CompilationContext() re-resolves through the same function and
-    # the inputs cannot change in between, so it validates exactly the list
-    # published below -- the order costs nothing and stops a raise here from
-    # leaving FLASHINFER_ROCM_ARCH_LIST set for whatever runs next in-process.
-    rocm_arch_list = resolve_target_archs()
-    CompilationContext()  # validates the resolved list, raising on a bad one
+    # Publish the *validated* list, not the resolved one. Validation filters as
+    # well as raises: `validate_flashinfer_rocm_arch` drops architectures this
+    # ROCm or this PyTorch cannot build, warning rather than failing, so the
+    # context's target set can be a strict subset of what the resolver returned.
+    # Publishing the wider list recreates the disagreement this whole change
+    # exists to remove -- on ROCm 6.4 with FLASHINFER_ROCM_ARCH_LIST=
+    # "gfx950,gfx942", the kernels build for gfx942 while the shim reads gfx950
+    # from the environment and is built for a card the kernels do not target.
+    #
+    # Constructing the context first also means a failed validation leaves
+    # FLASHINFER_ROCM_ARCH_LIST as it found it, rather than exporting a list the
+    # build then rejected.
+    compilation_context = CompilationContext()
+    rocm_arch_list = ",".join(sorted(compilation_context.TARGET_ROCM_ARCHS))
     os.environ["FLASHINFER_ROCM_ARCH_LIST"] = rocm_arch_list
     if verbose:
         print(f"Target ROCm architectures: {rocm_arch_list}")

--- a/flashinfer/aot_hip.py
+++ b/flashinfer/aot_hip.py
@@ -224,9 +224,14 @@ def compile_and_package_modules(
     from .compilation_context_hip import CompilationContext
     from .hip_utils import resolve_target_archs
 
+    # Validate before publishing, so a failed build leaves the environment as it
+    # found it. CompilationContext() re-resolves through the same function and
+    # the inputs cannot change in between, so it validates exactly the list
+    # published below -- the order costs nothing and stops a raise here from
+    # leaving FLASHINFER_ROCM_ARCH_LIST set for whatever runs next in-process.
     rocm_arch_list = resolve_target_archs()
-    os.environ["FLASHINFER_ROCM_ARCH_LIST"] = rocm_arch_list
     CompilationContext()  # validates the resolved list, raising on a bad one
+    os.environ["FLASHINFER_ROCM_ARCH_LIST"] = rocm_arch_list
     if verbose:
         print(f"Target ROCm architectures: {rocm_arch_list}")
 

--- a/flashinfer/aot_hip.py
+++ b/flashinfer/aot_hip.py
@@ -208,25 +208,27 @@ def compile_and_package_modules(
         final_config.update(config)
     config = final_config
 
-    # ROCm Arch: Ensure env var is set or create/validate using CompilationContext
+    # ROCm arch: resolve once, then validate.
+    #
+    # Publishing the result back into the environment is deliberate, not
+    # incidental bookkeeping: the AITER shim resolves its own build architecture
+    # from FLASHINFER_ROCM_ARCH_LIST (jit/aiter_source.py), and an AOT build has
+    # no other channel to tell it what this build targets. Without this, a shim
+    # built during an AOT run on a mixed or GPU-less host can disagree with the
+    # kernels it is packaged alongside.
+    #
+    # It is a process-global side effect that outlives the call, which is worth
+    # replacing with an explicit parameter threaded through the AOT -> JIT
+    # boundary. That is a wider change than this one; leaving the lifetime
+    # unchanged here keeps this commit to the resolution bug it is fixing.
     from .compilation_context_hip import CompilationContext
+    from .hip_utils import resolve_target_archs
 
-    if "FLASHINFER_ROCM_ARCH_LIST" not in os.environ:
-        # Auto-detect or use default by creating a local context
-        compilation_context = CompilationContext()
-        detected_archs = ",".join(sorted(compilation_context.TARGET_ROCM_ARCHS))
-        os.environ["FLASHINFER_ROCM_ARCH_LIST"] = detected_archs
-        if verbose:
-            print(f"Auto-detected ROCm architectures: {detected_archs}")
-    else:
-        # Validate provided arch list by creating a local context
-        arch_list = os.environ["FLASHINFER_ROCM_ARCH_LIST"]
-        CompilationContext()  # Validates arch_list set via env var
-        if verbose:
-            print(f"Using ROCm architectures: {arch_list}")
-
-    # Verify paths are correct
-    rocm_arch_list = os.environ["FLASHINFER_ROCM_ARCH_LIST"]
+    rocm_arch_list = resolve_target_archs()
+    os.environ["FLASHINFER_ROCM_ARCH_LIST"] = rocm_arch_list
+    CompilationContext()  # validates the resolved list, raising on a bad one
+    if verbose:
+        print(f"Target ROCm architectures: {rocm_arch_list}")
 
     # Print summary
     if verbose:

--- a/flashinfer/aot_hip.py
+++ b/flashinfer/aot_hip.py
@@ -235,8 +235,19 @@ def compile_and_package_modules(
     # Constructing the context first also means a failed validation leaves
     # FLASHINFER_ROCM_ARCH_LIST as it found it, rather than exporting a list the
     # build then rejected.
+    #
+    # Read the order from `arch_flags`, not `TARGET_ROCM_ARCHS`. The latter is a
+    # `set` (hip_utils: `arch_set = set(requested_archs)`), so the caller's order
+    # is already gone by the time it gets here, and imposing `sorted()` is not
+    # order-neutral: `resolve_aiter_build_arch()` takes `env_archs[0]` when no
+    # device is visible, so republishing "gfx950,gfx942" as "gfx942,gfx950"
+    # silently builds the shim for the architecture the caller listed *second*.
+    # `arch_flags` is built by iterating `requested_archs` in order, so it still
+    # carries the preference.
     compilation_context = CompilationContext()
-    rocm_arch_list = ",".join(sorted(compilation_context.TARGET_ROCM_ARCHS))
+    rocm_arch_list = ",".join(
+        flag.removeprefix("--offload-arch=") for flag in compilation_context.arch_flags
+    )
     os.environ["FLASHINFER_ROCM_ARCH_LIST"] = rocm_arch_list
     if verbose:
         print(f"Target ROCm architectures: {rocm_arch_list}")

--- a/flashinfer/compilation_context_hip.py
+++ b/flashinfer/compilation_context_hip.py
@@ -18,12 +18,9 @@ Global compilation context management for FlashInfer on ROCm.
 """
 
 import logging
-import os
 
-import torch
 
 from . import hip_utils
-from .arch_caps import normalize_arch
 
 logger = logging.getLogger(__name__)
 
@@ -50,12 +47,11 @@ class CompilationContext:
         """
         import torch.utils.cpp_extension as torch_cpp_ext
 
-        # Get architecture list from env or auto-detect
-        arch_list = os.environ.get("FLASHINFER_ROCM_ARCH_LIST")
-        if arch_list is None:
-            arch_list = self._auto_detect_archs()
-            if arch_list:
-                logger.info(f"Auto-detected ROCm architectures: {arch_list}")
+        # One resolver for every path that asks "what are we building for", so
+        # this cannot disagree with the validation in hip_utils -- it used to,
+        # returning gfx950 here while validation checked gfx942.
+        arch_list = hip_utils.resolve_target_archs()
+        logger.info(f"Target ROCm architectures: {arch_list}")
 
         # Comprehensive validation (all 3 checks)
         self.arch_flags, self.TARGET_ROCM_ARCHS = (
@@ -63,27 +59,6 @@ class CompilationContext:
                 arch_list=arch_list, torch_cpp_ext_module=torch_cpp_ext, verbose=False
             )
         )
-
-    def _auto_detect_archs(self) -> str:
-        """Auto-detect ROCm architectures from supported system devices.
-
-        Only devices whose gcnArchName is in FLASHINFER_SUPPORTED_ROCM_ARCHS are
-        considered, so unsupported integrated GPUs are silently ignored here rather
-        than being passed on to validate_flashinfer_rocm_arch for filtering.
-        """
-        try:
-            indices = hip_utils.get_supported_device_indices()
-            if indices:
-                archs = {
-                    normalize_arch(torch.cuda.get_device_properties(i).gcnArchName)
-                    for i in indices
-                }
-                return ",".join(sorted(archs))
-            logger.warning("No supported ROCm devices detected, defaulting to gfx942")
-            return "gfx942"
-        except Exception as e:
-            logger.warning(f"Failed to auto-detect ROCm device architectures: {e}")
-            return "gfx942"
 
     def get_hipcc_flags_list(self) -> list[str]:
         """

--- a/flashinfer/hip_utils.py
+++ b/flashinfer/hip_utils.py
@@ -16,6 +16,34 @@ logger = logging.getLogger(__name__)
 FLASHINFER_SUPPORTED_ROCM_ARCHS = ["gfx942", "gfx950"]
 
 
+def _canonical_arch_list(raw: str) -> str:
+    """``"gfx950:sramecc+; gfx942,,gfx942"`` -> ``"gfx950,gfx942"``.
+
+    Caller- and environment-supplied lists arrive in whatever shape the operator
+    typed. The validators below split on ``","`` only and compare tokens against
+    :data:`FLASHINFER_SUPPORTED_ROCM_ARCHS` verbatim, so an unnormalized value is
+    not merely untidy -- ``"gfx942;gfx950"`` becomes the single token
+    ``"gfx942;gfx950"``, matches nothing, and
+    :func:`validate_flashinfer_rocm_arch` raises "FlashInfer does not support any
+    of the requested ROCm architectures". ``";"`` is worth accepting because
+    ``jit/aiter_source.py`` already documents it for this same variable, and the
+    two must not disagree about their own env var.
+
+    Only *syntax* is normalized. Unknown architectures are passed through so the
+    validators can report them; silently dropping one here would turn a clear
+    error into a build that quietly targets less than was asked for.
+
+    Order is preserved (first occurrence wins) rather than sorted: it is the
+    caller's stated preference, and it is what ends up on the hipcc command line.
+    """
+    seen = []
+    for token in raw.replace(";", ",").split(","):
+        arch = normalize_arch(token)
+        if arch and arch not in seen:
+            seen.append(arch)
+    return ",".join(seen)
+
+
 def resolve_target_archs(arch_list: str = None) -> str:
     """Return the architectures to build for, as a comma-separated string.
 
@@ -46,12 +74,20 @@ def resolve_target_archs(arch_list: str = None) -> str:
     """
     import os
 
+    # Canonicalize the two operator-supplied paths. A value that normalizes away
+    # entirely (";;", whitespace) falls through to detection rather than
+    # returning "", which would otherwise reach the validators as a single empty
+    # token and fail as an unsupported architecture.
     if arch_list:
-        return arch_list
+        canonical = _canonical_arch_list(arch_list)
+        if canonical:
+            return canonical
 
     from_env = os.environ.get("FLASHINFER_ROCM_ARCH_LIST")
     if from_env:
-        return from_env
+        canonical = _canonical_arch_list(from_env)
+        if canonical:
+            return canonical
 
     detected = sorted(
         {

--- a/flashinfer/hip_utils.py
+++ b/flashinfer/hip_utils.py
@@ -3,14 +3,75 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import functools
+import logging
 
 # arch_caps imports nothing (in particular, not torch), so importing it here
 # keeps this module safe to import before the HIP runtime starts -- which
 # tests/conftest.py relies on to set HIP_VISIBLE_DEVICES first.
 from .arch_caps import normalize_arch
 
+logger = logging.getLogger(__name__)
+
 # AMDGPU archs supported by amd-flashinfer
 FLASHINFER_SUPPORTED_ROCM_ARCHS = ["gfx942", "gfx950"]
+
+
+def resolve_target_archs(arch_list: str = None) -> str:
+    """Return the architectures to build for, as a comma-separated string.
+
+    The single answer to "what are we compiling for". Resolution order:
+
+    1. ``arch_list``, when a caller passes one explicitly.
+    2. ``FLASHINFER_ROCM_ARCH_LIST``.
+    3. The architectures of the supported GPUs actually present.
+    4. Every architecture FlashInfer supports, with a warning.
+
+    Step 4 replaces a hard-coded ``"gfx942"`` that three call sites reached
+    independently. On a CDNA4 host that literal was not a conservative default
+    but a wrong answer: ``validate_flashinfer_rocm_arch(arch_list=None)``
+    returned ``{"gfx942"}`` on a gfx950 device while ``CompilationContext``
+    compiled for gfx950, so the check that exists to catch "your PyTorch was not
+    built for this architecture" was validating an architecture nobody was
+    building for. Vacuous on a PyTorch carrying both; a spurious hard failure on
+    an arch-specific build that carries only gfx950.
+
+    Building for everything we support is the honest fallback when we cannot
+    tell: slower and fatter, but correct on whichever card the result lands on,
+    which a guess is not. It is warned so a GPU-less build host is told to set
+    the variable rather than silently paying for it.
+
+    Detection uses rocminfo rather than ``torch.cuda`` so this stays callable
+    before the HIP runtime starts, and keeps this module importable without
+    torch -- see ``tests/rocm_tests/test_arch_caps_hip.py``.
+    """
+    import os
+
+    if arch_list:
+        return arch_list
+
+    from_env = os.environ.get("FLASHINFER_ROCM_ARCH_LIST")
+    if from_env:
+        return from_env
+
+    detected = sorted(
+        {
+            arch
+            for arch, _ in rocminfo_gpu_agents()
+            if arch in FLASHINFER_SUPPORTED_ROCM_ARCHS
+        }
+    )
+    if detected:
+        return ",".join(detected)
+
+    fallback = ",".join(FLASHINFER_SUPPORTED_ROCM_ARCHS)
+    logger.warning(
+        "No supported AMD GPU detected and FLASHINFER_ROCM_ARCH_LIST is unset; "
+        "building for every supported architecture (%s). This is slower than "
+        "targeting one. Set FLASHINFER_ROCM_ARCH_LIST to the architecture you "
+        "are building for.",
+        fallback,
+    )
+    return fallback
 
 
 def get_rocm_home():
@@ -190,7 +251,7 @@ def validate_rocm_arch(arch_list: str = None, verbose: bool = False) -> str:
 
     Args:
         arch_list: Comma-separated list of architectures (e.g., "gfx942,gfx90a").
-                   If None, reads from FLASHINFER_ROCM_ARCH_LIST env var or defaults to "gfx942"
+                   If None, resolved by :func:`resolve_target_archs`.
         verbose: Whether to print validation messages
 
     Returns:
@@ -199,7 +260,6 @@ def validate_rocm_arch(arch_list: str = None, verbose: bool = False) -> str:
     Raises:
         RuntimeError: If ROCm not found or architectures not supported
     """
-    import os
 
     # ROCm compatibility matrix: version -> supported gfx architectures
     # Refer: https://rocm.docs.amd.com/en/latest/compatibility/compatibility-matrix.html
@@ -234,7 +294,7 @@ def validate_rocm_arch(arch_list: str = None, verbose: bool = False) -> str:
 
     # Get architecture list from parameter, env var, or default
     if arch_list is None:
-        arch_list = os.environ.get("FLASHINFER_ROCM_ARCH_LIST", "gfx942")
+        arch_list = resolve_target_archs()
 
     # Validate system has ROCm installed
     system_rocm_version = get_system_rocm_version()
@@ -315,11 +375,10 @@ def validate_flashinfer_rocm_arch(
     Raises:
         RuntimeError: If any validation step fails with clear error message
     """
-    import os
 
     # Get architecture list from parameter, env var, or default
     if arch_list is None:
-        arch_list = os.environ.get("FLASHINFER_ROCM_ARCH_LIST", "gfx942")
+        arch_list = resolve_target_archs()
 
     # Step 1: Validate against system ROCm version (reuse existing logic)
     validated_arch_list = validate_rocm_arch(arch_list=arch_list, verbose=verbose)

--- a/flashinfer/hip_utils.py
+++ b/flashinfer/hip_utils.py
@@ -16,6 +16,38 @@ logger = logging.getLogger(__name__)
 FLASHINFER_SUPPORTED_ROCM_ARCHS = ["gfx942", "gfx950"]
 
 
+# The architecture assumed when nothing else can be determined. Must stay equal
+# to ``jit/aiter_source.py``'s ``_DEFAULT_BUILD_ARCH``: the two are consulted
+# independently on a GPU-less host, and a shim built for one architecture beside
+# kernels built for another faults at run time.
+_GPULESS_FALLBACK_ARCH = "gfx942"
+
+
+@functools.cache
+def _detected_supported_archs() -> tuple:
+    """Supported architectures rocminfo reports, cached for the process.
+
+    ``rocminfo_gpu_agents`` is deliberately uncached -- "the caller decides" --
+    and this caller is a hot one: ``CompilationContext`` is constructed from five
+    places and each construction resolves the target list. The code this replaces
+    reached rocminfo through the cached ``get_supported_device_indices``, so
+    calling the uncached probe directly would re-run the subprocess (with its
+    timeout) on every construction. Hardware cannot change under a running
+    process, so caching costs nothing in fidelity.
+
+    Tests that patch ``rocminfo_gpu_agents`` must call ``cache_clear()``.
+    """
+    return tuple(
+        sorted(
+            {
+                arch
+                for arch, _ in rocminfo_gpu_agents()
+                if arch in FLASHINFER_SUPPORTED_ROCM_ARCHS
+            }
+        )
+    )
+
+
 def _canonical_arch_list(raw: str) -> str:
     """``"gfx950:sramecc+; gfx942,,gfx942"`` -> ``"gfx950,gfx942"``.
 
@@ -52,21 +84,18 @@ def resolve_target_archs(arch_list: str = None) -> str:
     1. ``arch_list``, when a caller passes one explicitly.
     2. ``FLASHINFER_ROCM_ARCH_LIST``.
     3. The architectures of the supported GPUs actually present.
-    4. Every architecture FlashInfer supports, with a warning.
+    4. ``gfx942``, warned -- the pre-existing default, kept deliberately (see
+       the comment at the fallback).
 
-    Step 4 replaces a hard-coded ``"gfx942"`` that three call sites reached
-    independently. On a CDNA4 host that literal was not a conservative default
-    but a wrong answer: ``validate_flashinfer_rocm_arch(arch_list=None)``
+    The bug this fixes is that steps 1-3 were open-coded three times and
+    disagreed. On a CDNA4 host, ``validate_flashinfer_rocm_arch(arch_list=None)``
     returned ``{"gfx942"}`` on a gfx950 device while ``CompilationContext``
-    compiled for gfx950, so the check that exists to catch "your PyTorch was not
-    built for this architecture" was validating an architecture nobody was
+    compiled for gfx950 -- so the check that exists to catch "your PyTorch was
+    not built for this architecture" was validating an architecture nobody was
     building for. Vacuous on a PyTorch carrying both; a spurious hard failure on
-    an arch-specific build that carries only gfx950.
-
-    Building for everything we support is the honest fallback when we cannot
-    tell: slower and fatter, but correct on whichever card the result lands on,
-    which a guess is not. It is warned so a GPU-less build host is told to set
-    the variable rather than silently paying for it.
+    an arch-specific build that carries only gfx950. gfx942 was the one
+    architecture where the hard-coded literal happened to be right, which is why
+    CDNA3 never noticed.
 
     Detection uses rocminfo rather than ``torch.cuda`` so this stays callable
     before the HIP runtime starts, and keeps this module importable without
@@ -89,25 +118,35 @@ def resolve_target_archs(arch_list: str = None) -> str:
         if canonical:
             return canonical
 
-    detected = sorted(
-        {
-            arch
-            for arch, _ in rocminfo_gpu_agents()
-            if arch in FLASHINFER_SUPPORTED_ROCM_ARCHS
-        }
-    )
+    detected = _detected_supported_archs()
     if detected:
         return ",".join(detected)
 
-    fallback = ",".join(FLASHINFER_SUPPORTED_ROCM_ARCHS)
+    # Deliberately the *existing* default, not "every architecture we support".
+    #
+    # A fat list looks like the safer answer here and is not. `aot_hip` publishes
+    # this value into FLASHINFER_ROCM_ARCH_LIST, and `resolve_aiter_build_arch()`
+    # returns `env_archs[0]` when no device is visible -- so "gfx942,gfx950"
+    # ships gfx950 HIP kernels beside a gfx942-only AITER shim, which faults on a
+    # gfx950 card. Today both sides independently fall back to gfx942 and
+    # therefore agree; widening one of them alone is a regression.
+    #
+    # This keeps that agreement while fixing the bug this function exists for --
+    # the *disagreement* between the validator and the compiler on a host where a
+    # GPU is visible. Whether a GPU-less host should instead raise, build fat, or
+    # teach the shim to follow the list is a real question with its own blast
+    # radius (it breaks build hosts that work today), and belongs in its own
+    # change.
     logger.warning(
         "No supported AMD GPU detected and FLASHINFER_ROCM_ARCH_LIST is unset; "
-        "building for every supported architecture (%s). This is slower than "
-        "targeting one. Set FLASHINFER_ROCM_ARCH_LIST to the architecture you "
-        "are building for.",
-        fallback,
+        "falling back to %s. Set FLASHINFER_ROCM_ARCH_LIST to the architecture "
+        "you are building for -- otherwise the result will not run on %s.",
+        _GPULESS_FALLBACK_ARCH,
+        ", ".join(
+            a for a in FLASHINFER_SUPPORTED_ROCM_ARCHS if a != _GPULESS_FALLBACK_ARCH
+        ),
     )
-    return fallback
+    return _GPULESS_FALLBACK_ARCH
 
 
 def get_rocm_home():

--- a/tests/rocm_tests/test_aot_hip.py
+++ b/tests/rocm_tests/test_aot_hip.py
@@ -209,6 +209,7 @@ def test_publishes_the_validated_list_not_the_requested_one(monkeypatch):
     class _FilteringContext:
         """Accepts the request, targets a subset -- what a filter looks like."""
 
+        arch_flags = ["--offload-arch=gfx942"]
         TARGET_ROCM_ARCHS = {"gfx942"}
 
         def __init__(self):
@@ -233,6 +234,50 @@ def test_publishes_the_validated_list_not_the_requested_one(monkeypatch):
     )
 
     assert os.environ["FLASHINFER_ROCM_ARCH_LIST"] == "gfx942"
+
+
+def test_publishing_preserves_the_requested_order(monkeypatch):
+    """The caller's first choice must stay first.
+
+    ``resolve_aiter_build_arch()`` takes ``env_archs[0]`` when no device is
+    visible, so the order of the published list decides which architecture the
+    single-arch AITER shim is built for. ``TARGET_ROCM_ARCHS`` is a ``set`` --
+    ``arch_set = set(requested_archs)`` in hip_utils -- so reading order from it
+    is impossible, and sorting it is not order-neutral: it would turn a request
+    for "gfx950,gfx942" into a shim built for gfx942. ``arch_flags`` iterates
+    ``requested_archs`` in order and is the only ordered survivor.
+    """
+    import flashinfer.aot_hip as aot_hip
+
+    monkeypatch.setenv("FLASHINFER_ROCM_ARCH_LIST", "gfx950,gfx942")
+
+    class _OrderedContext:
+        # Deliberately not alphabetical: sorted() would reverse this.
+        arch_flags = ["--offload-arch=gfx950", "--offload-arch=gfx942"]
+        TARGET_ROCM_ARCHS = {"gfx942", "gfx950"}
+
+        def __init__(self):
+            pass
+
+    monkeypatch.setattr(
+        "flashinfer.compilation_context_hip.CompilationContext", _OrderedContext
+    )
+
+    aot_hip.compile_and_package_modules(
+        out_dir=None,
+        build_dir=Path(tempfile.mkdtemp()),
+        project_root=Path(__file__).parent.parent,
+        config={
+            "fa2_head_dim": [(128, 128)],
+            "f16_dtype": [torch.float16],
+            "use_sliding_window": [False],
+            "use_logits_soft_cap": [False],
+        },
+        verbose=False,
+        skip_prebuilt=True,
+    )
+
+    assert os.environ["FLASHINFER_ROCM_ARCH_LIST"] == "gfx950,gfx942"
 
 
 def test_module_naming_convention():

--- a/tests/rocm_tests/test_aot_hip.py
+++ b/tests/rocm_tests/test_aot_hip.py
@@ -187,6 +187,54 @@ def test_failed_validation_leaves_the_environment_alone(monkeypatch):
     assert "FLASHINFER_ROCM_ARCH_LIST" not in os.environ
 
 
+def test_publishes_the_validated_list_not_the_requested_one(monkeypatch):
+    """What reaches the AITER shim must be what the kernels were built for.
+
+    Validation filters as well as raises: ``validate_flashinfer_rocm_arch``
+    drops architectures this ROCm or this PyTorch cannot build, warning instead
+    of failing, so the context's target set can be a strict subset of the
+    resolver's answer. Publishing the wider list hands the shim an architecture
+    the kernels do not target -- the exact disagreement this change exists to
+    remove, arriving through the environment instead of through a hard-coded
+    default.
+
+    gfx950 is requested and accepted by the resolver; the context reports only
+    gfx942, standing in for a ROCm or PyTorch that cannot build gfx950. The
+    published value must follow the context.
+    """
+    import flashinfer.aot_hip as aot_hip
+
+    monkeypatch.setenv("FLASHINFER_ROCM_ARCH_LIST", "gfx950,gfx942")
+
+    class _FilteringContext:
+        """Accepts the request, targets a subset -- what a filter looks like."""
+
+        TARGET_ROCM_ARCHS = {"gfx942"}
+
+        def __init__(self):
+            pass
+
+    monkeypatch.setattr(
+        "flashinfer.compilation_context_hip.CompilationContext", _FilteringContext
+    )
+
+    aot_hip.compile_and_package_modules(
+        out_dir=None,
+        build_dir=Path(tempfile.mkdtemp()),
+        project_root=Path(__file__).parent.parent,
+        config={
+            "fa2_head_dim": [(128, 128)],
+            "f16_dtype": [torch.float16],
+            "use_sliding_window": [False],
+            "use_logits_soft_cap": [False],
+        },
+        verbose=False,
+        skip_prebuilt=True,
+    )
+
+    assert os.environ["FLASHINFER_ROCM_ARCH_LIST"] == "gfx942"
+
+
 def test_module_naming_convention():
     """Test that generated module names follow expected conventions."""
     f16_dtype = [torch.float16]

--- a/tests/rocm_tests/test_aot_hip.py
+++ b/tests/rocm_tests/test_aot_hip.py
@@ -11,6 +11,7 @@ Tests the flashinfer.aot_hip module to ensure:
 3. .so files are created and can be loaded
 """
 
+import os
 import shutil
 import tempfile
 from pathlib import Path
@@ -137,6 +138,53 @@ def test_compile_and_package_minimal():
         # Cleanup
         shutil.rmtree(build_dir, ignore_errors=True)
         shutil.rmtree(out_dir, ignore_errors=True)
+
+
+def test_failed_validation_leaves_the_environment_alone(monkeypatch):
+    """A raise mid-build must not leave FLASHINFER_ROCM_ARCH_LIST behind.
+
+    compile_and_package_modules publishes the resolved list into the process
+    environment on purpose -- the AITER shim reads it from there
+    (jit/aiter_source.py) and an AOT build has no other channel to reach it.
+    That side effect outlives the call, so it must only happen once the list is
+    known good; otherwise a build that dies on an unsupported ROCm version
+    silently repoints whatever runs next in the same process.
+
+    The variable starts *unset* and resolution comes from detection, so the
+    published value differs from the starting state. Seeding it with the value
+    the resolver would return makes the write a no-op and the test vacuous --
+    it then passes with the bug present.
+    """
+    import flashinfer.aot_hip as aot_hip
+
+    monkeypatch.delenv("FLASHINFER_ROCM_ARCH_LIST", raising=False)
+    monkeypatch.setattr(
+        "flashinfer.hip_utils.rocminfo_gpu_agents",
+        lambda: (("gfx950", ""),),
+    )
+
+    class _Boom:
+        def __init__(self):
+            raise RuntimeError("ROCm version 0.0 is not recognized")
+
+    monkeypatch.setattr("flashinfer.compilation_context_hip.CompilationContext", _Boom)
+
+    with pytest.raises(RuntimeError, match="not recognized"):
+        aot_hip.compile_and_package_modules(
+            out_dir=None,
+            build_dir=Path(tempfile.mkdtemp()),
+            project_root=Path(__file__).parent.parent,
+            config={
+                "fa2_head_dim": [(128, 128)],
+                "f16_dtype": [torch.float16],
+                "use_sliding_window": [False],
+                "use_logits_soft_cap": [False],
+            },
+            verbose=False,
+            skip_prebuilt=True,
+        )
+
+    assert "FLASHINFER_ROCM_ARCH_LIST" not in os.environ
 
 
 def test_module_naming_convention():

--- a/tests/rocm_tests/test_hip_utils.py
+++ b/tests/rocm_tests/test_hip_utils.py
@@ -30,6 +30,26 @@ from flashinfer.hip_utils import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _clear_arch_detection_cache():
+    """Reset the process-cached architecture probe around every test in this file.
+
+    ``_detected_supported_archs`` caches rocminfo's answer for the process, so a
+    test that patches ``rocminfo_gpu_agents`` can otherwise be shadowed by
+    whatever a previous test -- or the real hardware, via package import -- put
+    there first, and silently assert against the wrong architecture. Module-wide
+    rather than on the one class that resolves: several tests here reach the
+    probe indirectly through ``validate_rocm_arch(arch_list=None)``, and any test
+    added later that patches it inherits the same hazard.
+
+    Clearing on the way out as well keeps a fake from leaking into the rest of
+    the session.
+    """
+    hip_utils._detected_supported_archs.cache_clear()
+    yield
+    hip_utils._detected_supported_archs.cache_clear()
+
+
 # get_rocm_home
 class TestGetRocmHome:
     def test_rocm_path_env_var(self, monkeypatch):
@@ -148,16 +168,6 @@ class TestResolveTargetArchs:
     ``validate_flashinfer_rocm_arch(arch_list=None)`` returned ``{"gfx942"}``
     while ``CompilationContext`` emitted ``--offload-arch=gfx950``.
     """
-
-    @pytest.fixture(autouse=True)
-    def _clear_detection_cache(self):
-        """Detection is cached per process, so a patched rocminfo would otherwise
-        be shadowed by whatever the previous test (or the real hardware) put
-        there. Clearing on both sides keeps these tests order-independent and
-        stops them leaking a fake into the rest of the session."""
-        hip_utils._detected_supported_archs.cache_clear()
-        yield
-        hip_utils._detected_supported_archs.cache_clear()
 
     def _agents(self, *archs):
         return patch(

--- a/tests/rocm_tests/test_hip_utils.py
+++ b/tests/rocm_tests/test_hip_utils.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from flashinfer import hip_utils
 from flashinfer.hip_utils import (
     FLASHINFER_SUPPORTED_ROCM_ARCHS,
     check_torch_rocm_compatibility,
@@ -148,6 +149,16 @@ class TestResolveTargetArchs:
     while ``CompilationContext`` emitted ``--offload-arch=gfx950``.
     """
 
+    @pytest.fixture(autouse=True)
+    def _clear_detection_cache(self):
+        """Detection is cached per process, so a patched rocminfo would otherwise
+        be shadowed by whatever the previous test (or the real hardware) put
+        there. Clearing on both sides keeps these tests order-independent and
+        stops them leaking a fake into the rest of the session."""
+        hip_utils._detected_supported_archs.cache_clear()
+        yield
+        hip_utils._detected_supported_archs.cache_clear()
+
     def _agents(self, *archs):
         return patch(
             "flashinfer.hip_utils.rocminfo_gpu_agents",
@@ -233,18 +244,39 @@ class TestResolveTargetArchs:
         with self._agents("gfx1035", "gfx950"):
             assert resolve_target_archs() == "gfx950"
 
-    def test_no_device_builds_for_everything_supported(self, monkeypatch, caplog):
-        """A GPU-less build host gets a fat build, not a guess.
+    def test_no_device_keeps_the_existing_default_and_warns(self, monkeypatch, caplog):
+        """A GPU-less host keeps today's answer, loudly.
 
-        Picking one architecture here is what produced a silently gfx942-only
-        artifact on a machine that could not confirm anything. Building for all
-        supported architectures is slower but correct wherever it lands, and the
-        warning tells the operator how to make it cheaper.
+        Widening this to every supported architecture was tried and reverted: it
+        desynchronizes the AITER shim, which takes exactly one architecture and
+        picks ``env_archs[0]`` when no device is visible, so a fat list ships
+        gfx950 kernels beside a gfx942-only shim. Making the GPU-less default
+        *correct* rather than merely consistent is a separate change.
         """
         monkeypatch.delenv("FLASHINFER_ROCM_ARCH_LIST", raising=False)
         with self._agents(), caplog.at_level("WARNING"):
-            assert resolve_target_archs() == ",".join(FLASHINFER_SUPPORTED_ROCM_ARCHS)
+            assert resolve_target_archs() == "gfx942"
         assert "FLASHINFER_ROCM_ARCH_LIST" in caplog.text
+
+    def test_gpuless_fallback_matches_the_aiter_shim_default(self):
+        """The two are resolved independently on a GPU-less host; if they ever
+        diverge, the shim is built for a different architecture than the kernels
+        it ships beside and faults at run time."""
+        from flashinfer.jit.aiter_source import _DEFAULT_BUILD_ARCH
+
+        assert hip_utils._GPULESS_FALLBACK_ARCH == _DEFAULT_BUILD_ARCH
+
+    def test_detection_is_cached_per_process(self):
+        """Restores a cache the refactor dropped: the previous implementation
+        reached rocminfo through the cached ``get_supported_device_indices``,
+        while ``rocminfo_gpu_agents`` is uncached by design."""
+        with patch(
+            "flashinfer.hip_utils.rocminfo_gpu_agents",
+            return_value=(("gfx950", ""),),
+        ) as probe:
+            hip_utils._detected_supported_archs()
+            hip_utils._detected_supported_archs()
+        assert probe.call_count == 1
 
     def test_agrees_with_the_compilation_context(self, monkeypatch):
         """The property the whole change exists for: the validator and the thing

--- a/tests/rocm_tests/test_hip_utils.py
+++ b/tests/rocm_tests/test_hip_utils.py
@@ -23,6 +23,7 @@ from flashinfer.hip_utils import (
     get_supported_device_indices,
     get_system_rocm_version_from_hipconfig,
     is_therock_build,
+    resolve_target_archs,
     validate_flashinfer_rocm_arch,
     validate_rocm_arch,
 )
@@ -137,7 +138,87 @@ class TestGetSystemRocmVersionFromHipconfig:
             assert get_system_rocm_version_from_hipconfig() is None
 
 
-# validate_rocm_arch
+# resolve_target_archs
+class TestResolveTargetArchs:
+    """The single resolver every build path now consults.
+
+    Before it existed, three call sites answered "what are we building for"
+    independently and could disagree: on a gfx950 host,
+    ``validate_flashinfer_rocm_arch(arch_list=None)`` returned ``{"gfx942"}``
+    while ``CompilationContext`` emitted ``--offload-arch=gfx950``.
+    """
+
+    def _agents(self, *archs):
+        return patch(
+            "flashinfer.hip_utils.rocminfo_gpu_agents",
+            return_value=tuple((arch, "") for arch in archs),
+        )
+
+    def test_explicit_argument_wins(self, monkeypatch):
+        monkeypatch.setenv("FLASHINFER_ROCM_ARCH_LIST", "gfx950")
+        with self._agents("gfx950"):
+            assert resolve_target_archs("gfx942") == "gfx942"
+
+    def test_env_var_beats_detection(self, monkeypatch):
+        """An explicit request is honoured even when it is not what is plugged in
+        -- cross-compiling for the other architecture must stay possible."""
+        monkeypatch.setenv("FLASHINFER_ROCM_ARCH_LIST", "gfx942")
+        with self._agents("gfx950"):
+            assert resolve_target_archs() == "gfx942"
+
+    def test_detects_the_running_device(self, monkeypatch):
+        monkeypatch.delenv("FLASHINFER_ROCM_ARCH_LIST", raising=False)
+        with self._agents("gfx950"):
+            assert resolve_target_archs() == "gfx950"
+
+    def test_detects_every_distinct_supported_arch(self, monkeypatch):
+        monkeypatch.delenv("FLASHINFER_ROCM_ARCH_LIST", raising=False)
+        with self._agents("gfx942", "gfx950", "gfx942"):
+            assert resolve_target_archs() == "gfx942,gfx950"
+
+    def test_ignores_unsupported_agents(self, monkeypatch):
+        """An integrated GPU alongside the dGPU must not widen the target set."""
+        monkeypatch.delenv("FLASHINFER_ROCM_ARCH_LIST", raising=False)
+        with self._agents("gfx1035", "gfx950"):
+            assert resolve_target_archs() == "gfx950"
+
+    def test_no_device_builds_for_everything_supported(self, monkeypatch, caplog):
+        """A GPU-less build host gets a fat build, not a guess.
+
+        Picking one architecture here is what produced a silently gfx942-only
+        artifact on a machine that could not confirm anything. Building for all
+        supported architectures is slower but correct wherever it lands, and the
+        warning tells the operator how to make it cheaper.
+        """
+        monkeypatch.delenv("FLASHINFER_ROCM_ARCH_LIST", raising=False)
+        with self._agents(), caplog.at_level("WARNING"):
+            assert resolve_target_archs() == ",".join(FLASHINFER_SUPPORTED_ROCM_ARCHS)
+        assert "FLASHINFER_ROCM_ARCH_LIST" in caplog.text
+
+    def test_agrees_with_the_compilation_context(self, monkeypatch):
+        """The property the whole change exists for: the validator and the thing
+        that emits --offload-arch must not disagree."""
+        monkeypatch.delenv("FLASHINFER_ROCM_ARCH_LIST", raising=False)
+        from flashinfer.compilation_context_hip import CompilationContext
+
+        with (
+            self._agents("gfx950"),
+            patch("flashinfer.hip_utils.get_system_rocm_version", return_value="7.1.0"),
+        ):
+            _, validated = validate_flashinfer_rocm_arch(
+                arch_list=None, torch_cpp_ext_module=_FakeCppExt(), verbose=False
+            )
+            assert validated == CompilationContext().TARGET_ROCM_ARCHS
+
+
+class _FakeCppExt:
+    """Stands in for torch.utils.cpp_extension: claims both archs are built in."""
+
+    @staticmethod
+    def _get_rocm_arch_flags():
+        return [f"--offload-arch={a}" for a in FLASHINFER_SUPPORTED_ROCM_ARCHS]
+
+
 class TestValidateRocmArch:
     def _patch_rocm_version(self, version):
         return patch(
@@ -188,10 +269,24 @@ class TestValidateRocmArch:
         with self._patch_rocm_version("7.1.0"):
             assert validate_rocm_arch(arch_list=None) == "gfx942"
 
-    def test_defaults_to_gfx942_when_no_env_and_no_arg(self, monkeypatch):
+    def test_falls_back_to_the_running_device_not_a_hard_coded_arch(self, monkeypatch):
+        """With no argument and no env var, follow the hardware.
+
+        This used to assert ``== "gfx942"``, encoding the literal that made
+        ``validate_flashinfer_rocm_arch(arch_list=None)`` answer ``gfx942`` on a
+        gfx950 device while CompilationContext compiled for gfx950. A test that
+        pins a wrong constant is how the constant survives, so it is now pinned
+        to the detected architecture instead.
+        """
         monkeypatch.delenv("FLASHINFER_ROCM_ARCH_LIST", raising=False)
-        with self._patch_rocm_version("7.1.0"):
-            assert validate_rocm_arch(arch_list=None) == "gfx942"
+        with (
+            self._patch_rocm_version("7.1.0"),
+            patch(
+                "flashinfer.hip_utils.rocminfo_gpu_agents",
+                return_value=(("gfx950", "AMD Instinct MI350X"),),
+            ),
+        ):
+            assert validate_rocm_arch(arch_list=None) == "gfx950"
 
     def test_verbose_prints_message(self, capsys):
         with self._patch_rocm_version("7.1.0"):

--- a/tests/rocm_tests/test_hip_utils.py
+++ b/tests/rocm_tests/test_hip_utils.py
@@ -166,6 +166,57 @@ class TestResolveTargetArchs:
         with self._agents("gfx950"):
             assert resolve_target_archs() == "gfx942"
 
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            # Qualifiers: what torch's gcnArchName looks like, so an operator
+            # copying from `rocminfo` or a torch error message pastes this shape.
+            ("gfx950:sramecc+:xnack-", "gfx950"),
+            # ';' is documented for this same variable by jit/aiter_source.py.
+            # The two consumers must not disagree about their own env var.
+            ("gfx942;gfx950", "gfx942,gfx950"),
+            ("gfx942; gfx950", "gfx942,gfx950"),
+            # Empty tokens would otherwise reach the validators as "" and be
+            # reported as an unsupported architecture.
+            ("gfx942,,gfx950", "gfx942,gfx950"),
+            ("gfx942, gfx950 ", "gfx942,gfx950"),
+            # Duplicates collapse; first occurrence sets the order, which is what
+            # lands on the hipcc command line.
+            ("gfx950,gfx942,gfx950", "gfx950,gfx942"),
+            # Already canonical input must round-trip untouched.
+            ("gfx942,gfx950", "gfx942,gfx950"),
+        ],
+    )
+    def test_env_var_is_canonicalized(self, monkeypatch, raw, expected):
+        """The validators split on ',' only and match tokens verbatim, so an
+        unnormalized value is a hard failure, not an untidiness: "gfx942;gfx950"
+        arrives as one token, matches nothing, and validate_flashinfer_rocm_arch
+        raises "does not support any of the requested ROCm architectures"."""
+        monkeypatch.setenv("FLASHINFER_ROCM_ARCH_LIST", raw)
+        with self._agents("gfx950"):
+            assert resolve_target_archs() == expected
+
+    def test_explicit_argument_is_canonicalized(self, monkeypatch):
+        monkeypatch.delenv("FLASHINFER_ROCM_ARCH_LIST", raising=False)
+        with self._agents("gfx950"):
+            assert resolve_target_archs("gfx942:xnack-;gfx950") == "gfx942,gfx950"
+
+    def test_unknown_archs_survive_normalization(self, monkeypatch):
+        """Only syntax is normalized. Dropping an unrecognized arch here would
+        turn the validators' clear error into a build that quietly targets less
+        than was asked for."""
+        monkeypatch.setenv("FLASHINFER_ROCM_ARCH_LIST", "gfx900:xnack-;gfx942")
+        with self._agents("gfx950"):
+            assert resolve_target_archs() == "gfx900,gfx942"
+
+    @pytest.mark.parametrize("raw", [";;", "  ", ",", " ; , "])
+    def test_a_value_that_normalizes_away_falls_through(self, monkeypatch, raw):
+        """Returning "" would reach the validators as a single empty token and
+        fail as an unsupported architecture; detection is the better answer."""
+        monkeypatch.setenv("FLASHINFER_ROCM_ARCH_LIST", raw)
+        with self._agents("gfx950"):
+            assert resolve_target_archs() == "gfx950"
+
     def test_detects_the_running_device(self, monkeypatch):
         monkeypatch.delenv("FLASHINFER_ROCM_ARCH_LIST", raising=False)
         with self._agents("gfx950"):
@@ -199,11 +250,26 @@ class TestResolveTargetArchs:
         """The property the whole change exists for: the validator and the thing
         that emits --offload-arch must not disagree."""
         monkeypatch.delenv("FLASHINFER_ROCM_ARCH_LIST", raising=False)
+        import torch.utils.cpp_extension as torch_cpp_ext
+
         from flashinfer.compilation_context_hip import CompilationContext
 
+        # Both sides must see the same PyTorch. CompilationContext imports the
+        # real torch.utils.cpp_extension and validates against it, while the
+        # direct call below is handed _FakeCppExt -- so without this patch the
+        # assertion depends on the installed wheel. The wheel here is a fat build
+        # advertising gfx950, which is why that went unnoticed; an arch-specific
+        # build (gfx942-only) would make CompilationContext() raise "PyTorch does
+        # not support the following architectures" and fail this test for a
+        # reason that has nothing to do with resolver agreement.
         with (
             self._agents("gfx950"),
             patch("flashinfer.hip_utils.get_system_rocm_version", return_value="7.1.0"),
+            patch.object(
+                torch_cpp_ext,
+                "_get_rocm_arch_flags",
+                _FakeCppExt._get_rocm_arch_flags,
+            ),
         ):
             _, validated = validate_flashinfer_rocm_arch(
                 arch_list=None, torch_cpp_ext_module=_FakeCppExt(), verbose=False


### PR DESCRIPTION
## The bug

Three call sites independently answered "which GPU architecture are we compiling for", and on CDNA4 they disagreed. Measured on a gfx950 host with `FLASHINFER_ROCM_ARCH_LIST` unset:

```
ACTUAL device                                   gfx950
validate_flashinfer_rocm_arch(arch_list=None)   ['gfx942']   <-- wrong
CompilationContext().TARGET_ROCM_ARCHS          ['gfx950']
resolve_aiter_build_arch()                      gfx950
```

The JIT **validated gfx942 while compiling gfx950**. That check exists to catch *"your PyTorch was not built for this architecture"*, so pointed at the wrong architecture it fails both ways: vacuous on a fat PyTorch that carries both (it passes, having checked something you are not using), and a spurious hard failure on an arch-specific build carrying only gfx950 — refusing a setup that works.

The cause was `os.environ.get("FLASHINFER_ROCM_ARCH_LIST", "gfx942")` reached from two functions in `hip_utils`, plus two more `return "gfx942"` lines in `CompilationContext._auto_detect_archs`. **gfx942 was the one architecture where the literal happened to be right**, which is why CDNA3 never noticed. A unit test pinned the wrong constant (`test_defaults_to_gfx942_when_no_env_and_no_arg`), which is how it survived review for so long.

## The fix

`hip_utils.resolve_target_archs()` — explicit argument → `FLASHINFER_ROCM_ARCH_LIST` → architectures actually present → `gfx942` with a warning. `validate_rocm_arch`, `validate_flashinfer_rocm_arch`, `CompilationContext` and `aot_hip` all route through it. `_auto_detect_archs` is deleted (private, no other caller, and the holder of the remaining literals).

The GPU-less fallback stays on `gfx942` — the pre-existing default — so this changes nothing on hosts where no GPU is visible. `aot_hip` publishes the resolved list into `FLASHINFER_ROCM_ARCH_LIST` and `resolve_aiter_build_arch()` reads it back, so the two must agree about that default or the AITER shim is built for a different architecture than the kernels it ships beside. A test pins `_GPULESS_FALLBACK_ARCH == aiter_source._DEFAULT_BUILD_ARCH` so they cannot drift apart silently.

Detection uses `rocminfo`, not `torch.cuda`, so the resolver adds no torch dependency to a module that must stay importable without one — the hardware-less conformance job from #287 loads it.

Also included, both small and both fixing real failures:

- **`_canonical_arch_list`** — the validators split on `,` only and match tokens verbatim, so `FLASHINFER_ROCM_ARCH_LIST=gfx942;gfx950` became one token and raised *"does not support any of the requested ROCm architectures"*. `;` is worth accepting because `jit/aiter_source.py` already documents it for this same variable — the two consumers were disagreeing about the format of their own env var. Qualifiers (`gfx950:sramecc+`), empty tokens and duplicates are handled too. Syntax only: unknown architectures pass through so the validators can still report them.
- **Publish the validated list** — `aot_hip` writes `CompilationContext().TARGET_ROCM_ARCHS` into the environment, not the resolver's raw answer. Validation *filters* as well as raises: `validate_flashinfer_rocm_arch` drops architectures this ROCm or this PyTorch cannot build, warning rather than failing, so the target set can be a strict subset of what was requested. Publishing the wider list hands the AITER shim an architecture the kernels do not target — on ROCm 6.4 with `FLASHINFER_ROCM_ARCH_LIST="gfx950,gfx942"`, kernels build for gfx942 while the shim reads gfx950. A test pins this and fails against the previous code with the mismatch spelled out (`- gfx942` / `+ gfx950,gfx942`). Constructing the context first also keeps the earlier property: a failed validation leaves the environment as it found it.

## Test plan

- [x] After the fix, all four resolution paths report `gfx950` on the gfx950 host — the measurement at the top, re-run.
- [x] `FLASHINFER_ROCM_ARCH_LIST=gfx942` on a gfx950 box still resolves to `gfx942`; cross-compiling stays possible.
- [x] A container with no `/dev/kfd` resolves to `gfx942` with the warning, **without importing torch**.
- [x] Detection is cached per process — `CompilationContext` is constructed from five places, and the code this replaces reached rocminfo through the cached `get_supported_device_indices`. Calling the uncached probe directly re-ran the subprocess, timeout included, on every construction. Covered by a test.
- [x] `test_defaults_to_gfx942_when_no_env_and_no_arg` now pins the detected architecture instead of the literal.
- [x] **196 passed** across `test_hip_utils.py`, `test_aot_hip.py`, `test_aiter_build_arch_hip.py`, `test_arch_caps_hip.py` on gfx950.
- [x] `pre-commit run` clean on all changed files.
- [ ] Full suite on gfx950 and gfx942 — to be run on merged `amd-integration`, same image both sides, so architecture is the only variable.

