### PR TITLE
feat(rocm): AITER-backed fused MoE (flashinfer.aiter_fused_moe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ the routing decisions the library makes. Do not edit it by hand; run
 | `rmsnorm` | `aiter` | ✅ | ✅ |
 | `fused_add_rmsnorm` | `aiter` | ✅ | ✅ |
 | `silu_and_mul` | `aiter` | ✅ | ✅ |
+| `fused_moe` | `aiter` | ✅ | ✅ |
 | `single_decode` | `hip` | ◻️ | ◻️ |
 | `batch_decode` | `hip` | ◻️ | ◻️ |
 | `single_prefill` | `hip` | ◻️ | ◻️ |
@@ -127,7 +128,9 @@ the routing decisions the library makes. Do not edit it by hand; run
 Measured on:
 
 * `gfx942` — MI300X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-19
+* `gfx942` — fused_moe: MI300X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-24
 * `gfx950` — MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-19
+* `gfx950` — fused_moe: MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-24
 
 <!-- END GENERATED: arch support matrix -->
 

--- a/benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py
+++ b/benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py
@@ -1,0 +1,125 @@
+"""
+Copyright (c) 2026 Advanced Micro Devices, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Fused MoE benchmark: sweeps num_tokens across the decode -> prefill range for
+Mixtral-8x7B and Qwen3-235B expert shapes.
+
+At low token counts only a few rows land in each expert, so the two GEMMs read
+far more weight than activation and the roofline sits on HBM: the headline
+metric is expert-weight bytes/sec. Past roughly block_m tokens per expert the
+GEMMs fill their tiles and it becomes compute bound.
+
+Two numbers this exists to produce, both open questions in the shim:
+
+  1. The gap to `aiter.fused_moe`, which selects kernels from a tuned CSV while
+     the shim passes an empty kernelName and takes AITER's heuristic. If the gap
+     is small the CSV lookup is not worth building.
+  2. The cost of allocating the five sorting buffers per call, visible as the
+     shim's overhead over the same work at large M where allocation is amortized.
+
+Run:
+    python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py                 # full pipeline
+    python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py --timing-only   # no profiling
+    python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py --replot        # regenerate plot
+    python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py --counters      # PMC passes
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+import torch
+
+import flashinfer
+from flashinfer.fused_moe_rocm import shuffle_moe_weight
+from flashinfer.jit.core import logger as _jit_logger
+
+_jit_logger.setLevel(logging.WARNING)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "rocm_profiler"))
+from rocm_profiler import KernelConfig, RocmProfiler
+
+_OUTPUT_DIR = str(Path(__file__).parent)
+
+# Crosses the tile-fill boundary: 1-32 tokens leaves most experts with a partial
+# block_m tile, 1024+ saturates.
+_NUM_TOKENS = [1, 8, 32, 128, 512, 2048]
+
+# (label, num_experts, model_dim, inter_dim, topk)
+_SHAPES = [
+    ("mixtral8x7b", 8, 4096, 14336, 2),
+    ("qwen3-235b", 128, 4096, 1536, 8),
+]
+
+_DTYPE = torch.bfloat16
+
+
+@torch.inference_mode()
+def _make_configs() -> list[KernelConfig]:
+    itemsize = torch.tensor([], dtype=_DTYPE).element_size()
+    configs = []
+    for label, E, K, I, topk in _SHAPES:
+        w1 = shuffle_moe_weight(
+            torch.randn(E, 2 * I, K, device="cuda", dtype=_DTYPE) / 16
+        )
+        w2 = shuffle_moe_weight(torch.randn(E, K, I, device="cuda", dtype=_DTYPE) / 16)
+        for nt in _NUM_TOKENS:
+            x = torch.randn(nt, K, device="cuda", dtype=_DTYPE) / 8
+            logits = torch.randn(nt, E, device="cuda", dtype=torch.float32)
+            weights, ids = torch.topk(torch.softmax(logits, dim=-1), topk, dim=-1)
+            ids = ids.to(torch.int32).contiguous()
+            weights = weights.contiguous()
+            out = torch.empty(nt, K, device="cuda", dtype=_DTYPE)
+
+            # Two GEMMs per (token, expert): [1,K]x[K,2I] and [1,I]x[I,K].
+            theo_flops = 2 * nt * topk * (K * 2 * I + I * K)
+            # Weights dominate until every expert is hit by many tokens; count the
+            # experts actually touched rather than all E.
+            experts_hit = min(E, nt * topk)
+            theo_bytes = (
+                experts_hit * (2 * I * K + K * I) * itemsize
+                + nt * (K + topk * I + K) * itemsize
+            )
+            configs.append(
+                KernelConfig(
+                    name=f"moe_{label}_nt{nt}",
+                    run_fn=torch.inference_mode()(
+                        lambda x=x, w1=w1, w2=w2, ids=ids, weights=weights, out=out: (
+                            flashinfer.aiter_fused_moe(x, w1, w2, ids, weights, out=out)
+                        )
+                    ),
+                    theoretical_flops=theo_flops,
+                    theoretical_bytes=theo_bytes,
+                    num_tokens=nt,
+                    label=f"{label} nt={nt:>5d} E={E:>3d} topk={topk}",
+                )
+            )
+    return configs
+
+
+if __name__ == "__main__":
+    _skip_gpu = "--replot" in sys.argv or "--list-presets" in sys.argv
+    profiler = RocmProfiler(
+        configs=[] if _skip_gpu else _make_configs(),
+        num_warmup=3,
+        dry_run_ms=100,
+        repeat_ms=1000,
+        counters="roofline",
+        kernel_name_regex="moe|gemm",
+        output_dir=_OUTPUT_DIR,
+        label="fused_moe_aiter",
+        roofline=True,
+    )
+    profiler.run()

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -192,6 +192,8 @@ elif IS_HIP:
     from .decode_rocm import (  # type: ignore[no-redef]
         single_decode_with_kv_cache as single_decode_with_kv_cache,
     )
+    from .fused_moe_rocm import aiter_fused_moe as aiter_fused_moe
+    from .fused_moe_rocm import shuffle_moe_weight as shuffle_moe_weight
     from .get_include_paths import get_csrc_dir, get_include
     from .norm import fused_add_rmsnorm as fused_add_rmsnorm
     from .norm import gemma_fused_add_rmsnorm as gemma_fused_add_rmsnorm

--- a/flashinfer/arch_caps.py
+++ b/flashinfer/arch_caps.py
@@ -276,6 +276,17 @@ def _archs(gfx942: ArchSupport, gfx950: ArchSupport) -> Mapping[str, ArchSupport
 
 _OK_942 = ArchSupport(Support.SUPPORTED, evidence=_MEASURED_942)
 _OK_950 = ArchSupport(Support.SUPPORTED, evidence=_MEASURED_950)
+# Fused MoE has its own runs, so they name themselves: the README lists evidence
+# per architecture, and two bare gfx950 strings differing only by date are not
+# attributable to an op.
+_OK_942_MOE = ArchSupport(
+    Support.SUPPORTED,
+    evidence="fused_moe: MI300X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-24",
+)
+_OK_950_MOE = ArchSupport(
+    Support.SUPPORTED,
+    evidence="fused_moe: MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-24",
+)
 # HIP rows: declared, not yet individually attributed. The suites above cover
 # them, but no per-op HIP measurement has been recorded, so the evidence field
 # stays empty rather than borrowing the AITER runs' credibility.
@@ -310,6 +321,8 @@ CAPABILITIES: Tuple[Capability, ...] = (
         "fused_add_rmsnorm", "aiter", _archs(_OK_942, _OK_950), fallback="native"
     ),
     Capability("silu_and_mul", "aiter", _archs(_OK_942, _OK_950), fallback="native"),
+    # No HIP MoE kernel, so no fallback.
+    Capability("fused_moe", "aiter", _archs(_OK_942_MOE, _OK_950_MOE)),
     # --- HIP backends: declared; per-op evidence not yet recorded ----------
     Capability("single_decode", "hip", _archs(_HIP_942, _HIP_950)),
     Capability("batch_decode", "hip", _archs(_HIP_942, _HIP_950)),

--- a/flashinfer/csrc_rocm/fused_moe_aiter.cu
+++ b/flashinfer/csrc_rocm/fused_moe_aiter.cu
@@ -128,6 +128,9 @@ void fused_moe_aiter(at::Tensor out, at::Tensor hidden_states, at::Tensor w1, at
               "fused_moe_aiter: topk_ids/topk_weights must have ", num_tokens, " rows");
   TORCH_CHECK(topk_weights.size(1) == topk, "fused_moe_aiter: topk_weights has ",
               topk_weights.size(1), " columns but topk_ids has ", topk);
+  // topk==0 reaches a division by zero inside AITER and raises SIGFPE, which
+  // kills the process rather than surfacing as an exception.
+  TORCH_CHECK(topk >= 1, "fused_moe_aiter: topk must be at least 1, got ", topk);
   TORCH_CHECK(topk <= num_experts, "fused_moe_aiter: topk=", topk,
               " exceeds num_experts=", num_experts);
   TORCH_CHECK(out.size(0) == num_tokens && out.size(1) == model_dim,

--- a/flashinfer/csrc_rocm/fused_moe_aiter.cu
+++ b/flashinfer/csrc_rocm/fused_moe_aiter.cu
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// PyTorch entry point for AITER's CK two-stage fused MoE. FlashInfer links the
+// symbol-visible AITER modules (see flashinfer/jit/aiter_source.py) and calls the
+// kernels directly — no Python `import aiter` at runtime.
+//
+// Routing is the caller's: this takes topk_ids/topk_weights and runs
+// moe_sorting -> stage1 (gate/up + activation) -> stage2 (down + weighted sum).
+// The routing weights are applied in stage2, matching the `-m 2` (mulWeightStage2)
+// instances the JIT spec generates.
+
+#include <ATen/ATen.h>
+#include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
+#include <c10/hip/HIPGuard.h>
+
+#include <optional>
+#include <string>
+
+// AITER's public headers (moe_sorting.h, moe_ck.h) pull in <torch/extension.h> →
+// full pybind11, which clashes with FlashInfer's -DPy_LIMITED_API. torch::Tensor
+// is at::Tensor, so forward-declare the entry points; the linker resolves them
+// against the symbol-visible AITER .so. Both are at global namespace.
+void moe_sorting_fwd(at::Tensor& topk_ids, at::Tensor& topk_weights, at::Tensor& sorted_token_ids,
+                     at::Tensor& sorted_weights, at::Tensor& sorted_expert_ids,
+                     at::Tensor& num_valid_ids, at::Tensor& moe_buf, int num_experts, int unit_size,
+                     std::optional<at::Tensor> local_expert_mask,
+                     std::optional<at::Tensor> num_local_tokens, int dispatch_policy);
+
+void ck_moe_stage1(at::Tensor& hidden_states, at::Tensor& w1, at::Tensor& w2,
+                   at::Tensor& sorted_token_ids, at::Tensor& sorted_expert_ids,
+                   at::Tensor& num_valid_ids, at::Tensor& out, int topk, std::string& kernelName,
+                   std::optional<at::Tensor> w1_scale, std::optional<at::Tensor> a1_scale,
+                   std::optional<int> block_m, std::optional<at::Tensor> sorted_weights,
+                   int quant_type, int activation, std::optional<int> splitk, bool nt,
+                   std::optional<std::string> dst_type);
+
+void ck_moe_stage2(at::Tensor& inter_states, at::Tensor& w1, at::Tensor& w2,
+                   at::Tensor& sorted_token_ids, at::Tensor& sorted_expert_ids,
+                   at::Tensor& num_valid_ids, at::Tensor& out, int topk, std::string& kernelName,
+                   std::optional<at::Tensor> w2_scale, std::optional<at::Tensor> a2_scale,
+                   std::optional<int> block_m, std::optional<at::Tensor> sorted_weights,
+                   int quant_type, int activation, std::optional<int> splitk, bool nt,
+                   std::optional<std::string> dst_type);
+
+namespace {
+
+// aiter_enum.h: ActivationType { No = -1, Silu = 0, Gelu = 1, Swiglu = 2 }.
+constexpr int kActivationSilu = 0;
+constexpr int kActivationGelu = 1;
+// aiter_enum.h: QuantType { No = 0, ... }.
+constexpr int kQuantNone = 0;
+
+// The CK heuristic dispatch (ck2stages_moe_stage{1,2}_heuristic_dispatch.hpp)
+// enumerates exactly these and TORCH_CHECKs otherwise; reject here so the error
+// names the argument rather than surfacing from inside CK.
+bool is_supported_block_m(int64_t block_m) {
+  return block_m == 32 || block_m == 64 || block_m == 128;
+}
+
+// Byte ranges of two tensors' occupied memory intersect.
+bool overlaps(const at::Tensor& a, const at::Tensor& b) {
+  if (!a.has_storage() || !b.has_storage() || a.device() != b.device()) return false;
+  const auto* a0 = static_cast<const char*>(a.data_ptr());
+  const auto* b0 = static_cast<const char*>(b.data_ptr());
+  return a0 < b0 + b.nbytes() && b0 < a0 + a.nbytes();
+}
+
+}  // namespace
+
+// hidden_states: [m, model_dim]
+// w1:            [num_experts, 2 * inter_dim, model_dim]  (gate and up, concatenated)
+// w2:            [num_experts, model_dim, inter_dim]
+// topk_ids:      [m, topk]  int32, every value in [0, num_experts)
+// topk_weights:  [m, topk]  float32
+// out:           [m, model_dim]
+//
+// Caller precondition: topk_ids values are in range. Checking on device would
+// cost a synchronize per call, so out-of-range ids (a -1 drop marker, or global
+// ids against a local expert-parallel shard) index w1/w2 out of bounds instead.
+void fused_moe_aiter(at::Tensor out, at::Tensor hidden_states, at::Tensor w1, at::Tensor w2,
+                     at::Tensor topk_ids, at::Tensor topk_weights, int64_t block_m,
+                     int64_t activation) {
+  const c10::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(hidden_states.device());
+
+  TORCH_CHECK(activation == kActivationSilu || activation == kActivationGelu,
+              "fused_moe_aiter: activation must be silu (0) or gelu (1), got ", activation);
+  TORCH_CHECK(is_supported_block_m(block_m), "fused_moe_aiter: block_m must be 32, 64 or 128, got ",
+              block_m);
+
+  const auto dtype = hidden_states.scalar_type();
+  TORCH_CHECK(dtype == at::kBFloat16 || dtype == at::kHalf,
+              "fused_moe_aiter: hidden_states must be bfloat16 or float16, got ", dtype);
+  TORCH_CHECK(w1.scalar_type() == dtype && w2.scalar_type() == dtype,
+              "fused_moe_aiter: w1/w2 dtype must match hidden_states (", dtype, "), got ",
+              w1.scalar_type(), " and ", w2.scalar_type());
+  TORCH_CHECK(out.scalar_type() == dtype, "fused_moe_aiter: out dtype must match hidden_states (",
+              dtype, "), got ", out.scalar_type());
+
+  TORCH_CHECK(hidden_states.dim() == 2, "fused_moe_aiter: hidden_states must be 2-D, got ",
+              hidden_states.dim(), "-D");
+  TORCH_CHECK(w1.dim() == 3 && w2.dim() == 3, "fused_moe_aiter: w1 and w2 must be 3-D, got ",
+              w1.dim(), "-D and ", w2.dim(), "-D");
+  TORCH_CHECK(topk_ids.dim() == 2 && topk_weights.dim() == 2,
+              "fused_moe_aiter: topk_ids and topk_weights must be 2-D");
+
+  TORCH_CHECK(topk_ids.scalar_type() == at::kInt, "fused_moe_aiter: topk_ids must be int32, got ",
+              topk_ids.scalar_type());
+  TORCH_CHECK(topk_weights.scalar_type() == at::kFloat,
+              "fused_moe_aiter: topk_weights must be float32, got ", topk_weights.scalar_type());
+
+  const int64_t num_tokens = hidden_states.size(0);
+  const int64_t model_dim = hidden_states.size(1);
+  const int64_t num_experts = w1.size(0);
+  const int64_t inter_dim = w2.size(2);
+  const int64_t topk = topk_ids.size(1);
+
+  TORCH_CHECK(w1.size(1) == 2 * inter_dim,
+              "fused_moe_aiter: expected w1 [E, 2 * inter_dim, model_dim] with inter_dim=",
+              inter_dim, " from w2, got w1.size(1)=", w1.size(1));
+  TORCH_CHECK(w1.size(2) == model_dim, "fused_moe_aiter: w1.size(2)=", w1.size(2),
+              " must equal model_dim=", model_dim);
+  TORCH_CHECK(w2.size(0) == num_experts, "fused_moe_aiter: w1 has ", num_experts,
+              " experts but w2 has ", w2.size(0));
+  TORCH_CHECK(w2.size(1) == model_dim, "fused_moe_aiter: w2.size(1)=", w2.size(1),
+              " must equal model_dim=", model_dim);
+  TORCH_CHECK(topk_ids.size(0) == num_tokens && topk_weights.size(0) == num_tokens,
+              "fused_moe_aiter: topk_ids/topk_weights must have ", num_tokens, " rows");
+  TORCH_CHECK(topk_weights.size(1) == topk, "fused_moe_aiter: topk_weights has ",
+              topk_weights.size(1), " columns but topk_ids has ", topk);
+  TORCH_CHECK(topk <= num_experts, "fused_moe_aiter: topk=", topk,
+              " exceeds num_experts=", num_experts);
+  TORCH_CHECK(out.size(0) == num_tokens && out.size(1) == model_dim,
+              "fused_moe_aiter: out must be [", num_tokens, ", ", model_dim, "]");
+
+  TORCH_CHECK(hidden_states.is_contiguous() && w1.is_contiguous() && w2.is_contiguous(),
+              "fused_moe_aiter: hidden_states, w1 and w2 must be contiguous");
+  TORCH_CHECK(topk_ids.is_contiguous() && topk_weights.is_contiguous(),
+              "fused_moe_aiter: topk_ids and topk_weights must be contiguous");
+  TORCH_CHECK(out.is_contiguous(), "fused_moe_aiter: out must be contiguous");
+
+  // Every tensor is read or written by kernels launched on hidden_states' device.
+  const auto device = hidden_states.device();
+  TORCH_CHECK(w1.device() == device && w2.device() == device && topk_ids.device() == device &&
+                  topk_weights.device() == device && out.device() == device,
+              "fused_moe_aiter: every tensor must be on ", device, "; got w1=", w1.device(),
+              " w2=", w2.device(), " topk_ids=", topk_ids.device(),
+              " topk_weights=", topk_weights.device(), " out=", out.device());
+
+  // out doubles as moe_sorting_fwd's zero-filled accumulation buffer, so it is
+  // cleared before stage 1 reads the activations. Aliasing an input would feed
+  // stage 1 zeros and return an all-zero result with no error.
+  TORCH_CHECK(!overlaps(out, hidden_states),
+              "fused_moe_aiter: out must not overlap hidden_states (out is zero-filled "
+              "before the activations are read); pass a separate tensor");
+  TORCH_CHECK(!overlaps(out, w1) && !overlaps(out, w2),
+              "fused_moe_aiter: out must not overlap w1 or w2");
+
+  // Sorting buffer sizes, mirroring aiter/fused_moe.py::moe_sorting. Note
+  // num_valid_ids is 2 int32 even though moe_sorting.h comments it as [1].
+  const int64_t max_num_tokens_padded = topk_ids.numel() + num_experts * block_m - topk;
+  const int64_t max_num_m_blocks = (max_num_tokens_padded + block_m - 1) / block_m;
+
+  const auto i32 = hidden_states.options().dtype(at::kInt);
+  const auto f32 = hidden_states.options().dtype(at::kFloat);
+
+  at::Tensor sorted_token_ids = at::empty({max_num_tokens_padded}, i32);
+  at::Tensor sorted_weights = at::empty({max_num_tokens_padded}, f32);
+  at::Tensor sorted_expert_ids = at::empty({max_num_m_blocks}, i32);
+  at::Tensor num_valid_ids = at::empty({2}, i32);
+
+  // moe_sorting_fwd zero-fills moe_buf, and stage2 accumulates the per-expert
+  // contributions into it — so `out` is the sorting buffer, not a separate one.
+  moe_sorting_fwd(topk_ids, topk_weights, sorted_token_ids, sorted_weights, sorted_expert_ids,
+                  num_valid_ids, out, static_cast<int>(num_experts), static_cast<int>(block_m),
+                  /*local_expert_mask=*/std::nullopt, /*num_local_tokens=*/std::nullopt,
+                  /*dispatch_policy=*/0);
+
+  at::Tensor inter_states =
+      at::empty({num_tokens, topk, inter_dim}, hidden_states.options().dtype(dtype));
+
+  // Empty kernelName selects AITER's heuristic dispatch (moe_dispatch in
+  // gemm_moe_ck2stages.cu); a tuned name would come from aiter's tuned_fmoe.csv.
+  std::string kernel_name;
+  const int topk_i32 = static_cast<int>(topk);
+  const int block_m_i32 = static_cast<int>(block_m);
+  const int activation_i32 = static_cast<int>(activation);
+
+  ck_moe_stage1(hidden_states, w1, w2, sorted_token_ids, sorted_expert_ids, num_valid_ids,
+                inter_states, topk_i32, kernel_name, /*w1_scale=*/std::nullopt,
+                /*a1_scale=*/std::nullopt, block_m_i32, /*sorted_weights=*/std::nullopt, kQuantNone,
+                activation_i32, /*splitk=*/1, /*nt=*/false,
+                /*dst_type=*/std::nullopt);
+
+  ck_moe_stage2(inter_states, w1, w2, sorted_token_ids, sorted_expert_ids, num_valid_ids, out,
+                topk_i32, kernel_name, /*w2_scale=*/std::nullopt, /*a2_scale=*/std::nullopt,
+                block_m_i32, sorted_weights, kQuantNone, activation_i32, /*splitk=*/1,
+                /*nt=*/false, /*dst_type=*/std::nullopt);
+}

--- a/flashinfer/csrc_rocm/fused_moe_aiter_jit_pybind.cu
+++ b/flashinfer/csrc_rocm/fused_moe_aiter_jit_pybind.cu
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <ATen/ATen.h>
+
+#include "pytorch_extension_utils.h"
+
+void fused_moe_aiter(at::Tensor out, at::Tensor hidden_states, at::Tensor w1, at::Tensor w2,
+                     at::Tensor topk_ids, at::Tensor topk_weights, int64_t block_m,
+                     int64_t activation);
+
+TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) { m.def("fused_moe_aiter", fused_moe_aiter); }

--- a/flashinfer/fused_moe_rocm.py
+++ b/flashinfer/fused_moe_rocm.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Fused mixture-of-experts for ROCm, backed by AITER's CK two-stage kernels.
+
+Routing is the caller's responsibility: pass the selected experts and their
+weights, as with upstream's ``cutlass_fused_moe``. Only unquantized bfloat16 and
+float16 are wired up so far; the quantized paths are a follow-up.
+
+The expert weights must be pre-shuffled with :func:`shuffle_moe_weight` -- see
+that function for why this cannot be checked for you.
+
+The entry point is exported as ``flashinfer.aiter_fused_moe``, backend-prefixed
+like upstream's ``cutlass_fused_moe``. Plain ``fused_moe`` is unavailable as a
+top-level name: ``flashinfer/fused_moe/`` is a shipped subpackage, and importing
+it would rebind the attribute from this function to that module.
+"""
+
+import functools
+from typing import Optional
+
+import torch
+
+from .aiter_utils import require_aiter
+from .jit.fused_moe_rocm import SUPPORTED_DTYPES, gen_fused_moe_aiter_module
+
+__all__ = ["aiter_fused_moe", "shuffle_moe_weight"]
+
+# aiter_enum.h ActivationType, mirrored so callers need no aiter import. The keys
+# are also the supported-activation set, here and in the JIT spec.
+_ACTIVATION_CODE = {"silu": 0, "gelu": 1}
+
+# CK's stage-1 tile height. 32 suits decode-shaped batches; larger tiles amortize
+# better once there are many tokens per expert. The heuristic dispatch enumerates
+# exactly {32, 64, 128}.
+_DEFAULT_BLOCK_M = 32
+_SUPPORTED_BLOCK_M = (32, 64, 128)
+
+# CK's MFMA tile for the weight operand: 16 rows x 16 columns per instruction.
+_SHUFFLE_LAYOUT = (16, 16)
+
+
+@functools.cache
+def _get_module(dtype: torch.dtype, activation: str):
+    return gen_fused_moe_aiter_module(dtype, activation).build_and_load()
+
+
+def shuffle_moe_weight(w: torch.Tensor) -> torch.Tensor:
+    """Reorder an expert weight into the layout CK's MoE GEMM reads.
+
+    Call once per weight at model load and keep the result. The permutation
+    preserves shape and dtype, so nothing downstream can detect its absence:
+    unshuffled weights are silently wrong, not an error.
+
+    Args:
+        w: ``[num_experts, n, k]``. ``n`` must be a multiple of 16 and ``k`` a
+            multiple of 32.
+
+    Returns:
+        A new contiguous tensor with the same shape and dtype as ``w``.
+    """
+    if w.dim() != 3:
+        raise ValueError(f"expected a 3-D [num_experts, n, k] weight, got {w.dim()}-D")
+
+    block_n, inst_k = _SHUFFLE_LAYOUT
+    block_k = inst_k * 2
+    # Elements per 16-byte lane load, which is what the innermost axis groups.
+    lane = 16 // w.element_size()
+    n, k = w.shape[-2], w.shape[-1]
+    if n % block_n or k % block_k:
+        raise ValueError(
+            f"weight [..., {n}, {k}] must have n divisible by {block_n} and k "
+            f"divisible by {block_k} to be shuffled for CK's MoE GEMM"
+        )
+
+    return (
+        w.view(-1, n // block_n, block_n, k // block_k, block_k // lane, lane)
+        .permute(0, 1, 3, 4, 2, 5)
+        .contiguous()
+        .view(w.shape)
+    )
+
+
+def aiter_fused_moe(
+    hidden_states: torch.Tensor,
+    w1_shuffled: torch.Tensor,
+    w2_shuffled: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    *,
+    activation: str = "silu",
+    block_m: int = _DEFAULT_BLOCK_M,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    r"""Fused mixture-of-experts forward pass on ROCm.
+
+    Computes, for each token and each of its selected experts :math:`e`,
+    ``act(x @ w1_gate[e].T) * (x @ w1_up[e].T) @ w2[e].T``, scaled by the routing
+    weight and summed over the ``topk`` experts.
+
+    Both weights must have been passed through :func:`shuffle_moe_weight`; the
+    parameters are named for it because the requirement cannot be checked. The
+    first call per ``(dtype, activation)`` builds two AITER modules and takes
+    minutes, then caches under ``~/.cache/flashinfer/aiter_libs/``.
+
+    Args:
+        hidden_states: ``[num_tokens, model_dim]``, bfloat16 or float16.
+        w1_shuffled: ``[num_experts, 2 * inter_dim, model_dim]`` -- the gate and
+            up projections concatenated along dim 1, gate first, then shuffled.
+        w2_shuffled: ``[num_experts, model_dim, inter_dim]``, the down
+            projection, shuffled.
+        topk_ids: ``[num_tokens, topk]`` int32, the selected experts. Every
+            value must be in ``[0, num_experts)``; a drop marker such as ``-1``,
+            or a global id against a local expert-parallel shard, reads out of
+            bounds. Validating on device would cost a synchronize per call.
+        topk_weights: ``[num_tokens, topk]`` float32, the routing weights.
+        activation: ``"silu"`` or ``"gelu"``.
+        block_m: CK tile height, one of ``(32, 64, 128)``.
+        out: Optional ``[num_tokens, model_dim]`` destination. Allocated if
+            None. Overwritten, not accumulated into, and it may not overlap any
+            input -- it is zero-filled before the activations are read.
+
+    Returns:
+        ``[num_tokens, model_dim]``, same dtype as ``hidden_states``.
+
+    Raises:
+        ValueError: The device or the aiter install cannot serve this op, or an
+            argument is out of range.
+    """
+    require_aiter(hidden_states.device, "fused_moe")
+
+    if activation not in _ACTIVATION_CODE:
+        raise ValueError(
+            f"activation must be one of {sorted(_ACTIVATION_CODE)}, got {activation!r}"
+        )
+    if block_m not in _SUPPORTED_BLOCK_M:
+        raise ValueError(f"block_m must be one of {_SUPPORTED_BLOCK_M}, got {block_m}")
+    if hidden_states.dtype not in SUPPORTED_DTYPES:
+        # Ahead of _get_module: one module is built per dtype, so an unsupported
+        # one would otherwise compile for minutes before anything rejected it.
+        raise ValueError(
+            f"hidden_states must be one of {list(SUPPORTED_DTYPES)}, "
+            f"got {hidden_states.dtype}"
+        )
+
+    if out is None:
+        out = torch.empty(
+            (hidden_states.shape[0], hidden_states.shape[1]),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+
+    module = _get_module(hidden_states.dtype, activation)
+    # Skip torch custom-op dispatch, as the other AITER ROCm paths do: AITER is
+    # inference-only here and torch.compile support is not required.
+    module.fused_moe_aiter.default(
+        out,
+        hidden_states,
+        w1_shuffled,
+        w2_shuffled,
+        topk_ids,
+        topk_weights,
+        block_m,
+        _ACTIVATION_CODE[activation],
+    )
+    return out

--- a/flashinfer/fused_moe_rocm.py
+++ b/flashinfer/fused_moe_rocm.py
@@ -123,8 +123,10 @@ def aiter_fused_moe(
         ``[num_tokens, model_dim]``, same dtype as ``hidden_states``.
 
     Raises:
-        ValueError: The device or the aiter install cannot serve this op, or an
-            argument is out of range.
+        ValueError: The device or the aiter install cannot serve this op, or
+            ``activation``/``block_m``/the dtype is unsupported.
+        RuntimeError: A tensor fails the shim's shape, dtype, device,
+            contiguity, or aliasing checks.
     """
     require_aiter(hidden_states.device, "fused_moe")
 

--- a/flashinfer/jit/aiter_source.py
+++ b/flashinfer/jit/aiter_source.py
@@ -16,14 +16,19 @@ helper rebuilds the needed AITER module once with ``AITER_SYMBOL_VISIBLE=1`` via
 AITER's own ``aiter.jit.core.build_module`` (which also runs CK blob codegen for CK
 ops), caches the result under FlashInfer's cache dir as ``lib<module>.so``, and
 hands back the include/link flags for ``gen_jit_spec``.
+
+A shim may link more than one AITER module (fused MoE needs both ``moe_sorting``
+and a CK GEMM module), and a module may be built in a *specialized* form -- see
+:class:`AiterModule`.
 """
 
 import functools
 import os
 import re
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 from filelock import FileLock
 
@@ -37,6 +42,55 @@ _DEFAULT_BUILD_ARCH = "gfx942"
 # An architecture name and nothing else: "gfx942", "gfx950", "gfx90a". Anchored
 # so a token that merely starts with "gfx" cannot smuggle in a path separator.
 _ARCH_RE = re.compile(r"^gfx[0-9a-f]+$")
+
+# The linked library name becomes an -l flag and a filename, so it may not smuggle
+# in a path separator or a flag-looking prefix. \Z, not $: $ also matches before a
+# trailing newline, which would reach the ninja link line intact.
+_LIB_NAME_RE = re.compile(r"\A[A-Za-z0-9_][A-Za-z0-9_.+-]*\Z")
+
+
+@dataclass(frozen=True)
+class AiterModule:
+    """One AITER module to build symbol-visible and link into a FlashInfer shim.
+
+    ``name`` keys AITER's ``optCompilerConfig.json``, which supplies the sources
+    and compile flags. ``md_name`` and ``blob_gen_cmd`` override the two fields
+    that select *which instances* that source tree generates.
+
+    Specialization is not an optimization. ``module_moe_ck2stages`` builds every
+    dtype/activation/quant combination by default -- 280 MB and far past a
+    tolerable first-call build -- while one configuration needs a handful of
+    instances. AITER specializes it the same way (``get_moe_stage_module`` in
+    ``aiter/ops/moe_op.py``).
+
+    ``md_name`` also names the cached ``lib<md_name>.so``, so two specializations
+    of one module cannot overwrite each other.
+    """
+
+    name: str
+    md_name: Optional[str] = None
+    blob_gen_cmd: Optional[Union[str, Tuple[str, ...]]] = None
+
+    @property
+    def lib_name(self) -> str:
+        """The library basename: ``lib<lib_name>.so``, linked as ``-l<lib_name>``."""
+        # `is None`, not falsiness: an empty md_name must not silently resolve to
+        # the unspecialized name, which is how two specializations would collide.
+        return self.name if self.md_name is None else self.md_name
+
+    def __post_init__(self) -> None:
+        for label, value in (("name", self.name), ("md_name", self.md_name)):
+            if value is not None and not _LIB_NAME_RE.match(value):
+                raise ValueError(
+                    f"AITER {label} {value!r} is not usable as a library name; "
+                    "expected something like 'module_moe_sorting'"
+                )
+
+
+def _as_modules(
+    modules: Sequence[Union[str, AiterModule]],
+) -> Tuple[AiterModule, ...]:
+    return tuple(AiterModule(m) if isinstance(m, str) else m for m in modules)
 
 
 def _env_arch_list() -> List[str]:
@@ -240,24 +294,48 @@ def _aiter_csrc_include_dir() -> Path:
     )
 
 
-def ensure_aiter_lib(module_name: str) -> Path:
+def ensure_aiter_lib(module: Union[str, AiterModule]) -> Path:
     """
     Build (once, cached) a symbol-visible AITER module and return the path to the
-    linkable ``lib<module_name>.so`` under FlashInfer's cache.
+    linkable ``lib<name>.so`` under FlashInfer's cache.
 
     Idempotent: if the cached lib already exists it is returned without rebuilding.
     """
+    if isinstance(module, str):
+        module = AiterModule(module)
+    module_name = module.name
+    md_name = module.lib_name
+
     libs_dir = _aiter_libs_dir()
-    lib_path = libs_dir / f"lib{module_name}.so"
+    lib_path = libs_dir / f"lib{md_name}.so"
     if lib_path.exists():
         return lib_path
 
+    # Serialize the build across processes. `pytest -n auto` shares one cache dir,
+    # and a CK module takes minutes -- long enough that concurrent builders writing
+    # into the same AITER build tree is the expected case, not a rare race. The
+    # os.replace below makes *publishing* atomic; this makes producing safe.
+    with FileLock(str(libs_dir / f".{md_name}.build.lock"), thread_local=False):
+        if lib_path.exists():
+            return lib_path
+        return _build_aiter_lib(module_name, md_name, module.blob_gen_cmd, lib_path)
+
+
+def _build_aiter_lib(
+    module_name: str,
+    md_name: str,
+    blob_gen_cmd_override: Optional[Union[str, Tuple[str, ...]]],
+    lib_path: Path,
+) -> Path:
+    libs_dir = lib_path.parent
     # Build into a FlashInfer-owned dir so we never mutate the AITER install.
+    # Deliberately one dir for every module, not one per md_name: AITER_JIT_DIR
+    # is process-global, and a shim now builds two modules per spec. A per-module
+    # value makes concurrent builders overwrite each other's env; a constant one
+    # makes that write benign. AITER already isolates each build under
+    # {bd_dir}/{md_name} anyway.
     aiter_build_dir = libs_dir / "build"
     aiter_build_dir.mkdir(parents=True, exist_ok=True)
-
-    # AITER reads these from the environment at build time.
-    from ..hip_utils import get_rocm_home
 
     prev = {
         "AITER_SYMBOL_VISIBLE": os.environ.get("AITER_SYMBOL_VISIBLE"),
@@ -265,17 +343,23 @@ def ensure_aiter_lib(module_name: str) -> Path:
         "GPU_ARCHS": os.environ.get("GPU_ARCHS"),
         "ROCM_HOME": os.environ.get("ROCM_HOME"),
     }
-    os.environ["AITER_SYMBOL_VISIBLE"] = "1"
-    os.environ["AITER_JIT_DIR"] = str(aiter_build_dir)
-    # AITER splits GPU_ARCHS on ';' and validates each entry, so a comma-joined
-    # list reaches it as one unparseable token. A single architecture sidesteps
-    # the separator entirely -- and is required regardless; see
-    # resolve_aiter_build_arch.
-    os.environ["GPU_ARCHS"] = resolve_aiter_build_arch()
-    os.environ["ROCM_HOME"] = get_rocm_home()
 
     built: Optional[Path] = None
     try:
+        # Inside the try so a failure here still restores the environment: a
+        # leaked AITER_JIT_DIR sends the *next* module's .so hunt to the wrong
+        # directory.
+        from ..hip_utils import get_rocm_home
+
+        os.environ["AITER_SYMBOL_VISIBLE"] = "1"
+        os.environ["AITER_JIT_DIR"] = str(aiter_build_dir)
+        # AITER splits GPU_ARCHS on ';' and validates each entry, so a
+        # comma-joined list reaches it as one unparseable token. A single
+        # architecture sidesteps the separator entirely -- and is required
+        # regardless; see resolve_aiter_build_arch.
+        os.environ["GPU_ARCHS"] = resolve_aiter_build_arch()
+        os.environ["ROCM_HOME"] = get_rocm_home()
+
         from aiter.jit import core as aiter_core
         from aiter.jit.core import build_module, get_args_of_build
 
@@ -288,12 +372,25 @@ def ensure_aiter_lib(module_name: str) -> Path:
         # link with "undefined symbol".
         a = get_args_of_build(module_name)
         flags_extra_hip = list(a["flags_extra_hip"]) + ["-fvisibility=default"]
+        blob_gen_cmd = a["blob_gen_cmd"]
+        if blob_gen_cmd_override is not None:
+            blob_gen_cmd = (
+                blob_gen_cmd_override
+                if isinstance(blob_gen_cmd_override, str)
+                else list(blob_gen_cmd_override)
+            )
+        logger.info(
+            "Building symbol-visible AITER module %s for %s (first use; this can "
+            "take several minutes for CK modules)",
+            md_name,
+            os.environ["GPU_ARCHS"],
+        )
         build_module(
-            md_name=module_name,
+            md_name=md_name,
             srcs=a["srcs"],
             flags_extra_cc=a["flags_extra_cc"],
             flags_extra_hip=flags_extra_hip,
-            blob_gen_cmd=a["blob_gen_cmd"],
+            blob_gen_cmd=blob_gen_cmd,
             extra_include=a["extra_include"],
             extra_ldflags=a["extra_ldflags"],
             verbose=os.environ.get("FLASHINFER_JIT_VERBOSE", "0") == "1",
@@ -309,7 +406,7 @@ def ensure_aiter_lib(module_name: str) -> Path:
         # Resolve the produced file from AITER's own get_user_jit_dir() (which
         # re-reads the env), falling back to a recursive search of our build dir.
         built = _find_built_so(
-            module_name, aiter_build_dir, Path(aiter_core.get_user_jit_dir())
+            md_name, aiter_build_dir, Path(aiter_core.get_user_jit_dir())
         )
     finally:
         for k, v in prev.items():
@@ -320,7 +417,7 @@ def ensure_aiter_lib(module_name: str) -> Path:
 
     if built is None:
         raise RuntimeError(
-            f"AITER build for {module_name!r} did not produce a {module_name}.so. "
+            f"AITER build for {module_name!r} did not produce a {md_name}.so. "
             "Check that aiter is installed and ROCm is available."
         )
     # Copy (not symlink) the artifact into our arch-keyed cache so it survives
@@ -332,9 +429,9 @@ def ensure_aiter_lib(module_name: str) -> Path:
     return lib_path
 
 
-def _find_built_so(module_name: str, *search_dirs: Path) -> Optional[Path]:
-    """Locate the freshly built ``<module_name>.so`` across AITER's output dirs."""
-    name = f"{module_name}.so"
+def _find_built_so(md_name: str, *search_dirs: Path) -> Optional[Path]:
+    """Locate the freshly built ``<md_name>.so`` across AITER's output dirs."""
+    name = f"{md_name}.so"
     for d in search_dirs:
         candidate = d / name
         if candidate.is_file():
@@ -348,19 +445,25 @@ def _find_built_so(module_name: str, *search_dirs: Path) -> Optional[Path]:
 
 
 def aiter_jitspec_flags(
-    module_name: str,
+    *modules: Union[str, AiterModule],
 ) -> Tuple[List[Union[str, Path]], List[str]]:
     """
-    Build the AITER lib if needed and return ``(extra_include_paths, extra_ldflags)``
-    to pass to ``gen_jit_spec`` so the FlashInfer shim can find AITER's header and
-    link the kernel.
+    Build the AITER libs if needed and return ``(extra_include_paths, extra_ldflags)``
+    to pass to ``gen_jit_spec`` so the FlashInfer shim can find AITER's headers and
+    link the kernels.
+
+    Accepts more than one module: a shim that spans two AITER modules (fused MoE
+    calls ``moe_sorting`` and a CK GEMM module) links them all against the one
+    ``-L``/``-rpath`` pair, since every lib lands in the same arch-keyed cache dir.
     """
-    ensure_aiter_lib(module_name)
+    if not modules:
+        raise ValueError("aiter_jitspec_flags needs at least one AITER module")
+    resolved = _as_modules(modules)
+    for module in resolved:
+        ensure_aiter_lib(module)
     libs_dir = _aiter_libs_dir()
     extra_include_paths: List[Union[str, Path]] = [str(_aiter_csrc_include_dir())]
-    extra_ldflags = [
-        f"-L{libs_dir}",
-        f"-l{module_name}",
-        f"-Wl,-rpath,{libs_dir}",
-    ]
+    extra_ldflags = [f"-L{libs_dir}"]
+    extra_ldflags += [f"-l{module.lib_name}" for module in resolved]
+    extra_ldflags.append(f"-Wl,-rpath,{libs_dir}")
     return extra_include_paths, extra_ldflags

--- a/flashinfer/jit/aiter_source.py
+++ b/flashinfer/jit/aiter_source.py
@@ -26,6 +26,7 @@ import functools
 import os
 import re
 import shutil
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Sequence, Tuple, Union
@@ -47,6 +48,9 @@ _ARCH_RE = re.compile(r"^gfx[0-9a-f]+$")
 # in a path separator or a flag-looking prefix. \Z, not $: $ also matches before a
 # trailing newline, which would reach the ninja link line intact.
 _LIB_NAME_RE = re.compile(r"\A[A-Za-z0-9_][A-Za-z0-9_.+-]*\Z")
+
+# Guards the env-mutating build in _build_aiter_lib; see ensure_aiter_lib.
+_BUILD_LOCK = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -311,11 +315,14 @@ def ensure_aiter_lib(module: Union[str, AiterModule]) -> Path:
     if lib_path.exists():
         return lib_path
 
-    # Serialize the build across processes. `pytest -n auto` shares one cache dir,
-    # and a CK module takes minutes -- long enough that concurrent builders writing
-    # into the same AITER build tree is the expected case, not a rare race. The
-    # os.replace below makes *publishing* atomic; this makes producing safe.
-    with FileLock(str(libs_dir / f".{md_name}.build.lock"), thread_local=False):
+    # One lock for every module, not one per module. _build_aiter_lib mutates
+    # process-global env (AITER_JIT_DIR, GPU_ARCHS, ROCM_HOME) and restores a
+    # snapshot taken on entry, so two builds of *different* modules in one process
+    # interleave: the first to finish rolls the environment back under the one
+    # still running. The thread lock covers that; the file lock covers `pytest
+    # -n auto`, which shares a cache dir across processes. os.replace below makes
+    # publishing atomic; these make producing safe.
+    with _BUILD_LOCK, FileLock(str(libs_dir / ".aiter-build.lock"), thread_local=False):
         if lib_path.exists():
             return lib_path
         return _build_aiter_lib(module_name, md_name, module.blob_gen_cmd, lib_path)

--- a/flashinfer/jit/fused_moe_rocm.py
+++ b/flashinfer/jit/fused_moe_rocm.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""JIT spec for the AITER-backed fused MoE shim (ROCm).
+
+Separate from ``flashinfer/jit/fused_moe.py``, which is the upstream CUTLASS /
+TRT-LLM generator and is not touched by the ROCm port.
+"""
+
+import torch
+
+from . import env as jit_env
+from .aiter_source import AiterModule, aiter_jitspec_flags, refresh_aiter_jitspec
+from .core import JitSpec, gen_jit_spec
+
+# AITER's `dtype2str_dict` (aiter/ops/moe_op.py) spellings, for the codegen flags.
+# The keys double as the supported-dtype set; flashinfer/fused_moe_rocm.py
+# validates against SUPPORTED_DTYPES rather than keeping its own copy.
+_DTYPE_TAG = {
+    torch.bfloat16: "b16",
+    torch.float16: "f16",
+}
+SUPPORTED_DTYPES = tuple(_DTYPE_TAG)
+
+_SUPPORTED_ACTIVATIONS = frozenset({"silu", "gelu"})
+
+# CK's routing-weight stage. 2 = apply topk weights in stage 2, which is what the
+# shim does; the generated instances must agree or the lookup misses.
+_MUL_WEIGHT_STAGE = 2
+
+
+def _ck2stages_module(dtype: torch.dtype, activation: str) -> AiterModule:
+    """A ``module_moe_ck2stages`` specialized to one dtype/activation.
+
+    Mirrors AITER's own ``get_moe_stage_module`` rather than importing it, so a
+    rename there surfaces as a build error instead of a silent change.
+    """
+    # Imported lazily: this module is importable without aiter installed, and
+    # only a real build needs the path.
+    from aiter.jit.core import AITER_CSRC_DIR
+
+    a = b = c = _DTYPE_TAG[dtype]
+    act = activation
+    quant = "no"
+    md_name = "_".join(
+        [
+            "module_moe_ck2stages",
+            a,
+            b,
+            "preshuffle_off",
+            c,
+            act,
+            quant,
+            f"mulWeightStage{_MUL_WEIGHT_STAGE}",
+        ]
+    )
+    # build_module runs `blob_gen_cmd.format(blob_dir)`, so the string must carry
+    # exactly one `{}` and no other braces.
+    blob_gen_cmd = (
+        f"{AITER_CSRC_DIR}/ck_gemm_moe_2stages_codegen/gen_instances.py "
+        f"-a {a} -b {b} -c {c} -q {quant} -act {act} "
+        f"-m {_MUL_WEIGHT_STAGE} --working_path {{}}"
+    )
+    return AiterModule(
+        "module_moe_ck2stages", md_name=md_name, blob_gen_cmd=blob_gen_cmd
+    )
+
+
+def gen_fused_moe_aiter_module(dtype: torch.dtype, activation: str) -> JitSpec:
+    """Build the fused-MoE shim for one dtype/activation pair."""
+    if dtype not in _DTYPE_TAG:
+        # torch.dtype is not orderable, so list in declaration order.
+        raise ValueError(f"fused MoE (aiter) supports {list(_DTYPE_TAG)}, got {dtype}")
+    if activation not in _SUPPORTED_ACTIVATIONS:
+        raise ValueError(
+            f"fused MoE (aiter) supports activations "
+            f"{sorted(_SUPPORTED_ACTIVATIONS)}, got {activation!r}"
+        )
+
+    extra_include_paths, extra_ldflags = aiter_jitspec_flags(
+        AiterModule("module_moe_sorting"),
+        _ck2stages_module(dtype, activation),
+    )
+    return refresh_aiter_jitspec(
+        gen_jit_spec(
+            f"fused_moe_aiter_{_DTYPE_TAG[dtype]}_{activation}",
+            [
+                jit_env.FLASHINFER_CSRC_DIR / "fused_moe_aiter.cu",
+                jit_env.FLASHINFER_CSRC_DIR / "fused_moe_aiter_jit_pybind.cu",
+            ],
+            extra_include_paths=extra_include_paths,
+            extra_ldflags=extra_ldflags,
+        )
+    )

--- a/tests/rocm_tests/test_aiter_module_spec_hip.py
+++ b/tests/rocm_tests/test_aiter_module_spec_hip.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :class:`AiterModule` and the fused-MoE JIT spec's use of it.
+
+No GPU and no build: these cover the naming and flag construction that decide
+*which* lib a shim links. The ``_ck2stages_module`` tests still need ``aiter``
+importable, because the codegen command embeds AITER's own csrc path.
+
+What is being protected. Two specializations of ``module_moe_ck2stages`` (bf16
+vs fp16, silu vs gelu) are separate builds of the same AITER source tree. They
+are distinguished only by ``md_name``, which names the cached ``lib*.so``. If
+they collided on one filename the second build would be skipped and the first
+lib silently reused -- a wrong-dtype or wrong-activation kernel, with correct
+shapes and no error.
+"""
+
+import importlib.util
+
+import pytest
+import torch
+
+from flashinfer.jit.aiter_source import AiterModule, aiter_jitspec_flags
+from flashinfer.jit.fused_moe_rocm import _ck2stages_module
+
+# _ck2stages_module reads aiter.jit.core.AITER_CSRC_DIR. A ROCm box without the
+# aiter package is a supported state, so skip rather than error there.
+requires_aiter_import = pytest.mark.skipif(
+    importlib.util.find_spec("aiter") is None, reason="needs the aiter package"
+)
+
+
+def test_lib_name_defaults_to_the_config_key():
+    assert AiterModule("module_moe_sorting").lib_name == "module_moe_sorting"
+
+
+def test_md_name_overrides_the_lib_name():
+    m = AiterModule("module_moe_ck2stages", md_name="module_moe_ck2stages_b16_silu")
+    assert m.lib_name == "module_moe_ck2stages_b16_silu"
+
+
+@pytest.mark.parametrize(
+    "bad", ["", "../escape", "-levil", "has/slash", ".hidden", "trailing\n"]
+)
+def test_unusable_lib_names_are_rejected(bad):
+    """An empty md_name is rejected, not treated as "unset".
+
+    Falling back to the unspecialized name would put two specializations on one
+    ``lib*.so`` -- the second build skipped, the first silently reused.
+    """
+    with pytest.raises(ValueError, match="not usable as a library name"):
+        AiterModule("module_moe_ck2stages", md_name=bad)
+    with pytest.raises(ValueError, match="not usable as a library name"):
+        AiterModule(bad)
+
+
+@requires_aiter_import
+def test_specializations_do_not_collide():
+    """Every (dtype, activation) must map to a distinct cached lib."""
+    combos = [
+        (dt, act) for dt in (torch.bfloat16, torch.float16) for act in ("silu", "gelu")
+    ]
+    names = [_ck2stages_module(dt, act).lib_name for dt, act in combos]
+    assert len(set(names)) == len(combos), names
+    assert all(n != "module_moe_ck2stages" for n in names), names
+
+
+@requires_aiter_import
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("activation", ["silu", "gelu"])
+def test_blob_gen_cmd_is_format_safe(dtype, activation):
+    """AITER runs ``blob_gen_cmd.format(blob_dir)``: exactly one ``{}``, no others."""
+    cmd = _ck2stages_module(dtype, activation).blob_gen_cmd
+    assert cmd.count("{") == 1 and cmd.count("}") == 1
+    assert cmd.format("/tmp/blobs").endswith("--working_path /tmp/blobs")
+
+
+@requires_aiter_import
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("activation", ["silu", "gelu"])
+def test_codegen_flags_match_the_shim(dtype, activation):
+    """The generated instances must match what the C++ shim asks CK for.
+
+    ``-m 2`` because the shim passes sorted_weights to stage 2, ``-q no`` because
+    it passes QuantType::No, and the dtype tags because there is one build per
+    dtype. A mismatch is a lookup miss at runtime, not a build failure.
+    """
+    tag = {torch.bfloat16: "b16", torch.float16: "f16"}[dtype]
+    cmd = _ck2stages_module(dtype, activation).blob_gen_cmd
+    for flag in (
+        f"-a {tag}",
+        f"-b {tag}",
+        f"-c {tag}",
+        "-q no",
+        f"-act {activation}",
+        "-m 2",
+    ):
+        assert flag in cmd, f"{flag!r} missing from {cmd!r}"
+
+
+def test_flags_link_every_module_once(monkeypatch):
+    import flashinfer.jit.aiter_source as src
+
+    built = []
+    monkeypatch.setattr(src, "ensure_aiter_lib", lambda m: built.append(m.lib_name))
+    monkeypatch.setattr(src, "_aiter_csrc_include_dir", lambda: "/fake/csrc/include")
+    monkeypatch.setattr(src, "_aiter_libs_dir", lambda: "/fake/libs")
+
+    _, ldflags = aiter_jitspec_flags(
+        "module_moe_sorting", AiterModule("module_moe_ck2stages", md_name="spec_a")
+    )
+
+    assert built == ["module_moe_sorting", "spec_a"]
+    assert ldflags.count("-L/fake/libs") == 1
+    assert [f for f in ldflags if f.startswith("-l")] == [
+        "-lmodule_moe_sorting",
+        "-lspec_a",
+    ]
+    # rpath must come along, or the module loads whatever the loader finds first.
+    assert "-Wl,-rpath,/fake/libs" in ldflags
+
+
+def test_flags_needs_at_least_one_module():
+    with pytest.raises(ValueError, match="at least one AITER module"):
+        aiter_jitspec_flags()

--- a/tests/rocm_tests/test_aiter_module_spec_hip.py
+++ b/tests/rocm_tests/test_aiter_module_spec_hip.py
@@ -16,18 +16,19 @@ lib silently reused -- a wrong-dtype or wrong-activation kernel, with correct
 shapes and no error.
 """
 
-import importlib.util
-
 import pytest
 import torch
 
+from flashinfer.aiter_utils import _aiter_importable
 from flashinfer.jit.aiter_source import AiterModule, aiter_jitspec_flags
 from flashinfer.jit.fused_moe_rocm import _ck2stages_module
 
 # _ck2stages_module reads aiter.jit.core.AITER_CSRC_DIR. A ROCm box without the
 # aiter package is a supported state, so skip rather than error there.
+# _aiter_importable actually imports aiter, aiter_meta and aiter.jit.core, so a
+# half-installed aiter -- which find_spec reports as present -- skips too.
 requires_aiter_import = pytest.mark.skipif(
-    importlib.util.find_spec("aiter") is None, reason="needs the aiter package"
+    not _aiter_importable(), reason="needs a working aiter install"
 )
 
 

--- a/tests/rocm_tests/test_fused_moe_aiter_hip.py
+++ b/tests/rocm_tests/test_fused_moe_aiter_hip.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Tests for flashinfer.fused_moe, the AITER CK two-stage MoE backend on ROCm.
+# Tests for flashinfer.aiter_fused_moe, the AITER CK two-stage MoE backend on ROCm.
 #
 # Note on tolerances: the reference accumulates in float32 while the kernel
 # accumulates a K-long and then an inter_dim-long dot product in bf16/fp16
@@ -235,6 +235,17 @@ def test_fused_moe_rejects_bad_arguments(kwargs, cast, match):
         (lambda t: {"w2": t["w2"][:, :, : t["w2"].shape[2] // 2]}, "expected w1"),
         (lambda t: {"w1": t["w1"][:-1]}, "experts"),
         (lambda t: {"x": t["x"].unsqueeze(0)}, "must be 2-D"),
+        # topk=0 divides by zero inside AITER: without this check the process
+        # dies on SIGFPE, which no caller can catch. The upper bound below is
+        # the other half of the same range check.
+        (
+            lambda t: {
+                "ids": t["ids"][:, :0].contiguous(),
+                "weights": t["weights"][:, :0].contiguous(),
+            },
+            "topk must be at least 1",
+        ),
+        (lambda t: {"w1": t["w1"][:1], "w2": t["w2"][:1]}, "exceeds num_experts"),
     ],
 )
 def test_fused_moe_rejects_bad_tensors(mutate, match):

--- a/tests/rocm_tests/test_fused_moe_aiter_hip.py
+++ b/tests/rocm_tests/test_fused_moe_aiter_hip.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for flashinfer.fused_moe, the AITER CK two-stage MoE backend on ROCm.
+#
+# Note on tolerances: the reference accumulates in float32 while the kernel
+# accumulates a K-long and then an inter_dim-long dot product in bf16/fp16
+# operands. Relative error against the fp32 reference is ~4e-3 for bf16 and
+# ~1e-3 for fp16 across the shapes below; the 2e-2 bound leaves headroom without
+# being loose enough to hide a wrong kernel (unshuffled weights, the failure this
+# suite exists to catch, land at ~1.3).
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer.fused_moe_rocm import shuffle_moe_weight
+from tests.test_helpers.test_helpers import requires_aiter
+
+_ACT = {"silu": torch.nn.functional.silu, "gelu": torch.nn.functional.gelu}
+
+
+def _moe_ref(x, w1, w2, topk_ids, topk_weights, activation):
+    """Float32 reference: gather per expert, gated MLP, routing-weighted sum."""
+    act = _ACT[activation]
+    xf = x.float()
+    acc = torch.zeros(x.shape[0], x.shape[1], dtype=torch.float32, device=x.device)
+    for e in range(w1.shape[0]):
+        mask = topk_ids == e
+        rows = mask.any(dim=-1).nonzero(as_tuple=True)[0]
+        if rows.numel() == 0:
+            continue
+        gate, up = (xf[rows] @ w1[e].float().t()).chunk(2, dim=-1)
+        down = (act(gate) * up) @ w2[e].float().t()
+        acc.index_add_(
+            0, rows, down * (topk_weights * mask).sum(-1)[rows].unsqueeze(-1)
+        )
+    return acc
+
+
+def _make_case(M, E, K, I, topk, dtype, device, seed=0xA17E3):
+    torch.manual_seed(seed)
+    x = torch.randn(M, K, dtype=dtype, device=device) / 8
+    w1 = torch.randn(E, 2 * I, K, dtype=dtype, device=device) / 16
+    w2 = torch.randn(E, K, I, dtype=dtype, device=device) / 16
+    logits = torch.randn(M, E, dtype=torch.float32, device=device)
+    topk_weights, topk_ids = torch.topk(torch.softmax(logits, dim=-1), topk, dim=-1)
+    return x, w1, w2, topk_ids.to(torch.int32).contiguous(), topk_weights.contiguous()
+
+
+def _rel_err(got, ref):
+    return (got.float() - ref).abs().max().item() / max(ref.abs().max().item(), 1e-9)
+
+
+@requires_aiter
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "M,E,K,I,topk",
+    [
+        (1, 8, 512, 256, 2),  # single token: below block_m, exercises sort padding
+        (7, 8, 512, 256, 2),  # non-power-of-two, below block_m
+        (64, 8, 512, 256, 1),  # topk=1
+        (256, 32, 1024, 512, 6),
+        (1024, 8, 4096, 1408, 2),  # a real MoE layer shape
+    ],
+)
+def test_fused_moe_vs_ref(dtype, M, E, K, I, topk):
+    device = torch.device("cuda:0")
+    x, w1, w2, ids, weights = _make_case(M, E, K, I, topk, dtype, device)
+
+    got = flashinfer.aiter_fused_moe(
+        x, shuffle_moe_weight(w1), shuffle_moe_weight(w2), ids, weights
+    )
+
+    assert got.shape == (M, K) and got.dtype == dtype
+    assert torch.isfinite(got).all()
+    assert _rel_err(got, _moe_ref(x, w1, w2, ids, weights, "silu")) < 2e-2
+
+
+@requires_aiter
+@pytest.mark.parametrize("activation", ["silu", "gelu"])
+@pytest.mark.parametrize("block_m", [32, 64, 128])
+def test_fused_moe_activation_and_block_m(activation, block_m):
+    device = torch.device("cuda:0")
+    x, w1, w2, ids, weights = _make_case(128, 8, 512, 256, 2, torch.bfloat16, device)
+
+    got = flashinfer.aiter_fused_moe(
+        x,
+        shuffle_moe_weight(w1),
+        shuffle_moe_weight(w2),
+        ids,
+        weights,
+        activation=activation,
+        block_m=block_m,
+    )
+
+    assert _rel_err(got, _moe_ref(x, w1, w2, ids, weights, activation)) < 2e-2
+
+
+@requires_aiter
+def test_fused_moe_all_tokens_to_one_expert():
+    """Degenerate routing: one expert takes everything, the rest take nothing."""
+    device = torch.device("cuda:0")
+    M, E, K, I = 64, 8, 512, 256
+    x, w1, w2, _, _ = _make_case(M, E, K, I, 1, torch.bfloat16, device)
+    ids = torch.full((M, 1), 3, dtype=torch.int32, device=device)
+    weights = torch.ones(M, 1, dtype=torch.float32, device=device)
+
+    got = flashinfer.aiter_fused_moe(
+        x, shuffle_moe_weight(w1), shuffle_moe_weight(w2), ids, weights
+    )
+
+    assert _rel_err(got, _moe_ref(x, w1, w2, ids, weights, "silu")) < 2e-2
+
+
+@requires_aiter
+def test_fused_moe_writes_into_provided_out():
+    device = torch.device("cuda:0")
+    x, w1, w2, ids, weights = _make_case(64, 8, 512, 256, 2, torch.bfloat16, device)
+    out = torch.full((64, 512), 7.0, dtype=torch.bfloat16, device=device)
+
+    got = flashinfer.aiter_fused_moe(
+        x, shuffle_moe_weight(w1), shuffle_moe_weight(w2), ids, weights, out=out
+    )
+
+    assert got.data_ptr() == out.data_ptr()
+    # Overwritten, not accumulated into: the 7.0 fill must be gone.
+    assert _rel_err(out, _moe_ref(x, w1, w2, ids, weights, "silu")) < 2e-2
+
+
+@requires_aiter
+@pytest.mark.parametrize("alias", ["exact", "view", "w1"])
+def test_fused_moe_rejects_out_overlapping_an_input(alias):
+    """out is zero-filled before the activations are read.
+
+    Aliasing an input therefore feeds stage 1 zeros and returns an all-zero
+    result -- correct shape, correct dtype, no error. Measured before the guard:
+    100% of output elements zero.
+    """
+    device = torch.device("cuda:0")
+    x, w1, w2, ids, weights = _make_case(64, 8, 512, 256, 2, torch.bfloat16, device)
+    w1s, w2s = shuffle_moe_weight(w1), shuffle_moe_weight(w2)
+    out = {"exact": x, "view": x[:, :], "w1": w1s.view(-1)[: 64 * 512].view(64, 512)}[
+        alias
+    ]
+
+    with pytest.raises(RuntimeError, match="must not overlap"):
+        flashinfer.aiter_fused_moe(x, w1s, w2s, ids, weights, out=out)
+
+
+@requires_aiter
+def test_fused_moe_rejects_tensors_on_another_device():
+    if torch.cuda.device_count() < 2:
+        pytest.skip("needs two GPUs")
+    x, w1, w2, ids, weights = _make_case(
+        64, 8, 512, 256, 2, torch.bfloat16, torch.device("cuda:0")
+    )
+    out = torch.empty(64, 512, dtype=torch.bfloat16, device="cuda:1")
+
+    with pytest.raises(RuntimeError, match="every tensor must be on"):
+        flashinfer.aiter_fused_moe(
+            x, shuffle_moe_weight(w1), shuffle_moe_weight(w2), ids, weights, out=out
+        )
+
+
+@requires_aiter
+def test_unshuffled_weights_are_wrong():
+    """Pin the reason shuffle_moe_weight exists.
+
+    The shuffle preserves shape and dtype, so no layer can detect its absence.
+    If a future AITER stops requiring it this test fails loudly, which is the
+    point -- the API contract would then be wrong.
+    """
+    device = torch.device("cuda:0")
+    x, w1, w2, ids, weights = _make_case(64, 8, 512, 256, 2, torch.bfloat16, device)
+
+    got = flashinfer.aiter_fused_moe(x, w1, w2, ids, weights)
+
+    assert _rel_err(got, _moe_ref(x, w1, w2, ids, weights, "silu")) > 0.5
+
+
+@requires_aiter
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_shuffle_moe_weight_is_a_permutation(dtype):
+    """Shape and dtype are preserved and no element is lost."""
+    device = torch.device("cuda:0")
+    w = torch.randn(4, 128, 256, dtype=dtype, device=device)
+
+    s = shuffle_moe_weight(w)
+
+    assert s.shape == w.shape and s.dtype == w.dtype and s.is_contiguous()
+    assert torch.equal(s.flatten().sort().values, w.flatten().sort().values)
+
+
+def test_shuffle_moe_weight_rejects_bad_shapes():
+    """Pure tensor-metadata checks: no GPU and no aiter needed."""
+    with pytest.raises(ValueError, match="3-D"):
+        shuffle_moe_weight(torch.zeros(128, 256, dtype=torch.bfloat16))
+    with pytest.raises(ValueError, match="divisible"):
+        shuffle_moe_weight(torch.zeros(2, 120, 256, dtype=torch.bfloat16))
+    with pytest.raises(ValueError, match="divisible"):
+        shuffle_moe_weight(torch.zeros(2, 128, 250, dtype=torch.bfloat16))
+
+
+@requires_aiter
+@pytest.mark.parametrize(
+    "kwargs,cast,match",
+    [
+        ({"activation": "relu"}, None, "activation must be one of"),
+        ({"block_m": 48}, None, "block_m must be one of"),
+        # Rejected in Python, before _get_module: one module is built per dtype,
+        # so an unsupported dtype would otherwise trigger a multi-minute compile
+        # only to fail afterwards.
+        ({}, torch.float32, "hidden_states must be one of"),
+    ],
+)
+def test_fused_moe_rejects_bad_arguments(kwargs, cast, match):
+    device = torch.device("cuda:0")
+    x, w1, w2, ids, weights = _make_case(8, 8, 512, 256, 2, torch.bfloat16, device)
+    if cast is not None:
+        x = x.to(cast)
+    with pytest.raises(ValueError, match=match):
+        flashinfer.aiter_fused_moe(
+            x, shuffle_moe_weight(w1), shuffle_moe_weight(w2), ids, weights, **kwargs
+        )
+
+
+@requires_aiter
+@pytest.mark.parametrize(
+    "mutate,match",
+    [
+        (lambda t: {"w1": t["w1"].float()}, "w1/w2 dtype must match"),
+        (lambda t: {"ids": t["ids"].to(torch.int64)}, "topk_ids must be int32"),
+        (lambda t: {"weights": t["weights"].to(torch.bfloat16)}, "must be float32"),
+        (lambda t: {"w2": t["w2"][:, :, : t["w2"].shape[2] // 2]}, "expected w1"),
+        (lambda t: {"w1": t["w1"][:-1]}, "experts"),
+        (lambda t: {"x": t["x"].unsqueeze(0)}, "must be 2-D"),
+    ],
+)
+def test_fused_moe_rejects_bad_tensors(mutate, match):
+    """Each bad input must raise a readable error, not abort inside CK."""
+    device = torch.device("cuda:0")
+    x, w1, w2, ids, weights = _make_case(64, 8, 512, 256, 2, torch.bfloat16, device)
+    t = {
+        "x": x,
+        "w1": shuffle_moe_weight(w1),
+        "w2": shuffle_moe_weight(w2),
+        "ids": ids,
+        "weights": weights,
+    }
+    t.update(mutate(t))
+    with pytest.raises(RuntimeError, match=match):
+        flashinfer.aiter_fused_moe(t["x"], t["w1"], t["w2"], t["ids"], t["weights"])

--- a/tests/test_helpers/test_helpers.py
+++ b/tests/test_helpers/test_helpers.py
@@ -1,9 +1,8 @@
 import torch
 import functools
-import importlib.util
 import os
 from flashinfer.utils import GPUArchitectureError
-from flashinfer.aiter_utils import is_aiter_supported
+from flashinfer.aiter_utils import _aiter_importable, is_aiter_supported
 import pytest
 import gc
 
@@ -11,10 +10,7 @@ import gc
 # is_aiter_supported only checks the GPU arch; AITER is a separate source install,
 # so a supported board can still lack the package. Require both so AITER tests skip
 # (rather than error/fail) when the arch matches but aiter isn't importable.
-_aiter_available = (
-    is_aiter_supported(torch.device("cuda:0"))
-    and importlib.util.find_spec("aiter") is not None
-)
+_aiter_available = is_aiter_supported(torch.device("cuda:0")) and _aiter_importable()
 requires_aiter = pytest.mark.skipif(
     not _aiter_available,
     reason="AITER backend requires gfx942/gfx950 and the aiter package",


### PR DESCRIPTION
## Summary

MoE was the largest remaining gap in the ROCm port: `flashinfer/fused_moe/` is CUTLASS/TRT-LLM and imported only under `IS_CUDA`, so every MoE model (DeepSeek-V3, Mixtral, Qwen-MoE, Llama-4) fell back to the framework's own kernels. This wires AITER's CK two-stage fused MoE in at the C++ level, the same way rmsnorm/rope/activation are wired — a `csrc_rocm/*_aiter.cu` shim calling AITER's C++ entry points against a symbol-visible rebuild, with no `import aiter` at runtime.

Scope is unquantized bf16/fp16, silu or gelu, with caller-supplied routing. Measured on both gfx942 and gfx950. The quantized paths, AITER's routing ops, and expert parallelism are follow-ups.

```python
from flashinfer import aiter_fused_moe, shuffle_moe_weight

w1s = shuffle_moe_weight(w1)   # [E, 2*inter_dim, model_dim], once at model load
w2s = shuffle_moe_weight(w2)   # [E, model_dim, inter_dim]

out = aiter_fused_moe(hidden_states, w1s, w2s, topk_ids, topk_weights)
```

### What changed

- **`flashinfer/csrc_rocm/fused_moe_aiter.cu`** — new shim running `moe_sorting_fwd` → `ck_moe_stage1` → `ck_moe_stage2`. Forward-declares the three entry points at global namespace (unlike `activation.h`'s `namespace aiter` — the mangled name differs). Validates dtype, shape, device, contiguity, `topk` range, and `out`-vs-input aliasing, so failures name the argument rather than surfacing from inside CK.
- **`flashinfer/csrc_rocm/fused_moe_aiter_jit_pybind.cu`** — `TORCH_LIBRARY_FRAGMENT` registration, following the `norm_aiter` pattern.
- **`flashinfer/jit/fused_moe_rocm.py`** — new; builds the shim per `(dtype, activation)` and mirrors AITER's `get_moe_stage_module` to request one specialized `module_moe_ck2stages` instead of the 280 MB default. Upstream `flashinfer/jit/fused_moe.py` is untouched.
- **`flashinfer/jit/aiter_source.py`** — `AiterModule` carries `(name, md_name, blob_gen_cmd)`; `aiter_jitspec_flags` takes varargs so one shim can link several AITER modules. `md_name` also names the cached `lib*.so`, which is load-bearing — see below. Builds are serialized process-wide because the AITER build reads process-global env.
- **`flashinfer/fused_moe_rocm.py`** — new public API: `aiter_fused_moe` and `shuffle_moe_weight`. Routing is caller-supplied, like upstream's `cutlass_fused_moe`.
- **`flashinfer/arch_caps.py`** — `Capability("fused_moe", "aiter", ...)` for both archs, each with its own measured evidence string. No fallback: there is no native HIP MoE kernel.
- **`flashinfer/__init__.py`** — exports both names on HIP.
- **`tests/test_helpers/test_helpers.py`** — `requires_aiter` now uses `aiter_utils._aiter_importable()` rather than `find_spec("aiter")`, which reports a half-installed aiter as present and turns an intended skip into a collection error.
- **`tests/rocm_tests/test_fused_moe_aiter_hip.py`**, **`tests/rocm_tests/test_aiter_module_spec_hip.py`** — correctness/guard suite, and GPU-free module-naming and codegen-flag checks.
- **`benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py`** — Mixtral-8x7B and Qwen3-235B shapes across 1–2048 tokens.

### Architecture / design notes

**Linking is the only route to AITER's MoE.** `nm -D` on `module_moe_{asm,ck2stages,sorting,topk}.so` exports only `PyInit_*`; every entry point is `-fvisibility=hidden`, and there is no `extern "C"` symbol and no `TORCH_LIBRARY` registration, so neither `dlsym` nor the PyTorch dispatcher reaches them. The existing `ensure_aiter_lib()` symbol-visible rebuild is the only clean path.

**The CK GEMM module must be specialized, and its cache key must include the specialization.** `module_moe_ck2stages` defaults to every dtype × activation × quant — 944 gemm1 instances, 280 MB. AITER does not build it that way at runtime either. The specialized bf16/silu build takes 438 s, against a default build that did not finish in usable time. Because two specializations differ only by `md_name`, that name also names the cached `lib*.so`: collide them and the second build is skipped and the first lib silently reused, which is a wrong-dtype kernel with correct shapes and no error. `lib_name` therefore tests `md_name is None` rather than falsiness, so an empty name is rejected instead of collapsing back to the unspecialized one.

**Weights must be pre-shuffled, and nothing can detect that they are not.** `moe_ck.h` only hints at it in a comment, and AITER's own `torch_moe` reference takes *unshuffled* weights — so comparing the two looks like a kernel miscompile, which is the trap. Measured on gfx950 / ROCm 7.2 / aiter 0.1.10:

| | relative error |
|---|---|
| `ck_moe_stage1`, unshuffled | 1.441296 |
| `ck_moe_stage1`, shuffled | 0.000001 |
| `aiter.fused_moe`, unshuffled | 1.260791 |
| `aiter.fused_moe`, shuffled | 0.003597 |

The shuffle preserves shape *and* dtype, so unshuffled weights are silently wrong rather than an error. `shuffle_moe_weight` is a pure-torch port (no aiter import) and the parameters are named `w1_shuffled`/`w2_shuffled`: the contract goes in the signature because it cannot go in a check. AITER tags its own output with a Python `is_shuffled` attribute, which does not survive into C++.

**`out` may not overlap an input.** It doubles as `moe_sorting_fwd`'s zero-filled accumulation buffer, so it is cleared before stage 1 reads the activations. `out=hidden_states` — which the signature invites, both being `[num_tokens, model_dim]` of the same dtype — fed stage 1 zeros and returned an all-zero tensor with correct shape and dtype and no error. Now rejected by byte-range overlap check.

**`topk=0` was a process kill, not a wrong answer.** AITER divides by `topk`, so a `[M, 0]` `topk_ids` raised SIGFPE and took the interpreter down uncatchably. Both range bounds are now checked and tested. The two checks are kept separate deliberately: merged into one, an over-`num_experts` failure reported "topk=0 divides by zero", a claim about a value the caller did not pass.

**`topk_ids` *values* are a caller precondition, not a check.** A `-1` drop marker, or a global id against a local expert-parallel shard, indexes `w1`/`w2` out of bounds — but validating on device costs a synchronize per call. Documented on the public API and in the shim header; expert parallelism is out of scope here, and AITER's `local_expert_mask` is passed as `nullopt`.

**The AITER build dir is shared across modules, not keyed by `md_name`.** `AITER_JIT_DIR` is process-global and a shim now builds two modules per spec, so a per-module value lets concurrent builders overwrite each other's environment. A constant value makes that write benign, and AITER already isolates each build under `{bd_dir}/{md_name}`. The env mutation and restore are additionally serialized under one process-wide lock, since the restore is a snapshot that a second builder would otherwise roll back mid-flight.

**Kernel selection uses AITER's heuristic dispatch, not `tuned_fmoe.csv`.** An empty `kernelName` falls through to `moe_stage{1,2}_heuristic_dispatch`. The tuned CSV is keyed on `cu_num` among 13 columns, so shipped rows miss a non-matching part and degrade to that same heuristic — with a `pandas` dependency and a CSV parser bought for nothing. The benchmark exists to measure the gap before that complexity is added.

**Exported as `aiter_fused_moe`, not `fused_moe`.** `flashinfer/fused_moe/` is a shipped subpackage that `flashinfer/gemm/gemm_base.py` imports from, so binding a function to that attribute is undone the moment anything triggers the subpackage import — CPython `setattr`s the module over it and every later call raises `'module' object is not callable`. The backend prefix also matches upstream's `cutlass_fused_moe` / `trtllm_*_moe` naming.

## Test plan

- [x] `pytest tests/rocm_tests/test_fused_moe_aiter_hip.py tests/rocm_tests/test_aiter_module_spec_hip.py` — MI300X (gfx942) and MI350X (gfx950), ROCm 7.2.0 / aiter 0.1.10 / torch 2.9.1.
- [x] Correctness across dtype × activation × shape, including `M=1` and `M=7` (below `block_m`, where the sorting-padding math is) and a 1024×4096×1408 layer shape: bf16 ≤ 8.3e-3, fp16 ≤ 1.1e-3 relative to an fp32 reference, against a 2e-2 bound. The bound sits well below the ~1.3 that unshuffled weights produce, so a looser tolerance could not hide the bug the suite exists to catch.
- [x] Cross-checked bit-exact against `aiter.fused_moe` on identical inputs, to rule out a shared-reference blind spot.
- [x] `pytest tests/rocm_tests/test_{rmsnorm,rope,activation}_aiter_hip.py test_append_paged_kv_cache_aiter_hip.py test_mla_aiter_hip.py test_aiter_{jitspec_refresh,build_arch}_hip.py test_arch_caps_hip.py` — covers the `aiter_source.py` refactor and the capability table.
- [x] A/B'd the new guards: with the overlap check removed, all three aliasing cases report `DID NOT RAISE`; `topk=0` reproduced as SIGFPE before the fix.
- [x] `pre-commit run -a`

Not run: `benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py`. It is added here but its two numbers — the heuristic-vs-tuned-CSV gap and the per-call sorting-buffer allocation cost — are follow-up work, not gating for correctness.
