### PR TITLE
docs(pr-workflow): draft PR descriptions in the repo, not /tmp

### DIFF
--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -320,7 +320,14 @@ or a won't-fix rationale.
 **Draft it at `$(git rev-parse --show-toplevel)/tmp/pr/<branch>.md`** — the repo
 root of whichever checkout you are in, main or worktree, so the draft sits with
 the branch that it describes. Anchor to the top level rather than writing a
-relative `tmp/pr/...`, which resolves wrong from any subdirectory.
+relative `tmp/pr/...`, which resolves wrong from any subdirectory. `tmp/pr/`
+does not exist in a fresh clone or worktree, so create it as you go:
+
+```bash
+draft="$(git rev-parse --show-toplevel)/tmp/pr/$(git branch --show-current).md"
+mkdir -p "$(dirname "$draft")"
+# write the body to "$draft", then pass it as --body-file "$draft"
+```
 
 Never the **system** `/tmp`: it is shared, and there is no remove access to it
 on these nodes, so drafts left there cannot be cleaned up. Note the two are

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -324,10 +324,15 @@ relative `tmp/pr/...`, which resolves wrong from any subdirectory. `tmp/pr/`
 does not exist in a fresh clone or worktree, so create it as you go:
 
 ```bash
-draft="$(git rev-parse --show-toplevel)/tmp/pr/$(git branch --show-current).md"
+branch=$(git branch --show-current)   # empty on a detached HEAD
+draft="$(git rev-parse --show-toplevel)/tmp/pr/${branch:-detached-$(git rev-parse --short HEAD)}.md"
 mkdir -p "$(dirname "$draft")"
 # write the body to "$draft", then pass it as --body-file "$draft"
 ```
+
+A detached HEAD is an abort condition for the PR itself (see above); the
+fallback name only keeps the snippet from producing `tmp/pr/.md` if you run it
+before noticing.
 
 Never the **system** `/tmp`: it is shared, and there is no remove access to it
 on these nodes, so drafts left there cannot be cleaned up. Note the two are

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -122,17 +122,13 @@ branch or checkout path — so every worktree shares one cache. Clear it with
 per-branch, when comparing kernel changes across branches.
 
 Exclude the worktree root **per-clone** rather than in a tracked ignore file, so
-it never appears as a diff against upstream. One run covers the whole clone,
-worktrees included:
+it never appears as a diff against upstream. This is the same `/tmp/` entry that
+hides PR drafts — run the snippet in *One-time setup after a fresh clone* once
+and it covers the whole clone, worktrees included.
 
-```bash
-ex="$(git rev-parse --git-common-dir)/info/exclude"
-grep -qxF '/tmp/' "$ex" || printf '/tmp/\n' >> "$ex"
-```
-
-Use `--git-common-dir`, not a literal `.git/info/exclude`: inside a linked
-worktree `.git` is a *file* pointing at the real git dir, so the literal path
-fails with `not a directory`.
+That snippet uses `--git-common-dir`, not a literal `.git/info/exclude`, because
+inside a linked worktree `.git` is a *file* pointing at the real git dir, so the
+literal path fails with `not a directory`.
 
 ### A fresh worktree is source-only
 

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -44,6 +44,7 @@ These are local config (not checked in) and must be redone per clone:
 git remote -v                        # origin should be AMD-Ecosystem/flashinfer; there must be NO flashinfer-ai remote
 gh repo set-default AMD-Ecosystem/flashinfer  # pin gh base repo so it does not fall back to the fork parent
 ex="$(git rev-parse --git-common-dir)/info/exclude"   # per-clone ignore patterns
+mkdir -p "$(dirname "$ex")"                           # info/ is absent in some clones
 grep -qxF '/tmp/' "$ex" || printf '/tmp/\n' >> "$ex"  # ignores the repo's own tmp/
 ```
 

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -30,7 +30,7 @@ mismatch to the user instead. Never guess the target.
 
 ```bash
 gh pr create --repo AMD-Ecosystem/flashinfer --base amd-integration \
-  --title "<title>" --body "$(cat tmp/pr/<branch>.md)"
+  --title "<title>" --body-file "$(git rev-parse --show-toplevel)/tmp/pr/<branch>.md"
 ```
 
 If the resolved owner of `--repo` is ever `flashinfer-ai`, abort. It is always
@@ -43,8 +43,8 @@ These are local config (not checked in) and must be redone per clone:
 ```bash
 git remote -v                        # origin should be AMD-Ecosystem/flashinfer; there must be NO flashinfer-ai remote
 gh repo set-default AMD-Ecosystem/flashinfer  # pin gh base repo so it does not fall back to the fork parent
-ex="$(git rev-parse --git-common-dir)/info/exclude"   # holds worktree roots and PR drafts
-grep -qxF '/tmp/' "$ex" || printf '/tmp/\n' >> "$ex"
+ex="$(git rev-parse --git-common-dir)/info/exclude"   # per-clone ignore patterns
+grep -qxF '/tmp/' "$ex" || printf '/tmp/\n' >> "$ex"  # ignores the repo's own tmp/
 ```
 
 If a remote pointing at `flashinfer-ai/flashinfer` exists, remove it:
@@ -207,7 +207,7 @@ in doubt, hold the push and ask.
 gh api repos/AMD-Ecosystem/flashinfer/pulls/<number> --method PATCH --field body="<body>"
 
 # Or from a file
-gh api repos/AMD-Ecosystem/flashinfer/pulls/<number> --method PATCH --field body="$(cat tmp/pr/<branch>.md)"
+gh api repos/AMD-Ecosystem/flashinfer/pulls/<number> --method PATCH --field body="$(cat "$(git rev-parse --show-toplevel)/tmp/pr/<branch>.md")"
 ```
 
 Ask the user to confirm before running `git push` or `gh pr create` — these
@@ -317,11 +317,21 @@ or a won't-fix rationale.
 
 ## PR Description
 
-**Draft it at `tmp/pr/<branch>.md` in the main checkout** — never `/tmp`, which
-is shared and has no remove access on these nodes. This relies on `/tmp/` being
-in the clone's `info/exclude` (see *One-time setup after a fresh clone*); that
-file lives in the git *common* dir, so one entry covers every linked worktree
-and the draft never shows up as untracked. If `git status` does show it, that
+**Draft it at `$(git rev-parse --show-toplevel)/tmp/pr/<branch>.md`** — the repo
+root of whichever checkout you are in, main or worktree, so the draft sits with
+the branch that it describes. Anchor to the top level rather than writing a
+relative `tmp/pr/...`, which resolves wrong from any subdirectory.
+
+Never the **system** `/tmp`: it is shared, and there is no remove access to it
+on these nodes, so drafts left there cannot be cleaned up. Note the two are
+easily confused — the `/tmp/` entry in `info/exclude` is a *repo-root-anchored*
+pattern (the leading slash means repo root, not the filesystem root), so it
+ignores this repo's own `tmp/` directory and has nothing to do with the system
+one.
+
+That entry comes from *One-time setup after a fresh clone*. Because
+`info/exclude` lives in the git **common** dir, the single line covers the main
+checkout and every linked worktree. If `git status` does show your draft, that
 setup step has not been run in this clone.
 
 - **Do not hard-wrap** the body to a fixed column. GitHub renders a single

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -30,7 +30,7 @@ mismatch to the user instead. Never guess the target.
 
 ```bash
 gh pr create --repo AMD-Ecosystem/flashinfer --base amd-integration \
-  --title "<title>" --body "$(cat /tmp/pr_body.md)"
+  --title "<title>" --body "$(cat tmp/pr/<branch>.md)"
 ```
 
 If the resolved owner of `--repo` is ever `flashinfer-ai`, abort. It is always
@@ -43,6 +43,8 @@ These are local config (not checked in) and must be redone per clone:
 ```bash
 git remote -v                        # origin should be AMD-Ecosystem/flashinfer; there must be NO flashinfer-ai remote
 gh repo set-default AMD-Ecosystem/flashinfer  # pin gh base repo so it does not fall back to the fork parent
+ex="$(git rev-parse --git-common-dir)/info/exclude"   # holds worktree roots and PR drafts
+grep -qxF '/tmp/' "$ex" || printf '/tmp/\n' >> "$ex"
 ```
 
 If a remote pointing at `flashinfer-ai/flashinfer` exists, remove it:
@@ -205,7 +207,7 @@ in doubt, hold the push and ask.
 gh api repos/AMD-Ecosystem/flashinfer/pulls/<number> --method PATCH --field body="<body>"
 
 # Or from a file
-gh api repos/AMD-Ecosystem/flashinfer/pulls/<number> --method PATCH --field body="$(cat /tmp/pr_body.md)"
+gh api repos/AMD-Ecosystem/flashinfer/pulls/<number> --method PATCH --field body="$(cat tmp/pr/<branch>.md)"
 ```
 
 Ask the user to confirm before running `git push` or `gh pr create` — these
@@ -314,6 +316,13 @@ Done = no unresolved Copilot threads remain, each carrying either a fix+SHA repl
 or a won't-fix rationale.
 
 ## PR Description
+
+**Draft it at `tmp/pr/<branch>.md` in the main checkout** — never `/tmp`, which
+is shared and has no remove access on these nodes. This relies on `/tmp/` being
+in the clone's `info/exclude` (see *One-time setup after a fresh clone*); that
+file lives in the git *common* dir, so one entry covers every linked worktree
+and the draft never shows up as untracked. If `git status` does show it, that
+setup step has not been run in this clone.
 
 - **Do not hard-wrap** the body to a fixed column. GitHub renders a single
   newline inside a paragraph as a `<br>`, so column-wrapped prose shows up as


### PR DESCRIPTION
## Summary

The `pr-workflow` skill told you to draft PR descriptions at `/tmp/pr_body.md`, which contradicts the standing rule to keep scratch files out of `/tmp`. This moves the drafts into the repo at `tmp/pr/<branch>.md` and closes the gap that made that path safe only some of the time.

### What changed

- **`.claude/skills/pr-workflow/SKILL.md`** — both `/tmp/pr_body.md` references now point at `tmp/pr/<branch>.md`; new paragraph under `## PR Description` explaining where drafts live; the `info/exclude` setup line added to the fresh-clone setup block.

### Why not `/tmp`

There is no remove access to `/tmp` on these nodes, so anything left there cannot be cleaned up, and it is shared across users — a generic `/tmp/pr_body.md` already turned out to belong to someone else on one occasion, and writing to it would have destroyed their work. `tmp/pr/<branch>.md` is branch-namespaced, sits next to the work it describes, and cannot collide.

### The non-obvious part

`tmp/` is excluded per-clone via `info/exclude` rather than a tracked ignore file, so the exclusion never shows up as a diff against upstream. That entry lives in the git **common** dir, which means one line covers the main checkout and every linked worktree — a draft written from inside a worktree is excluded too.

The catch: that setup step was only documented under the worktree section. A clone that had not yet created a worktree would have no `/tmp/` entry, so a draft would show as untracked and could be committed by accident. The same idempotent line is now in `### One-time setup after a fresh clone`, and the new paragraph points at that section instead of asserting the exclusion is already in place.

## Test plan

- [x] `git check-ignore -v tmp/pr/test.md` resolves to `.git/info/exclude:7:/tmp/`
- [x] Verified the exclusion applies from a linked worktree, not just the main checkout
- [x] `grep -n 'pr_body' .claude/skills/pr-workflow/SKILL.md CLAUDE.md` returns nothing — no stale references left
- [x] Setup snippet is idempotent: `grep -qxF` guard means re-running adds no duplicate line
- [x] `/code-review` on the changelist before pushing — it caught the fresh-clone gap above, which is why the setup-block change is in this PR
