### PR TITLE
docs: align CLAUDE.md's AITER install with the README pin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,13 @@ explains the index choice. Note `amd-aiter` is **not** on the top-level
 `pypi.amd.com/simple` index, and it must be `--extra-index-url` rather than
 `--index-url` so AITER's own dependencies still resolve from PyPI.
 
+**Only cp310 and cp312 wheels exist** on that channel (verified 2026-08-20).
+On any other interpreter — 3.11, 3.13, 3.14 — the command fails with
+`No matching distribution found`, and there is no pinned-version fallback:
+public PyPI tops out at a stale `0.1.7.post2.dev18`, and the nightlies index
+only carries `>= 0.1.16`. Use CPython 3.12 unless you are prepared to run an
+unvalidated AITER.
+
 A source build (`git clone --recursive https://github.com/ROCm/aiter.git &&
 cd aiter && python3 setup.py develop`) tracks master, which is **many releases
 ahead of the pin with a different C ABI** — symbols the shim expects are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,19 +86,39 @@ count to avoid HSA/HIPBLAS flakiness under concurrent load. The `slow` marker
 gates 1M-trial sampling and 4 GB tensor tests — exclude with `-m "not slow"`
 for fast iteration.
 
-**AITER is a separate install**: The AITER backend (used by prefill attention
-on gfx942) is not bundled. Install from source:
+**AITER is a separate install, and the version matters**: The AITER backend
+(used by prefill attention on gfx942) is not bundled. Install the pinned wheel:
 
 ```bash
-git clone --recursive https://github.com/ROCm/aiter.git
-cd aiter && python3 setup.py develop
+pip install amd-aiter==0.1.10 --extra-index-url https://pypi.amd.com/rocm-7.1.1/simple
+```
+
+`0.1.10` is what this repo is built and tested against —
+`prefill_rocm.py` records it as `_AITER_LAST_VALIDATED`, and the README's
+[Install AITER wheel package](README.md#install-aiter-wheel-package) section
+explains the index choice. Note `amd-aiter` is **not** on the top-level
+`pypi.amd.com/simple` index, and it must be `--extra-index-url` rather than
+`--index-url` so AITER's own dependencies still resolve from PyPI.
+
+A source build (`git clone --recursive https://github.com/ROCm/aiter.git &&
+cd aiter && python3 setup.py develop`) tracks master, which is **many releases
+ahead of the pin with a different C ABI** — symbols the shim expects are
+renamed, hidden rather than `extern "C"`, or absent. Nothing stops you running
+one, but treat it as untested here.
+
+That gap is a trap when working on the C++ shim: read the **installed** tree,
+never a source checkout, before designing against an AITER symbol.
+
+```bash
+nm -D --defined-only -C <site-packages>/aiter/jit/module_<x>.so | grep '<fn>('
+sed -n '/<fn>/,/;/p' <site-packages>/aiter_meta/csrc/include/<hdr>.h
 ```
 
 Check availability in code: `from flashinfer.aiter_utils import is_aiter_supported`
 
 ## Arch ↔ codename
 
-MI300X / MI325X = gfx942 = CDNA3; MI355X = gfx950 = CDNA4.
+MI300X / MI325X = gfx942 = CDNA3; MI350X / MI355X = gfx950 = CDNA4.
 
 External tuning references (CK, AITER, HipKittens) live in the
 `benchmark-kernel` skill; PR/`gh` workflow details live in the `pr-workflow`


### PR DESCRIPTION
## Summary

`CLAUDE.md` told contributors to build AITER from source master and said nothing about a version. `README.md` says the opposite — *"Pin `0.1.10`: it is the version this repo is built and tested against"* — and `prefill_rocm.py` records the same value as `_AITER_LAST_VALIDATED`. Following the project instructions therefore put you on an untested build.

### What changed

- **`CLAUDE.md`** — the AITER install block now leads with the pinned wheel, copied verbatim from the README; documents the source build as legitimate-but-untested rather than deleting it; and spells out the read-the-installed-tree rule for shim work. Also adds MI350X to the arch/codename line.

### Why it matters

Master is many releases ahead of the pin **with a different C ABI** — symbols the shim expects are renamed, hidden rather than `extern "C"`, or absent outright. Concretely, between the installed `amd-aiter 0.1.10` and a recent source checkout: `mla_reduce_v1` does not exist at all, the MLA asm entry points are `torch::Tensor&` and C++-mangled rather than `aiter_tensor_t*` and `extern "C"`, and `reshape_and_cache_flash` changes signature.

This is not hypothetical. A C++ shim design was drafted against a source checkout and turned out to be unbuildable on the installed wheel — caught only when `nm -D` on the installed `.so` disagreed with the checkout's header. That is why the two `nm -D` / header commands are now in the file: they are what settles the question in seconds.

The wheel command is copied byte-for-byte from the README so the two cannot drift, and links to the section explaining why it must be `--extra-index-url` rather than `--index-url` (AITER's own dependencies still need to resolve from PyPI).

### MI350X

gfx950 covers both MI350X and MI355X. `README.md` already says so as of #288, and the `evidence` strings in the capability table were measured on an MI350X — so the narrower `MI355X = gfx950` line read as a contradiction against the repo's own recorded measurements.

## Test plan

Docs only — no Python touched, so there are no tests to run.

- [x] `pre-commit run --files CLAUDE.md` — clean (markdownlint included).
- [x] The README anchor resolves: `### Install AITER wheel package` exists at `README.md:428`.
- [x] The `pip install` line is byte-identical to `README.md:435`.