### PR TITLE
perf(rocm): measure and tune MLA on CDNA4 (gfx950)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Measured on:
 * `gfx942` — fused_moe: MI300X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-24
 * `gfx950` — MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-19
 * `gfx950` — fused_moe: MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-24
+* `gfx950` — mla: MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-24 (decode + prefill, heads 16/128)
 
 <!-- END GENERATED: arch support matrix -->
 

--- a/benchmarks/rocm_benchmarks/bench_mla_hip.py
+++ b/benchmarks/rocm_benchmarks/bench_mla_hip.py
@@ -116,10 +116,9 @@ _counters = _bench_args.counters
 _auto_label = "mla" if _counters == "roofline" else f"mla_{_counters}"
 if _bench_args.mode != "all":
     _auto_label += f"_{_bench_args.mode}"
-# Only non-default sweeps are encoded, so the invocations in the docstring keep
-# the filenames the CDNA3 numbers were published under.
-if _bench_args.heads != _bench_parser.get_default("heads"):
-    _auto_label += f"_h{_bench_args.heads.replace(',', '-')}"
+# Only a non-default --batches is encoded. --heads deliberately is not: it
+# predates this flag, so suffixing it would orphan already-published CSVs from
+# --replot.
 if _bench_args.batches != _bench_parser.get_default("batches"):
     _auto_label += f"_b{_bench_args.batches.replace(',', '-')}"
 if _bench_args.separate:
@@ -134,7 +133,25 @@ _HEAD_DIM_KPE = 64  # qk_rope_head_dim
 _QK_HEAD_DIM = _HEAD_DIM_CKV + _HEAD_DIM_KPE  # 576
 _DTYPE = torch.bfloat16
 _PAGE_SIZE = 1  # what vLLM's AITER MLA backend requires
-_BATCHES = [int(b) for b in _bench_args.batches.split(",") if b.strip()]
+
+
+def _positive_ints(raw: str, flag: str) -> list:
+    """Parse a comma-separated sweep list, failing through argparse.
+
+    Unvalidated, a bad value surfaces far from its cause: batch 0 divides by
+    zero in the roofline only after the GPU work is done, and an empty list
+    reports as "no configs", which is what a missing GPU also looks like.
+    """
+    try:
+        values = [int(v) for v in raw.split(",") if v.strip()]
+    except ValueError:
+        _bench_parser.error(f"{flag}: expected comma-separated integers, got {raw!r}")
+    if not values or any(v < 1 for v in values):
+        _bench_parser.error(f"{flag}: values must be >= 1, got {raw!r}")
+    return values
+
+
+_BATCHES = _positive_ints(_bench_args.batches, "--batches")
 _KV_LENS = [1024, 8192, 32768]
 
 # --mode pool: fixed (small) active set, growing page pool. Not in --mode all
@@ -217,7 +234,7 @@ def _make_attn_config(batch, kv_len, num_heads):
         _HEAD_DIM_CKV,
         _HEAD_DIM_KPE,
         _PAGE_SIZE,
-        False,  # causal — ignored by the ROCm wrapper, passed for API parity
+        False,  # causal — moot at q_len=1; plan() rejects False above it
         1.0 / (_QK_HEAD_DIM**0.5),
         _DTYPE,
         _DTYPE,

--- a/benchmarks/rocm_benchmarks/bench_mla_hip.py
+++ b/benchmarks/rocm_benchmarks/bench_mla_hip.py
@@ -36,6 +36,7 @@ Run:
     python benchmarks/rocm_benchmarks/bench_mla_hip.py --timing-only --separate
     python benchmarks/rocm_benchmarks/bench_mla_hip.py --mode pool --timing-only
     python benchmarks/rocm_benchmarks/bench_mla_hip.py --heads 16,128
+    python benchmarks/rocm_benchmarks/bench_mla_hip.py --batches 1,8,32,64,128,256
     python benchmarks/rocm_benchmarks/bench_mla_hip.py                 # + roofline
 
 Bench flags are parsed at module level because rocprofv3 re-executes this script
@@ -90,6 +91,14 @@ _bench_parser.add_argument(
     help="Comma-separated num_heads per GPU (AITER MLA: multiples of 16, <=128). Default: 16.",
 )
 _bench_parser.add_argument(
+    "--batches",
+    default="1,8,32",
+    help=(
+        "Comma-separated batch sizes. Default: 1,8,32. AITER picks split-k depth "
+        "from the CU count, so the architectures only diverge above 32."
+    ),
+)
+_bench_parser.add_argument(
     "--separate",
     action="store_true",
     help=(
@@ -107,6 +116,12 @@ _counters = _bench_args.counters
 _auto_label = "mla" if _counters == "roofline" else f"mla_{_counters}"
 if _bench_args.mode != "all":
     _auto_label += f"_{_bench_args.mode}"
+# Only non-default sweeps are encoded, so the invocations in the docstring keep
+# the filenames the CDNA3 numbers were published under.
+if _bench_args.heads != _bench_parser.get_default("heads"):
+    _auto_label += f"_h{_bench_args.heads.replace(',', '-')}"
+if _bench_args.batches != _bench_parser.get_default("batches"):
+    _auto_label += f"_b{_bench_args.batches.replace(',', '-')}"
 if _bench_args.separate:
     _auto_label += "_separate"
 _label = _bench_args.label if _bench_args.label is not None else _auto_label
@@ -119,7 +134,7 @@ _HEAD_DIM_KPE = 64  # qk_rope_head_dim
 _QK_HEAD_DIM = _HEAD_DIM_CKV + _HEAD_DIM_KPE  # 576
 _DTYPE = torch.bfloat16
 _PAGE_SIZE = 1  # what vLLM's AITER MLA backend requires
-_BATCHES = [1, 8, 32]
+_BATCHES = [int(b) for b in _bench_args.batches.split(",") if b.strip()]
 _KV_LENS = [1024, 8192, 32768]
 
 # --mode pool: fixed (small) active set, growing page pool. Not in --mode all

--- a/benchmarks/rocm_benchmarks/bench_mla_hip.py
+++ b/benchmarks/rocm_benchmarks/bench_mla_hip.py
@@ -116,10 +116,14 @@ _counters = _bench_args.counters
 _auto_label = "mla" if _counters == "roofline" else f"mla_{_counters}"
 if _bench_args.mode != "all":
     _auto_label += f"_{_bench_args.mode}"
-# Only a non-default --batches is encoded. --heads deliberately is not: it
-# predates this flag, so suffixing it would orphan already-published CSVs from
+# Only a non-default --batches, and only where it is actually consumed: pool
+# mode sweeps _POOL_PAGES at the fixed _POOL_BATCH, so encoding a batch list
+# there would name a sweep the rows do not contain. --heads deliberately is not
+# encoded: it predates this flag, so a suffix would orphan published CSVs from
 # --replot.
-if _bench_args.batches != _bench_parser.get_default("batches"):
+if _bench_args.mode != "pool" and _bench_args.batches != _bench_parser.get_default(
+    "batches"
+):
     _auto_label += f"_b{_bench_args.batches.replace(',', '-')}"
 if _bench_args.separate:
     _auto_label += "_separate"

--- a/flashinfer/arch_caps.py
+++ b/flashinfer/arch_caps.py
@@ -248,6 +248,14 @@ class Capability:
 _MEASURED_950 = "MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-19"
 _MEASURED_942 = "MI300X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-19"
 
+# MLA is called out separately: the suite runs above predate the MLA decode and
+# prefill tests, so the ✅ on that row was carried by a run that never exercised
+# it. Decode and prefill are now measured directly on both head counts.
+_MEASURED_950_MLA = (
+    "mla: MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-24 "
+    "(decode + prefill, heads 16/128)"
+)
+
 # The one defect measured so far. Upstream calls it a compiler bug and gates
 # their own test skips on exactly (major, minor) == (7, 2) with gfx950
 # (aiter op_tests/test_batch_prefill.py::should_skip_rocm72_issue, still present
@@ -311,7 +319,12 @@ CAPABILITIES: Tuple[Capability, ...] = (
         ),
         fallback="fa2",
     ),
-    Capability("mla", "aiter", _archs(_OK_942, _OK_950)),  # no alternative backend
+    # No alternative backend -- hence no fallback=.
+    Capability(
+        "mla",
+        "aiter",
+        _archs(_OK_942, ArchSupport(Support.SUPPORTED, evidence=_MEASURED_950_MLA)),
+    ),
     Capability("rope", "aiter", _archs(_OK_942, _OK_950), fallback="native"),
     Capability(
         "append_paged_kv_cache", "aiter", _archs(_OK_942, _OK_950), fallback="native"

--- a/flashinfer/arch_caps.py
+++ b/flashinfer/arch_caps.py
@@ -248,9 +248,7 @@ class Capability:
 _MEASURED_950 = "MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-19"
 _MEASURED_942 = "MI300X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-19"
 
-# MLA is called out separately: the suite runs above predate the MLA decode and
-# prefill tests, so the ✅ on that row was carried by a run that never exercised
-# it. Decode and prefill are now measured directly on both head counts.
+# Separate from the suite strings above, which predate the MLA tests.
 _MEASURED_950_MLA = (
     "mla: MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-24 "
     "(decode + prefill, heads 16/128)"

--- a/flashinfer/mla_rocm.py
+++ b/flashinfer/mla_rocm.py
@@ -242,7 +242,9 @@ class BatchMLAPagedAttentionWrapper:
         page_size : int
             Page size of the paged KV-cache.
         causal : bool
-            Whether to apply causal masking (no-op for single-token decode).
+            Whether to apply causal masking. No-op for single-token decode.
+            Multi-token queries are always masked causally by AITER, so
+            ``causal=False`` raises rather than silently masking.
         sm_scale : float
             Softmax scale (typically ``1 / sqrt(head_dim_ckv + head_dim_kpe)``).
         q_data_type : torch.dtype
@@ -296,6 +298,17 @@ class BatchMLAPagedAttentionWrapper:
         self._sm_scale = sm_scale
         qo_lens = qo_host[1:] - qo_host[:-1]
         self._max_seqlen_q = int(qo_lens.max()) if qo_lens.numel() > 0 else 1
+
+        # AITER's mla_prefill_fwd takes no causal flag -- it always dispatches
+        # the causal ASM kernel -- so honouring causal=False is impossible here.
+        # Single-token decode masks nothing either way, hence the length guard.
+        if self._max_seqlen_q > 1 and not causal:
+            raise ValueError(
+                "AITER MLA applies causal masking unconditionally for "
+                f"multi-token queries (max_seqlen_q={self._max_seqlen_q}); "
+                "causal=False cannot be honoured. Pass causal=True, or use "
+                "single-token queries where the distinction does not arise."
+            )
 
     def run(
         self,

--- a/flashinfer/mla_rocm.py
+++ b/flashinfer/mla_rocm.py
@@ -142,7 +142,10 @@ class BatchMLAPagedAttentionWrapper:
     r"""ROCm MLA paged attention wrapper backed by AITER.
 
     Mirrors the public API of :class:`flashinfer.mla.BatchMLAPagedAttentionWrapper`
-    for use on AMD gfx942/gfx950 GPUs.  Implements the Matrix Absorption variant
+    for use on AMD gfx942/gfx950 GPUs, with one divergence: the CUDA wrapper
+    honours ``causal=False`` for multi-token queries, and AITER's prefill kernel
+    cannot, so :meth:`plan` rejects it rather than silently masking.
+    Implements the Matrix Absorption variant
     (absorbed W_UQ·W_UK and W_UV·W_O) where the KV-cache stores compressed-KV
     (``ckv``) and rope-key (``kpe``) tensors concatenated into a single buffer.
 
@@ -285,30 +288,33 @@ class BatchMLAPagedAttentionWrapper:
                 f"got {tuple(kv_len_arr.shape)} for kv_indptr with length {kv_indptr.numel()}."
             )
 
-        self._qo_indptr = qo_indptr.to(self.device, non_blocking=True)
-        self._kv_indptr = kv_indptr.to(self.device, non_blocking=True)
-        self._kv_indices = kv_indices.to(self.device, non_blocking=True)
         qo_host, kv_indptr_host, kv_lens_host = _gather_plan_inputs_on_host(
             qo_indptr, kv_indptr, kv_len_arr
         )
-        last_cpu = _kv_lens_to_last_page_len_cpu(
-            kv_indptr_host, kv_lens_host, page_size
-        )
-        self._kv_last_page_len = last_cpu.to(self.device, non_blocking=True)
-        self._sm_scale = sm_scale
         qo_lens = qo_host[1:] - qo_host[:-1]
-        self._max_seqlen_q = int(qo_lens.max()) if qo_lens.numel() > 0 else 1
+        max_seqlen_q = int(qo_lens.max()) if qo_lens.numel() > 0 else 1
 
-        # AITER's mla_prefill_fwd takes no causal flag -- it always dispatches
-        # the causal ASM kernel -- so honouring causal=False is impossible here.
-        # Single-token decode masks nothing either way, hence the length guard.
-        if self._max_seqlen_q > 1 and not causal:
+        # AITER's mla_prefill_fwd takes no causal flag, so causal=False cannot be
+        # honoured for multi-token queries. Single-token masks nothing either way.
+        if max_seqlen_q > 1 and not causal:
             raise ValueError(
                 "AITER MLA applies causal masking unconditionally for "
-                f"multi-token queries (max_seqlen_q={self._max_seqlen_q}); "
+                f"multi-token queries (max_seqlen_q={max_seqlen_q}); "
                 "causal=False cannot be honoured. Pass causal=True, or use "
                 "single-token queries where the distinction does not arise."
             )
+        last_cpu = _kv_lens_to_last_page_len_cpu(
+            kv_indptr_host, kv_lens_host, page_size
+        )
+
+        # Every validation above this line runs before any state is written, so a
+        # rejected plan() leaves a previously-planned wrapper untouched.
+        self._qo_indptr = qo_indptr.to(self.device, non_blocking=True)
+        self._kv_indptr = kv_indptr.to(self.device, non_blocking=True)
+        self._kv_indices = kv_indices.to(self.device, non_blocking=True)
+        self._kv_last_page_len = last_cpu.to(self.device, non_blocking=True)
+        self._sm_scale = sm_scale
+        self._max_seqlen_q = max_seqlen_q
 
     def run(
         self,

--- a/rocm_profiler/rocm_profiler.py
+++ b/rocm_profiler/rocm_profiler.py
@@ -163,6 +163,10 @@ class HardwareCeilings:
 
 
 KNOWN_HW: dict[str, HardwareCeilings] = {
+    # gfx950 covers both MI350X (1 kW air) and MI355X (1.4 kW liquid); they
+    # differ only in clock, so the lower MI350X matrix peak is used and a
+    # roofline taken on an MI355X reads slightly optimistic.
+    "gfx950": HardwareCeilings(2300.0, 8.0, "MI350X"),
     "gfx942": HardwareCeilings(1307.4, 5.3, "MI300X"),
     "gfx90a": HardwareCeilings(383.0, 3.277, "MI250X"),
     "gfx908": HardwareCeilings(185.0, 1.228, "MI100"),

--- a/tests/rocm_tests/test_mla_aiter_hip.py
+++ b/tests/rocm_tests/test_mla_aiter_hip.py
@@ -34,24 +34,9 @@ def _paged_mla_ref(
 
     out = torch.zeros_like(q_nope)
     for b in range(batch):
-        start = int(kv_indptr[b].item())
-        end = int(kv_indptr[b + 1].item())
-        last_len = int(kv_last_page_len[b].item())
-
-        keys_nope = []
-        keys_pe = []
-        for p_idx in range(start, end - 1):
-            pg = int(kv_indices[p_idx].item())
-            keys_nope.append(ckv_cache[pg])  # [page_size, ckv]
-            keys_pe.append(kpe_cache[pg])
-        if start < end:
-            pg = int(kv_indices[end - 1].item())
-            keys_nope.append(ckv_cache[pg, :last_len])
-            keys_pe.append(kpe_cache[pg, :last_len])
-
-        k_nope = torch.cat(keys_nope, dim=0).float()  # [kv_len, ckv]
-        k_pe = torch.cat(keys_pe, dim=0).float()  # [kv_len, kpe]
-        k = torch.cat([k_nope, k_pe], dim=-1)  # [kv_len, ckv+kpe]
+        k_nope, k = _gather_paged_kv(
+            ckv_cache, kpe_cache, kv_indptr, kv_indices, kv_last_page_len, b
+        )
 
         q = torch.cat(
             [q_nope[b].float(), q_pe[b].float()], dim=-1
@@ -116,13 +101,17 @@ def _paged_mla_prefill_ref(
         q_start = int(qo_indptr[b].item())
         q_end = int(qo_indptr[b + 1].item())
         qo_len = q_end - q_start
-        if qo_len == 0:
+        if qo_len <= 0:
             continue
 
         k_nope, k = _gather_paged_kv(
             ckv_cache, kpe_cache, kv_indptr, kv_indices, kv_last_page_len, b
         )
         kv_len = k.shape[0]
+        # Right-aligned masking leaves query 0 with kv_len-qo_len+1 keys; if that
+        # is <= 0 the row is fully masked and softmax returns NaN, which reads as
+        # a kernel fault rather than an invalid reference input.
+        assert kv_len >= qo_len, f"request {b}: kv_len={kv_len} < qo_len={qo_len}"
 
         q = torch.cat(
             [q_nope[q_start:q_end].float(), q_pe[q_start:q_end].float()], dim=-1
@@ -339,12 +328,7 @@ def _run_prefill(
 def test_mla_prefill_vs_ref(
     dtype, num_heads, head_dim_ckv, head_dim_kpe, qo_lens, kv_lens
 ):
-    """Cover the mla_prefill_fwd branch, which had no test on either arch.
-
-    ROCm 7.2.x is recorded as miscompiling AITER's *other* causal kernel on
-    gfx950 (arch_caps._ROCM72_CAUSAL_PREFILL); prefill MLA uses the same
-    causal ASM family, so it needs a numeric reference and not an assumption.
-    """
+    """Cover the mla_prefill_fwd branch against an fp32 reference."""
     device = torch.device("cuda:0")
     got, ref_args = _run_prefill(
         qo_lens, kv_lens, num_heads, head_dim_ckv, head_dim_kpe, dtype, device
@@ -353,17 +337,26 @@ def test_mla_prefill_vs_ref(
 
     # Report max_abs_err the way the batch-prefill miscompile was characterised
     # (0.595 vs fp32), so a failure here is comparable to that investigation.
+    # Scale the tolerance to the reference peak. A fixed 1e-1 exceeds |out|
+    # itself once kv_len is long -- softmax is near-uniform over zero-mean keys,
+    # so |out| ~ 0.1/sqrt(kv_len) -- and an all-zeros kernel would pass.
+    ref_peak = ref.float().abs().max().item()
     max_abs_err = (got.float() - ref.float()).abs().max().item()
-    assert max_abs_err < 1e-1, f"max_abs_err={max_abs_err:.6f}"
-    torch.testing.assert_close(got.float(), ref.float(), rtol=1e-1, atol=1e-1)
+    assert max_abs_err <= 0.05 * ref_peak, (
+        f"max_abs_err={max_abs_err:.6f} exceeds 5% of reference peak {ref_peak:.6f}"
+    )
+    torch.testing.assert_close(
+        got.float(), ref.float(), rtol=1e-2, atol=0.05 * ref_peak
+    )
 
 
 @requires_aiter
 def test_mla_plan_rejects_non_causal_multi_token():
     """causal=False with multi-token queries must raise, not mask silently.
 
-    aiter.mla.mla_prefill_fwd has no causal parameter; it always dispatches
-    mla_prefill_asm_fwd, so the flag cannot be honoured.
+    A rejected plan() must also leave the wrapper's state alone: run() only
+    gates on ``_qo_indptr is None``, so a half-planned wrapper would answer
+    with exactly the masking the raise exists to prevent.
     """
     from flashinfer.mla_rocm import BatchMLAPagedAttentionWrapper
 
@@ -386,17 +379,22 @@ def test_mla_plan_rejects_non_causal_multi_token():
         q_data_type=torch.bfloat16,
         kv_data_type=torch.bfloat16,
     )
+    single = torch.tensor([0, 1], dtype=torch.int32, device=device)
     multi = torch.tensor([0, 4], dtype=torch.int32, device=device)
+
+    # Plan a valid decode first, so the reject below has state it could corrupt.
+    wrapper.plan(qo_indptr=single, causal=False, **kwargs)
     with pytest.raises(ValueError, match="causal"):
         wrapper.plan(qo_indptr=multi, causal=False, **kwargs)
 
-    # Same shape with causal=True, and single-token with causal=False, both fine.
+    # Checked before any re-plan: run() gates only on `_qo_indptr is None`, so a
+    # leaked _max_seqlen_q would route this decode into mla_prefill_fwd.
+    assert wrapper._max_seqlen_q == 1
+    assert torch.equal(wrapper._qo_indptr, single.to(wrapper._qo_indptr.device))
+
+    # Same shape with causal=True is fine.
     wrapper.plan(qo_indptr=multi, causal=True, **kwargs)
-    wrapper.plan(
-        qo_indptr=torch.tensor([0, 1], dtype=torch.int32, device=device),
-        causal=False,
-        **kwargs,
-    )
+    assert wrapper._max_seqlen_q == 4
 
 
 @requires_aiter

--- a/tests/rocm_tests/test_mla_aiter_hip.py
+++ b/tests/rocm_tests/test_mla_aiter_hip.py
@@ -322,7 +322,11 @@ def _run_prefill(
 
 @requires_aiter
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
-@pytest.mark.parametrize("num_heads,head_dim_ckv,head_dim_kpe", [(16, 512, 64)])
+# AITER's prefill ASM accepts gqa_ratio 16 or 128 only -- 32/48/64 raise
+# "only support num_q_heads/num_kv_heads==16 or 128". 16 is TP8, 128 is TP1.
+@pytest.mark.parametrize(
+    "num_heads,head_dim_ckv,head_dim_kpe", [(16, 512, 64), (128, 512, 64)]
+)
 @pytest.mark.parametrize(
     "qo_lens,kv_lens",
     [

--- a/tests/rocm_tests/test_mla_aiter_hip.py
+++ b/tests/rocm_tests/test_mla_aiter_hip.py
@@ -65,6 +65,80 @@ def _paged_mla_ref(
     return out
 
 
+def _gather_paged_kv(
+    ckv_cache: torch.Tensor,
+    kpe_cache: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_indices: torch.Tensor,
+    kv_last_page_len: torch.Tensor,
+    b: int,
+):
+    """Flatten request ``b``'s pages into contiguous fp32 [kv_len, dim] keys."""
+    start = int(kv_indptr[b].item())
+    end = int(kv_indptr[b + 1].item())
+    last_len = int(kv_last_page_len[b].item())
+
+    keys_nope, keys_pe = [], []
+    for p_idx in range(start, end - 1):
+        pg = int(kv_indices[p_idx].item())
+        keys_nope.append(ckv_cache[pg])
+        keys_pe.append(kpe_cache[pg])
+    if start < end:
+        pg = int(kv_indices[end - 1].item())
+        keys_nope.append(ckv_cache[pg, :last_len])
+        keys_pe.append(kpe_cache[pg, :last_len])
+
+    k_nope = torch.cat(keys_nope, dim=0).float()
+    k_pe = torch.cat(keys_pe, dim=0).float()
+    return k_nope, torch.cat([k_nope, k_pe], dim=-1)
+
+
+def _paged_mla_prefill_ref(
+    q_nope: torch.Tensor,
+    q_pe: torch.Tensor,
+    ckv_cache: torch.Tensor,
+    kpe_cache: torch.Tensor,
+    qo_indptr: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_indices: torch.Tensor,
+    kv_last_page_len: torch.Tensor,
+    sm_scale: float,
+    causal: bool = True,
+) -> torch.Tensor:
+    """Pure-PyTorch ragged paged MLA prefill reference.
+
+    q_nope/q_pe are ragged over ``qo_indptr``: [total_q, num_heads, head_dim].
+    Causal masking is right-aligned -- the last query attends to every key --
+    which is the append/chunked-prefill convention.
+    """
+    out = torch.zeros_like(q_nope)
+    for b in range(int(qo_indptr.numel()) - 1):
+        q_start = int(qo_indptr[b].item())
+        q_end = int(qo_indptr[b + 1].item())
+        qo_len = q_end - q_start
+        if qo_len == 0:
+            continue
+
+        k_nope, k = _gather_paged_kv(
+            ckv_cache, kpe_cache, kv_indptr, kv_indices, kv_last_page_len, b
+        )
+        kv_len = k.shape[0]
+
+        q = torch.cat(
+            [q_nope[q_start:q_end].float(), q_pe[q_start:q_end].float()], dim=-1
+        )  # [qo_len, num_heads, ckv+kpe]
+
+        scores = torch.einsum("qhd,ld->qhl", q, k) * sm_scale
+        if causal:
+            qi = torch.arange(qo_len, device=scores.device).unsqueeze(1)
+            ki = torch.arange(kv_len, device=scores.device).unsqueeze(0)
+            mask = ki > (kv_len - qo_len + qi)  # [qo_len, kv_len]
+            scores = scores.masked_fill(mask.unsqueeze(1), float("-inf"))
+        attn = torch.softmax(scores, dim=-1)
+        out[q_start:q_end] = torch.einsum("qhl,lc->qhc", attn, k_nope).to(out.dtype)
+    return out
+
+
 def _build_paged_kv(
     batch_size: int,
     kv_lens: list,
@@ -181,6 +255,103 @@ def test_mla_decode_vs_ref(
     # MLA decode: fp16 atol ~5e-2 due to large head_dim softmax, bf16 slightly wider
     rtol, atol = (1e-1, 1e-1) if dtype == torch.bfloat16 else (5e-2, 5e-2)
     torch.testing.assert_close(got.float(), ref.float(), rtol=rtol, atol=atol)
+
+
+def _run_prefill(
+    qo_lens, kv_lens, num_heads, head_dim_ckv, head_dim_kpe, dtype, device
+):
+    """Drive the wrapper's prefill branch and return (got, ref_inputs)."""
+    from flashinfer.mla_rocm import BatchMLAPagedAttentionWrapper
+
+    batch_size = len(kv_lens)
+    total_q = sum(qo_lens)
+    sm_scale = 1.0 / math.sqrt(head_dim_ckv + head_dim_kpe)
+    page_size = 1
+
+    ckv_cache, kpe_cache, kv_indptr, kv_indices, kv_last_page_len = _build_paged_kv(
+        batch_size, kv_lens, page_size, head_dim_ckv, head_dim_kpe, dtype, device
+    )
+    kv_len_tensor = torch.tensor(kv_lens, dtype=torch.int32, device=device)
+
+    torch.manual_seed(42)
+    q_nope = (
+        torch.randn(total_q, num_heads, head_dim_ckv, dtype=dtype, device=device) * 0.1
+    )
+    q_pe = (
+        torch.randn(total_q, num_heads, head_dim_kpe, dtype=dtype, device=device) * 0.1
+    )
+
+    qo_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    for i, n in enumerate(qo_lens):
+        qo_indptr[i + 1] = qo_indptr[i] + n
+
+    ws = torch.empty(1, dtype=torch.float32, device=device)
+    wrapper = BatchMLAPagedAttentionWrapper(ws, backend="aiter")
+    wrapper.plan(
+        qo_indptr=qo_indptr,
+        kv_indptr=kv_indptr,
+        kv_indices=kv_indices,
+        kv_len_arr=kv_len_tensor,
+        num_heads=num_heads,
+        head_dim_ckv=head_dim_ckv,
+        head_dim_kpe=head_dim_kpe,
+        page_size=page_size,
+        causal=True,
+        sm_scale=sm_scale,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    # The whole point: this must take the mla_prefill_fwd branch, not decode.
+    assert wrapper._max_seqlen_q == max(qo_lens)
+
+    got = wrapper.run(
+        q_nope=q_nope, q_pe=q_pe, ckv_cache=ckv_cache, kpe_cache=kpe_cache
+    )
+    return got, (
+        q_nope,
+        q_pe,
+        ckv_cache,
+        kpe_cache,
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        sm_scale,
+    )
+
+
+@requires_aiter
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("num_heads,head_dim_ckv,head_dim_kpe", [(16, 512, 64)])
+@pytest.mark.parametrize(
+    "qo_lens,kv_lens",
+    [
+        ([4], [4]),  # full triangle
+        ([16], [16]),
+        ([48], [64]),  # chunked prefill, 3:4
+        ([2, 8, 5, 1], [2, 64, 127, 32]),  # ragged, mixed ratios
+    ],
+)
+def test_mla_prefill_vs_ref(
+    dtype, num_heads, head_dim_ckv, head_dim_kpe, qo_lens, kv_lens
+):
+    """Cover the mla_prefill_fwd branch, which had no test on either arch.
+
+    ROCm 7.2.x is recorded as miscompiling AITER's *other* causal kernel on
+    gfx950 (arch_caps._ROCM72_CAUSAL_PREFILL); prefill MLA uses the same
+    causal ASM family, so it needs a numeric reference and not an assumption.
+    """
+    device = torch.device("cuda:0")
+    got, ref_args = _run_prefill(
+        qo_lens, kv_lens, num_heads, head_dim_ckv, head_dim_kpe, dtype, device
+    )
+    ref = _paged_mla_prefill_ref(*ref_args)
+
+    # Report max_abs_err the way the batch-prefill miscompile was characterised
+    # (0.595 vs fp32), so a failure here is comparable to that investigation.
+    max_abs_err = (got.float() - ref.float()).abs().max().item()
+    assert max_abs_err < 1e-1, f"max_abs_err={max_abs_err:.6f}"
+    torch.testing.assert_close(got.float(), ref.float(), rtol=1e-1, atol=1e-1)
 
 
 @requires_aiter

--- a/tests/rocm_tests/test_mla_aiter_hip.py
+++ b/tests/rocm_tests/test_mla_aiter_hip.py
@@ -355,6 +355,47 @@ def test_mla_prefill_vs_ref(
 
 
 @requires_aiter
+def test_mla_plan_rejects_non_causal_multi_token():
+    """causal=False with multi-token queries must raise, not mask silently.
+
+    aiter.mla.mla_prefill_fwd has no causal parameter; it always dispatches
+    mla_prefill_asm_fwd, so the flag cannot be honoured.
+    """
+    from flashinfer.mla_rocm import BatchMLAPagedAttentionWrapper
+
+    device = torch.device("cuda:0")
+    ckv, kpe, kv_indptr, kv_indices, _ = _build_paged_kv(
+        1, [8], 1, 512, 64, torch.bfloat16, device
+    )
+    ws = torch.empty(1, dtype=torch.float32, device=device)
+    wrapper = BatchMLAPagedAttentionWrapper(ws, backend="aiter")
+
+    kwargs = dict(
+        kv_indptr=kv_indptr,
+        kv_indices=kv_indices,
+        kv_len_arr=torch.tensor([8], dtype=torch.int32, device=device),
+        num_heads=16,
+        head_dim_ckv=512,
+        head_dim_kpe=64,
+        page_size=1,
+        sm_scale=1.0 / math.sqrt(576),
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    multi = torch.tensor([0, 4], dtype=torch.int32, device=device)
+    with pytest.raises(ValueError, match="causal"):
+        wrapper.plan(qo_indptr=multi, causal=False, **kwargs)
+
+    # Same shape with causal=True, and single-token with causal=False, both fine.
+    wrapper.plan(qo_indptr=multi, causal=True, **kwargs)
+    wrapper.plan(
+        qo_indptr=torch.tensor([0, 1], dtype=torch.int32, device=device),
+        causal=False,
+        **kwargs,
+    )
+
+
+@requires_aiter
 def test_mla_decode_out_tensor():
     """run() respects a pre-allocated out= tensor."""
     from flashinfer.mla_rocm import BatchMLAPagedAttentionWrapper

--- a/tests/rocm_tests/test_mla_aiter_hip.py
+++ b/tests/rocm_tests/test_mla_aiter_hip.py
@@ -361,7 +361,7 @@ def test_mla_plan_rejects_non_causal_multi_token():
     from flashinfer.mla_rocm import BatchMLAPagedAttentionWrapper
 
     device = torch.device("cuda:0")
-    ckv, kpe, kv_indptr, kv_indices, _ = _build_paged_kv(
+    _, _, kv_indptr, kv_indices, _ = _build_paged_kv(
         1, [8], 1, 512, 64, torch.bfloat16, device
     )
     ws = torch.empty(1, dtype=torch.float32, device=device)


### PR DESCRIPTION
## Summary

PR #292 made the ROCm MLA path fast, and said plainly that it had only been measured on one architecture: *"This is the CDNA3 path. Everything above was measured on gfx942. gfx950 is unmeasured and no behaviour is arch-gated, so CDNA4 gets the same code with unverified numbers."* This closes that gap.

It is not a port. The MLA stack is already architecture-agnostic — `mla_rocm.py` has zero `gfx942`/`gfx950` branching, `arch_caps.py` already declared the row supported on both, and AITER 0.1.10 ships *more* MLA kernel objects for gfx950 (24 `.co`) than for gfx942 (18). So the deliverable is measurement, plus only what the measurement justified: one correctness bug it exposed, one missing profiler entry, and coverage for a code path that had none.

### What changed

- **`tests/rocm_tests/test_mla_aiter_hip.py`** — MLA prefill had **no test at all**, on either architecture. Every existing test built `qo_indptr` as `arange(batch+1)`, so `run()`'s `_max_seqlen_q == 1` branch was the only one ever taken and `mla_prefill_fwd` was never executed. Adds a ragged causal reference accumulating in fp32, four shapes, and both supported head counts.
- **`flashinfer/mla_rocm.py`** — `plan()` accepted `causal` and never stored or used it. Harmless for single-token decode; a silent wrong answer for multi-token, because `aiter.mla.mla_prefill_fwd` takes no causal parameter and unconditionally dispatches the causal ASM kernel. `causal=False` now raises instead of quietly returning a masked result, and does so before any wrapper state is written so a rejected `plan()` leaves a previously-planned wrapper intact. **This is a deliberate divergence from the CUDA wrapper**, which does honour `causal=False` for multi-token queries (`flashinfer/mla.py:415`); the class docstring now says so. Raising is the right trade against returning a causally-masked answer to a caller who asked for the opposite, but it is a behaviour change and reviewers should see it framed as one.
- **`rocm_profiler/rocm_profiler.py`** — `KNOWN_HW` had no `gfx950` entry, so on MI350X the lookup fell through to a warning and returned no ceilings: `--counters roofline` produced a plot with no hardware roof, and none of #292's roofline conclusions could even be restated on CDNA4.
- **`benchmarks/rocm_benchmarks/bench_mla_hip.py`** — `--batches`, mirroring the existing `--heads`, defaulting to today's `1,8,32`. Both now feed the output label when non-default; `--heads` did not before, so a `--heads 16,128` run silently overwrote the baseline it was meant to be compared against.
- **`flashinfer/arch_caps.py`, `README.md`** — the gfx950 MLA row carried a whole-suite evidence string from 2026-08-19 that predates the MLA tests entirely, so its checkmark was borrowed from a run that never exercised MLA. Replaced with an MLA-specific string.

## Results

All measured on 1× MI350X (gfx950), ROCm 7.2.0, torch 2.9.1+rocm7.2.0, amd-aiter 0.1.10.

**MLA prefill is correct on ROCm 7.2 / gfx950.** This was the main open risk: ROCm 7.2.x is already recorded as miscompiling AITER's causal *batch-prefill* kernel on gfx950 (`arch_caps._ROCM72_CAUSAL_PREFILL`), and MLA prefill dispatches into the same causal ASM family (`mla_pfl_bf16_a16w16_causal_*.co`). It does not extend to MLA. No gate was needed, which is why this PR adds none.

**#292's central fix transfers to CDNA4.** KV-pool sweep, combined (zero-copy view) against `--separate` (the pre-#292 concatenating layout), batch 8, kv_len 1024:

| pool | combined | separate |
|---|---|---|
| 0.01 GB | 0.166 ms | 0.172 ms |
| 0.28 GB | 0.169 ms | 0.279 ms |
| 1.12 GB | 0.152 ms | 0.942 ms |
| 4.50 GB | 0.149 ms | **2.054 ms** (13.8×) |

Flat in pool size on CDNA4 exactly as on CDNA3 — cost tracks the working set, not the allocated pool. `plan()` is likewise flat in batch across 1..256.

**Supported head counts, which were never written down:**

| num_heads | decode (qlen=1) | prefill (qlen=4) |
|---|---|---|
| 16 | ok | ok |
| 32 | ok | RuntimeError |
| 48 | RuntimeError | RuntimeError |
| 64 | ok | RuntimeError |
| 128 | ok | ok |

All clean `RuntimeError`s — no crash, no NaN, no silent wrong answer — so no capability gate is warranted. 16 is TP8 and 128 is TP1; prefill now covers both.

### Measured, and deliberately not changed

**AITER's `num_kv_splits` heuristic is fine at 256 CU.** This was the one concrete CDNA3/CDNA4 divergence identified up front: `get_meta_param` (`aiter/mla.py:101-140`) picks split depth from `get_cu_num()`, and MI300X has 304 CU against MI350X's 256, so the two architectures land on different values — 14 vs 4 at batch 64 / kv 32768, 7 vs 1 at batch 256. A first sweep of fixed splits 1..16 appeared to show gains up to 1.71×. Re-measuring with alternating arms and reported variance collapsed every one of them to within noise:

| shape (heads, bs, kv) | heuristic | auto | best fixed | gain |
|---|---|---|---|---|
| 16, 32, 1024 | 8 | 0.1069 ± 0.0034 ms | 16 → 0.1089 ± 0.0040 ms | 0.98× |
| 16, 1, 8192 | 16 | 0.0866 ± 0.0026 ms | 5 → 0.0827 ± 0.0081 ms | 1.05× |
| 16, 8, 8192 | 16 | 0.0667 ± 0.0151 ms | 8 → 0.0816 ± 0.0135 ms | 0.82× |
| 16, 256, 1024 | 1 | 0.1026 ± 0.0064 ms | 2 → 0.0980 ± 0.0022 ms | 1.05× |

The first sweep was measuring drift, not split-k — the giveaway was cells reporting *below* 1.00×, impossible when "best" is a minimum over the same work. Same conclusion #292 reached at 304 CU, now established for 256. No override lands, and `mla_rocm.py` gains no tuning knob.

**Absolute times on this host are not comparable to #292's.** Everything here runs ~2× slower than the gfx942 figures, including a ~0.15 ms floor visible on work small enough to be free. Direct CUDA-event timing of the same calls gives 0.06–0.10 ms, so that floor is benchmark-harness and host dispatch overhead on this box, not a CDNA4 kernel property. The within-box ratios above are sound; cross-box absolute comparison is not supported by this data and is not claimed.

**AITER 0.1.10's MLA dispatch is architecture-blind.** Neither `aiter/mla.py` nor `csrc/py_itfs_cu/asm_mla.cu` contains a single `gfx` test at this version; the architecture enters only as a path prefix when `hipModuleLoad` resolves `hsa/<arch>/mla/`. gfx950 therefore receives gfx942's kernel *choices*, and six of the 24 gfx950 `.co` files shipped in the wheel are never named by the dispatcher. Every gfx950-specific dispatch fix upstream landed after 0.1.10 (native qh64 instead of head-folding, the qh128 fp8 gate, `mgc=32`, persistent-mode support). This is a pin-version limitation, not something this PR can fix — recorded here so the next AITER bump has a reason attached.

## Test plan

- [x] `tests/rocm_tests/test_mla_aiter_hip.py` — **29 passed** on MI350X.
- [x] `tests/rocm_tests/test_arch_caps_hip.py` — **64 passed**, GPU-less.
- [x] A/B on the new prefill test, via an all-zeros output rather than a plausible-looking perturbation. This is what caught the tolerance being larger than the signal: a fixed `atol=1e-1` let a zeros tensor pass at `([48],[64])`, whose reference peaks at 0.077. The tolerance is now 5% of the reference peak; zeros fail at all 8 parametrizations and real output passes with 4–17× margin (measured error is ~1% of peak). The earlier "data artifact" explanation for that shape was wrong — the output was simply under tolerance.
- [x] A/B on the causal guard: replaced with `if False`, the new test reports "DID NOT RAISE ValueError". Separately, moving the guard back below the state assignments makes the leak assertion fail `assert 4 == 1` — that placement was a real defect found in review, not a hypothetical.
- [x] Regression control: `test_torch_compile_hip.py` + `test_append_paged_kv_cache_aiter_hip.py` + `test_mla_aiter_hip.py` run at base `ab0ae5ef` and at HEAD produce **byte-identical failure sets** (60 both sides, zero regressions, zero fixes); none are MLA. **Correction (2026-08-25):** this body originally attributed those 60 to "JIT-dependent tests that cannot build under the source-only `PYTHONPATH` harness". That reason was wrong — the container invocation named the conda interpreter by absolute path but did not put its `bin` on `PATH`, so `ninja` was missing and every JIT build failed with `FileNotFoundError`. The conclusion is unchanged (environmental, identical at base, no MLA test affected), but the stated cause was not.
- [x] Every commit individually `pre-commit`-clean, so `git bisect` never lands on a red tree.
- [x] `scripts/gen_arch_support_matrix.py --check` exits 0.

## Not in scope

The `vec_size` deferral from #292 (`AppendPagedKVMlaCache` hardcodes `vec_size = 2`; `AppendPagedKVCache` derives it partly from `HEAD_DIM / 32`, a CUDA warp-size constant that is wrong on a 64-lane wavefront). Real, and equally wrong on gfx942 — it is an arch-agnostic kernel-tuning change needing its own before/after on both boards, and folding it in would make these MLA numbers non-attributable. Worth its own PR.

**Follow-up measurement (2026-08-25), since the above understated where it matters.** Sizing the append against an MLA decode step on MI350X, and against a plain `copy_` of the same bytes:

| nnz | MB moved | append | plain `copy_` | append GB/s | copy GB/s |
|---|---|---|---|---|---|
| 256 | 0.3 | 5.66 µs | 3.37 µs | 104 | 175 |
| 4096 | 4.7 | 5.70 µs | 3.31 µs | 1655 | 2855 |
| 16384 | 18.9 | 12.66 µs | 5.65 µs | 2983 | 6682 |
| 65536 | 75.5 | 42.66 µs | 21.85 µs | 3540 | 6911 |

Two regimes. Below nnz≈4096 the kernel is **launch-bound** — flat at ~5.7 µs across a 16× range of work — so `vec_size` cannot help there. A decode step appends one token per sequence, i.e. nnz == batch, which sits entirely in that regime: the append is 13.6% of a decode step at batch ≤32 and 2.4% at batch 256, but none of that is byte movement. **Changing `vec_size` will not speed up decode.**

Above nnz≈16384 it is bandwidth-bound and the gap is real: ~3.5 TB/s against 6.9 TB/s for a plain copy, i.e. 44% of MI350X's 8.0 TB/s peak where the copy reaches 86%. That 2× ratio is the signature of 4-byte accesses. So the fix is worth doing, but its beneficiary is **chunked-prefill ingestion, not decode** — which is the opposite of what #292's framing implied.

Note also that the two sites sit on opposite sides of the additive-only policy: `AppendPagedKVMlaCache` lives in `include/flashinfer/attention/generic/page.cuh`, the AMD kernel fork (one commit, 16 HIP markers), so it is ours to change with no rebase cost. `AppendPagedKVCache`'s `HEAD_DIM / 32` lives in `include/flashinfer/page.cuh`, which is upstream-tracked (54 commits, zero HIP markers) — editing it would break the byte-identical-upstream rule and change CUDA behaviour that cannot be validated here.
