### PR TITLE
bench(rocm): run the unified benchmark harness on gfx942/gfx950

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -268,14 +268,20 @@ them reports "not supported" rather than failing at import.
 
 | Routine | gfx942 | gfx950 |
 |---|---|---|
-| **BatchDecodeWithPagedKVCacheWrapper** | fa2, auto, aiter | fa2, auto, aiter |
-| **BatchPrefillWithPagedKVCacheWrapper** | fa2, auto, aiter | fa2, auto (AITER gated on ROCm 7.2.x) |
-| **BatchPrefillWithRaggedKVCacheWrapper** | fa2, auto, aiter | fa2, auto (AITER gated on ROCm 7.2.x) |
+| **BatchDecodeWithPagedKVCacheWrapper** | fa2, auto | fa2, auto |
+| **BatchPrefillWithPagedKVCacheWrapper** | fa2, auto | fa2, auto |
+| **BatchPrefillWithRaggedKVCacheWrapper** | fa2, auto | fa2, auto |
 
 - **fa2** — the in-tree HIP kernel.
-- **aiter** — the [AITER](https://github.com/ROCm/aiter) backend, requires `amd-aiter`.
-- **auto** — what the library picks in production: AITER when the call satisfies
-  its constraints, otherwise fa2.
+- **auto** — what the library picks in production: [AITER](https://github.com/ROCm/aiter)
+  when `amd-aiter` is installed and the call satisfies its constraints, otherwise fa2.
+  `backend_resolved` records which one ran.
+
+`--backends aiter` is deliberately not offered. AITER is reached through `auto`,
+which reports what it resolved to, so an explicit name would add no coverage —
+and on gfx950 under ROCm 7.2.x `auto` resolves to fa2 for both prefill routines
+anyway, because `arch_caps` gates AITER off there for the causal-miscompile
+known-bad entry.
 
 ### Running
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -253,3 +253,70 @@ Backend Legend:
 - trtllm: TensorRT-LLM
 - trtllm-gen: TensorRT-LLM
 - trtllm-native: TensorRT-LLM (out-of-wrapper)
+
+## ROCm (gfx942 / gfx950)
+
+On AMD the supported-backend table above does not apply: gfx942 and gfx950 report
+compute capability 9.4 and 9.5, which match no entry in it. The ROCm branch keys
+off the GPU architecture instead and derives the backend list from
+[`flashinfer/arch_caps.py`](../flashinfer/arch_caps.py), so it tracks the
+arch-support matrix rather than restating it.
+
+Only the attention routines are available. `gemm` and `moe` are not built on
+ROCm, and `BatchMLAPagedAttentionWrapper` is not wired up yet; requesting any of
+them reports "not supported" rather than failing at import.
+
+| Routine | gfx942 | gfx950 |
+|---|---|---|
+| **BatchDecodeWithPagedKVCacheWrapper** | fa2, auto, aiter | fa2, auto, aiter |
+| **BatchPrefillWithPagedKVCacheWrapper** | fa2, auto, aiter | fa2, auto (AITER gated on ROCm 7.2.x) |
+| **BatchPrefillWithRaggedKVCacheWrapper** | fa2, auto, aiter | fa2, auto (AITER gated on ROCm 7.2.x) |
+
+- **fa2** — the in-tree HIP kernel.
+- **aiter** — the [AITER](https://github.com/ROCm/aiter) backend, requires `amd-aiter`.
+- **auto** — what the library picks in production: AITER when the call satisfies
+  its constraints, otherwise fa2.
+
+### Running
+
+```bash
+cd benchmarks
+python flashinfer_benchmark.py --testlist rocm_benchmarks/testlist_rocm.txt \
+    --output_path run-$(date +%F).csv
+```
+
+Diff successive CSVs **by column name**, not position — the ROCm columns below
+were appended and shift the index of everything after them.
+
+### Reading the output
+
+Two columns exist only on ROCm:
+
+- **`backend_resolved`** — what `auto` actually became (`aiter` or `fa2`). Without
+  it an `auto` row is uninterpretable, since both possibilities look identical.
+- **`backend_fallback_reason`** — why `auto` declined AITER. This is what separates
+  "AITER correctly rejected this shape" from "the benchmark got in the way".
+
+A row with `backend_resolved=fa2` and an **empty** reason came from neither: it
+means `auto` was short-circuited because `use_tensor_cores` was set or CUDA-graph
+capture was enabled. The testlist avoids both, so treat it as worth investigating.
+
+`auto` rows are always timed eagerly. Under graph capture `auto` stays on fa2 by
+design — AITER's launch grid is fixed at the shapes seen during capture, so
+replaying at a longer sequence is silently wrong. Graph-mode AITER decode is the
+explicit capture-at-max path in
+[`rocm_benchmarks/bench_decode_graph_hip.py`](rocm_benchmarks/bench_decode_graph_hip.py).
+
+### Two tiers
+
+This runner answers "did anything regress" across model-shaped configs. For
+"why is this kernel slow", use [`rocm_profiler`](../rocm_profiler/rocm_profiler.py)
+and the per-op drivers in [`rocm_benchmarks/`](rocm_benchmarks/), which collect
+`rocprofv3` hardware counters and plot a roofline.
+
+### Comparing numbers
+
+Record the architecture and toolchain with every result — `gcnArchName`,
+`torch.version.hip`, and the `amd-aiter` version. A gfx942 / ROCm 7.2 number is
+not comparable to a gfx950 / ROCm 7.1 one, and the AITER prefill path in
+particular is gated differently between them.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -290,7 +290,9 @@ were appended and shift the index of everything after them.
 
 ### Reading the output
 
-Two columns exist only on ROCm:
+Two columns are present in every CSV, but only ever populated on ROCm — the
+schema is the same on both platforms, so a CUDA run leaves them empty rather
+than omitting them:
 
 - **`backend_resolved`** — what `auto` actually became (`aiter` or `fa2`). Without
   it an `auto` row is uninterpretable, since both possibilities look identical.

--- a/benchmarks/flashinfer_benchmark.py
+++ b/benchmarks/flashinfer_benchmark.py
@@ -149,6 +149,23 @@ def parse_args(line=sys.argv[1:]):
         help="Number of dry runs.",
     )
     parser.add_argument(
+        "--dry_run_time_ms",
+        type=int,
+        required=False,
+        default=None,
+        help="Warmup budget in ms. Overrides --dry_run_iters. On ROCm prefer this "
+        "over an iteration count: clock sampling intervals run to hundreds of ms, "
+        "so a handful of iterations warms up well short of steady-state clocks.",
+    )
+    parser.add_argument(
+        "--repeat_time_ms",
+        type=int,
+        required=False,
+        default=None,
+        help="Measurement budget in ms. Overrides --num_iters. Leaving this unset "
+        "keeps the sample count fixed, which makes std_time comparable run over run.",
+    )
+    parser.add_argument(
         "--case_tag",
         type=str,
         required=False,

--- a/benchmarks/flashinfer_benchmark.py
+++ b/benchmarks/flashinfer_benchmark.py
@@ -7,8 +7,33 @@ from routines.flashinfer_benchmark_utils import (
     full_output_columns,
     output_column_dict,
 )
-from routines.gemm import parse_gemm_args, run_gemm_test
-from routines.moe import parse_moe_args, run_moe_test
+
+# The gemm and moe routines pull in CUDA-only modules (flashinfer.autotuner,
+# flashinfer.fused_moe), so importing them unconditionally makes the whole runner
+# unimportable on ROCm -- including the attention routines, which do work there.
+_ROUTINE_IMPORT_ERRORS = {}
+
+try:
+    from routines.gemm import parse_gemm_args, run_gemm_test
+except Exception as exc:
+    parse_gemm_args = run_gemm_test = None
+    _ROUTINE_IMPORT_ERRORS["gemm"] = exc
+
+try:
+    from routines.moe import parse_moe_args, run_moe_test
+except Exception as exc:
+    parse_moe_args = run_moe_test = None
+    _ROUTINE_IMPORT_ERRORS["moe"] = exc
+
+
+def require_routine_group(group):
+    """Raise with the original import error if this routine group failed to import."""
+    exc = _ROUTINE_IMPORT_ERRORS.get(group)
+    if exc is not None:
+        raise RuntimeError(
+            f"The '{group}' benchmark routines are unavailable on this platform: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
 
 
 def run_test(args):
@@ -23,8 +48,10 @@ def run_test(args):
     if args.routine in benchmark_apis["attention"]:
         res = run_attention_test(args)
     elif args.routine in benchmark_apis["gemm"]:
+        require_routine_group("gemm")
         res = run_gemm_test(args)
     elif args.routine in benchmark_apis["moe"]:
+        require_routine_group("moe")
         res = run_moe_test(args)
     else:
         raise ValueError(f"Unsupported routine: {args.routine}")
@@ -147,8 +174,10 @@ def parse_args(line=sys.argv[1:]):
     if args.routine in benchmark_apis["attention"]:
         args = parse_attention_args(line, parser)
     elif args.routine in benchmark_apis["gemm"]:
+        require_routine_group("gemm")
         args = parse_gemm_args(line, parser)
     elif args.routine in benchmark_apis["moe"]:
+        require_routine_group("moe")
         args = parse_moe_args(line, parser)
     else:
         raise ValueError(f"Unsupported routine: {args.routine}")

--- a/benchmarks/flashinfer_benchmark.py
+++ b/benchmarks/flashinfer_benchmark.py
@@ -1,4 +1,5 @@
 import argparse
+import csv
 import sys
 
 from routines.attention import parse_attention_args, run_attention_test
@@ -58,15 +59,13 @@ def run_test(args):
 
     # Write results to output file if specified
     if args.output_path is not None:
-        with open(args.output_path, "a") as fout:
+        with open(args.output_path, "a", newline="") as fout:
+            writer = csv.writer(fout, lineterminator="\n")
             for cur_res in res:
                 for key in output_column_dict["general"]:
                     cur_res[key] = getattr(args, key)
 
-                output_line = ",".join(
-                    [str(cur_res[col]) for col in full_output_columns]
-                )
-                fout.write(output_line + "\n")
+                writer.writerow([str(cur_res[col]) for col in full_output_columns])
             fout.flush()
     return
 
@@ -208,8 +207,8 @@ if __name__ == "__main__":
 
     # Setup output file if specified
     if testlist_args.output_path is not None:
-        with open(testlist_args.output_path, "w") as fout:
-            fout.write(",".join(full_output_columns) + "\n")
+        with open(testlist_args.output_path, "w", newline="") as fout:
+            csv.writer(fout, lineterminator="\n").writerow(full_output_columns)
 
     # Process tests either from testlist file or command line arguments
     if testlist_args.testlist is not None:

--- a/benchmarks/rocm_benchmarks/testlist_rocm.txt
+++ b/benchmarks/rocm_benchmarks/testlist_rocm.txt
@@ -4,10 +4,15 @@
 #   python flashinfer_benchmark.py --testlist rocm_benchmarks/testlist_rocm.txt \
 #       --output_path run-$(date +%F).csv
 #
-# Every line runs `fa2` and `auto`. `fa2` is the in-tree HIP kernel and, being
+# Every line requests `fa2` and `auto`. `fa2` is the in-tree HIP kernel and, being
 # listed first, is also the reference that --refcheck compares against; `auto` is
 # whatever the library would pick in production. Read backend_resolved to see
 # which one `auto` became and backend_fallback_reason for why it declined AITER.
+#
+# A requested backend can still be dropped before it runs when the kernel cannot
+# serve the shape -- the Llama-3.1-405B rows below lose `fa2` that way. Those
+# rows have no reference and are therefore NOT refcheck-verified, so count the
+# rows per config in the CSV rather than assuming two.
 # A row with backend_resolved=fa2 and an EMPTY reason did not come from a
 # constraint -- investigate rather than assume.
 #

--- a/benchmarks/rocm_benchmarks/testlist_rocm.txt
+++ b/benchmarks/rocm_benchmarks/testlist_rocm.txt
@@ -1,0 +1,74 @@
+# ROCm attention testlist for benchmarks/flashinfer_benchmark.py (gfx942 / gfx950).
+#
+#   cd benchmarks
+#   python flashinfer_benchmark.py --testlist rocm_benchmarks/testlist_rocm.txt \
+#       --output_path run-$(date +%F).csv
+#
+# Every line runs `fa2` and `auto`. `fa2` is the in-tree HIP kernel and, being
+# listed first, is also the reference that --refcheck compares against; `auto` is
+# whatever the library would pick in production. Read backend_resolved to see
+# which one `auto` became and backend_fallback_reason for why it declined AITER.
+# A row with backend_resolved=fa2 and an EMPTY reason did not come from a
+# constraint -- investigate rather than assume.
+#
+# Choices worth knowing before editing:
+#
+#   --page_size 128 for paged prefill, not 16. 128 is AITER-native for
+#     amd-aiter >= 0.1.10; other sizes take a flat-gather path that copies the
+#     whole KV cache inside the timed region, so the row becomes a memcpy
+#     benchmark. Decode has no gather path and uses the serving-default 16.
+#
+#   --refcheck WITHOUT --allow_output_mismatch. fa2 and auto run side by side
+#     anyway, so the correctness check is free, and a fast-but-wrong number is
+#     worse than a missing row in a run-over-run diff.
+#
+#   No --random_actual_seq_len. GPU-RNG-derived lengths vary max_kv_len, which
+#     varies AITER's compiled kernel variant and makes shapes differ run to run.
+#
+#   bf16 only. The decode routine accepts bf16 or fp8_e4m3 (not fp16), and AITER
+#     is fp16/bf16, so bf16 is the one dtype common to every path here.
+#
+#   DeepSeek-R1 (head_dim_qk 192 / head_dim_vo 128) is deliberately absent: AITER
+#     requires equal head dims, and the fa2 fallback fails to compile on gfx950
+#     (static_assert in permuted_smem.cuh). Neither backend can serve it.
+#
+# On gfx950 with ROCm 7.2.x every prefill row resolves to fa2: arch_caps gates
+# AITER batch prefill off for the causal-miscompile known-bad entry. That is
+# correct behaviour, and the reason column says so. Decode is unaffected.
+
+## Batch decode -- page_size 16, bf16, GQA
+# Llama-3.1-8B (32 qo / 8 kv heads)
+--routine BatchDecodeWithPagedKVCacheWrapper --backends fa2 auto --page_size 16 --batch_size 1 --s_qo 1 --s_kv 1024 --num_qo_heads 32 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-8B"
+--routine BatchDecodeWithPagedKVCacheWrapper --backends fa2 auto --page_size 16 --batch_size 16 --s_qo 1 --s_kv 1024 --num_qo_heads 32 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-8B"
+--routine BatchDecodeWithPagedKVCacheWrapper --backends fa2 auto --page_size 16 --batch_size 64 --s_qo 1 --s_kv 1024 --num_qo_heads 32 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-8B"
+--routine BatchDecodeWithPagedKVCacheWrapper --backends fa2 auto --page_size 16 --batch_size 16 --s_qo 1 --s_kv 8192 --num_qo_heads 32 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-8B"
+--routine BatchDecodeWithPagedKVCacheWrapper --backends fa2 auto --page_size 16 --batch_size 64 --s_qo 1 --s_kv 8192 --num_qo_heads 32 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-8B"
+
+# Llama-3.1-70B (64 qo / 8 kv heads)
+--routine BatchDecodeWithPagedKVCacheWrapper --backends fa2 auto --page_size 16 --batch_size 1 --s_qo 1 --s_kv 1024 --num_qo_heads 64 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-70B"
+--routine BatchDecodeWithPagedKVCacheWrapper --backends fa2 auto --page_size 16 --batch_size 16 --s_qo 1 --s_kv 1024 --num_qo_heads 64 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-70B"
+--routine BatchDecodeWithPagedKVCacheWrapper --backends fa2 auto --page_size 16 --batch_size 64 --s_qo 1 --s_kv 1024 --num_qo_heads 64 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-70B"
+--routine BatchDecodeWithPagedKVCacheWrapper --backends fa2 auto --page_size 16 --batch_size 16 --s_qo 1 --s_kv 8192 --num_qo_heads 64 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-70B"
+--routine BatchDecodeWithPagedKVCacheWrapper --backends fa2 auto --page_size 16 --batch_size 64 --s_qo 1 --s_kv 8192 --num_qo_heads 64 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-70B"
+
+# Llama-3.1-405B (128 qo / 8 kv heads). GQA group size 16 is outside the HIP
+# kernel's DISPATCH_GQA_GROUP_SIZE set {1,2,3,4,8}, so fa2 is skipped and only
+# AITER runs -- these two rows have no reference and are NOT refcheck-verified.
+--routine BatchDecodeWithPagedKVCacheWrapper --backends fa2 auto --page_size 16 --batch_size 16 --s_qo 1 --s_kv 1024 --num_qo_heads 128 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-405B"
+--routine BatchDecodeWithPagedKVCacheWrapper --backends fa2 auto --page_size 16 --batch_size 64 --s_qo 1 --s_kv 8192 --num_qo_heads 128 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-405B"
+
+## Batch paged prefill -- page_size 128 (AITER-native), causal, bf16
+--routine BatchPrefillWithPagedKVCacheWrapper --backends fa2 auto --page_size 128 --batch_size 1 --s_qo 1024 --s_kv 1024 --num_qo_heads 32 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --causal --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-8B"
+--routine BatchPrefillWithPagedKVCacheWrapper --backends fa2 auto --page_size 128 --batch_size 16 --s_qo 1024 --s_kv 1024 --num_qo_heads 32 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --causal --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-8B"
+--routine BatchPrefillWithPagedKVCacheWrapper --backends fa2 auto --page_size 128 --batch_size 4 --s_qo 4096 --s_kv 4096 --num_qo_heads 32 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --causal --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-8B"
+--routine BatchPrefillWithPagedKVCacheWrapper --backends fa2 auto --page_size 128 --batch_size 1 --s_qo 1024 --s_kv 1024 --num_qo_heads 64 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --causal --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-70B"
+--routine BatchPrefillWithPagedKVCacheWrapper --backends fa2 auto --page_size 128 --batch_size 16 --s_qo 1024 --s_kv 1024 --num_qo_heads 64 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --causal --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-70B"
+--routine BatchPrefillWithPagedKVCacheWrapper --backends fa2 auto --page_size 128 --batch_size 4 --s_qo 4096 --s_kv 4096 --num_qo_heads 64 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --causal --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-70B"
+
+## Batch ragged prefill -- causal, bf16
+--routine BatchPrefillWithRaggedKVCacheWrapper --backends fa2 auto --batch_size 1 --s_qo 1024 --s_kv 1024 --num_qo_heads 32 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --causal --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-8B"
+--routine BatchPrefillWithRaggedKVCacheWrapper --backends fa2 auto --batch_size 16 --s_qo 1024 --s_kv 1024 --num_qo_heads 32 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --causal --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-8B"
+--routine BatchPrefillWithRaggedKVCacheWrapper --backends fa2 auto --batch_size 4 --s_qo 4096 --s_kv 4096 --num_qo_heads 32 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --causal --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-8B"
+--routine BatchPrefillWithRaggedKVCacheWrapper --backends fa2 auto --batch_size 1 --s_qo 1024 --s_kv 1024 --num_qo_heads 64 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --causal --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-70B"
+--routine BatchPrefillWithRaggedKVCacheWrapper --backends fa2 auto --batch_size 16 --s_qo 1024 --s_kv 1024 --num_qo_heads 64 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --causal --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-70B"
+--routine BatchPrefillWithRaggedKVCacheWrapper --backends fa2 auto --batch_size 4 --s_qo 4096 --s_kv 4096 --num_qo_heads 64 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128 --causal --q_dtype bfloat16 --kv_dtype bfloat16 --refcheck --generate_repro_command --case_tag "Llama-3.1-70B"

--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -16,6 +16,8 @@ from .flashinfer_benchmark_utils import (
     print_perf_metrics,
     is_close_stats,
     filter_backends_by_compute_capability,
+    as_nhd_paged_kv_cache,
+    record_backend_resolution,
 )
 
 
@@ -92,6 +94,7 @@ def parse_attention_args(line, parser):
             "trtllm-gen",
             "trtllm-native",
             "trtllm-gen-native",  # Deprecated, will be removed in future
+            "auto",  # ROCm: let the wrapper pick AITER or fa2 per its constraints
         ],
         help="Kernel backends to test. Default: fa2",
     )
@@ -456,15 +459,18 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
     # Prepare wrappers
     backend_wrappers = {}
     for backend in backends:
-        if backend in ["fa2", "fa2_tc", "trtllm-gen"]:
+        if backend in ["fa2", "fa2_tc", "trtllm-gen", "auto"]:
             plan_kv_indptr = (
                 kv_indptr.clone().detach() if backend == "trtllm-gen" else kv_indptr
             )
+            # AITER decode needs NHD, use_tensor_cores=False and no graph capture;
+            # `auto` silently resolves to fa2 if any of those is not met, so pass
+            # all three or the row measures fa2 while claiming to be auto.
             backend_wrappers[backend] = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
                 workspace_buffer,
-                "HND",
-                use_cuda_graph=is_cuda_graph_compatible,
-                use_tensor_cores=(backend != "fa2"),
+                "NHD" if backend == "auto" else "HND",
+                use_cuda_graph=is_cuda_graph_compatible and backend != "auto",
+                use_tensor_cores=(backend not in ("fa2", "auto")),
                 paged_kv_indptr_buffer=plan_kv_indptr,
                 paged_kv_indices_buffer=kv_indices,
                 paged_kv_last_page_len_buffer=kv_last_page_len,
@@ -501,9 +507,10 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
             kv_cache_for_trt = torch.cat([k_fp8, v_fp8], dim=1)
 
     def run_backend_wrapper(backend):
-        if backend in ["fa2", "fa2_tc", "trtllm-gen"]:
+        if backend in ["fa2", "fa2_tc", "trtllm-gen", "auto"]:
+            cache = as_nhd_paged_kv_cache(kv_cache) if backend == "auto" else kv_cache
             return backend_wrappers[backend].run(
-                q, kv_cache, k_scale=k_scale, v_scale=v_scale
+                q, cache, k_scale=k_scale, v_scale=v_scale
             )
         elif backend == "cudnn":
             return flashinfer.decode.cudnn_batch_decode_with_kv_cache(
@@ -554,7 +561,11 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
             l2_flush_device=device,
             sleep_after_run=False,
             enable_cupti=args.use_cupti,
-            use_cuda_graph=(is_cuda_graph_compatible and cur_backend != "fa2"),
+            # "auto" may have resolved to AITER, whose launch grid is fixed at
+            # capture shapes; time it eagerly like fa2 rather than under a graph.
+            use_cuda_graph=(
+                is_cuda_graph_compatible and cur_backend not in ("fa2", "auto")
+            ),
         )
 
     # Perform reference check
@@ -622,6 +633,7 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
                 cur_res["tflops"] = tflops
                 cur_res["tb_per_sec"] = tb_per_sec
                 cur_res["backend"] = backend
+                record_backend_resolution(cur_res, backend_wrappers.get(backend))
                 cur_res["page_size"] = page_size
                 cur_res["batch_size"] = batch_size
                 cur_res["s_qo"] = s_qo
@@ -919,13 +931,14 @@ def testBatchPrefillWithPagedKVCacheWrapper(args):
     # Prepare wrappers
     backend_wrappers = {}
     for backend in backends:
-        if backend in ["fa2", "fa3", "trtllm-gen"]:
+        if backend in ["fa2", "fa3", "trtllm-gen", "auto"]:
+            # AITER paged prefill requires NHD; `auto` falls back to fa2 without it.
             backend_wrappers[backend] = (
                 flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
                     workspace_buffer,
-                    "HND",
+                    "NHD" if backend == "auto" else "HND",
                     use_cuda_graph=is_cuda_graph_compatible
-                    if backend != "fa2"
+                    if backend not in ("fa2", "auto")
                     else False,
                     qo_indptr_buf=qo_indptr,
                     paged_kv_indptr_buf=kv_indptr,
@@ -962,9 +975,10 @@ def testBatchPrefillWithPagedKVCacheWrapper(args):
         kv_cache = torch.cat([k_fp8, v_fp8], dim=1)
 
     def run_backend_wrapper(backend):
-        if backend in ["fa2", "fa3", "trtllm-gen"]:
+        if backend in ["fa2", "fa3", "trtllm-gen", "auto"]:
+            cache = as_nhd_paged_kv_cache(kv_cache) if backend == "auto" else kv_cache
             return backend_wrappers[backend].run(
-                q, kv_cache, k_scale=k_scale, v_scale=v_scale
+                q, cache, k_scale=k_scale, v_scale=v_scale
             )
         elif backend == "cudnn":
             return flashinfer.prefill.cudnn_batch_prefill_with_kv_cache(
@@ -1022,7 +1036,11 @@ def testBatchPrefillWithPagedKVCacheWrapper(args):
             l2_flush_device=device,
             sleep_after_run=False,
             enable_cupti=args.use_cupti,
-            use_cuda_graph=(is_cuda_graph_compatible and cur_backend != "fa2"),
+            # "auto" may have resolved to AITER, whose launch grid is fixed at
+            # capture shapes; time it eagerly like fa2 rather than under a graph.
+            use_cuda_graph=(
+                is_cuda_graph_compatible and cur_backend not in ("fa2", "auto")
+            ),
         )
 
     # Perform reference check
@@ -1091,6 +1109,7 @@ def testBatchPrefillWithPagedKVCacheWrapper(args):
                 cur_res["tflops"] = tflops
                 cur_res["tb_per_sec"] = tb_per_sec
                 cur_res["backend"] = backend
+                record_backend_resolution(cur_res, backend_wrappers.get(backend))
                 cur_res["page_size"] = page_size
                 cur_res["batch_size"] = batch_size
                 cur_res["s_qo"] = s_qo
@@ -1375,13 +1394,14 @@ def testBatchPrefillWithRaggedKVCacheWrapper(args):
     # Prepare wrappers
     backend_wrappers = {}
     for backend in backends:
-        if backend in ["cutlass", "fa2", "fa3", "trtllm-gen"]:
+        if backend in ["cutlass", "fa2", "fa3", "trtllm-gen", "auto"]:
+            # Already NHD, so `auto` only needs the graph capture suppressed.
             backend_wrappers[backend] = (
                 flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper(
                     workspace_buffer,
                     "NHD",
                     use_cuda_graph=is_cuda_graph_compatible
-                    if backend != "fa2"
+                    if backend not in ("fa2", "auto")
                     else False,
                     qo_indptr_buf=qo_indptr,
                     kv_indptr_buf=kv_indptr,
@@ -1410,7 +1430,7 @@ def testBatchPrefillWithRaggedKVCacheWrapper(args):
         v = (v / v_scale).to(kv_dtype)
 
     def run_backend_wrapper(backend):
-        if backend in ["cutlass", "fa2", "fa3", "trtllm-gen"]:
+        if backend in ["cutlass", "fa2", "fa3", "trtllm-gen", "auto"]:
             return backend_wrappers[backend].run_return_lse(q, k, v)[0]
         elif backend == "cudnn":
             return flashinfer.prefill.cudnn_batch_prefill_with_kv_cache(
@@ -1476,7 +1496,11 @@ def testBatchPrefillWithRaggedKVCacheWrapper(args):
             l2_flush_device=device,
             sleep_after_run=True,
             enable_cupti=args.use_cupti,
-            use_cuda_graph=(is_cuda_graph_compatible and cur_backend != "fa2"),
+            # "auto" may have resolved to AITER, whose launch grid is fixed at
+            # capture shapes; time it eagerly like fa2 rather than under a graph.
+            use_cuda_graph=(
+                is_cuda_graph_compatible and cur_backend not in ("fa2", "auto")
+            ),
         )
 
     # Perform reference check
@@ -1546,6 +1570,7 @@ def testBatchPrefillWithRaggedKVCacheWrapper(args):
                 cur_res["tflops"] = tflops
                 cur_res["tb_per_sec"] = tb_per_sec
                 cur_res["backend"] = backend
+                record_backend_resolution(cur_res, backend_wrappers.get(backend))
                 cur_res["page_size"] = 0  # No page size for ragged
                 cur_res["batch_size"] = batch_size
                 cur_res["s_qo"] = s_qo
@@ -1873,7 +1898,11 @@ def testBatchMLAPagedAttentionWrapper(args):
             l2_flush_device=device,
             sleep_after_run=False,
             enable_cupti=args.use_cupti,
-            use_cuda_graph=(is_cuda_graph_compatible and cur_backend != "fa2"),
+            # "auto" may have resolved to AITER, whose launch grid is fixed at
+            # capture shapes; time it eagerly like fa2 rather than under a graph.
+            use_cuda_graph=(
+                is_cuda_graph_compatible and cur_backend not in ("fa2", "auto")
+            ),
         )
 
     # Perform reference check

--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -20,6 +20,7 @@ from .flashinfer_benchmark_utils import (
     record_backend_resolution,
     bench_timing_kwargs,
     HIP_DECODE_GQA_GROUP_SIZES,
+    fa2_backed_backends,
 )
 from flashinfer.device_utils import IS_HIP
 
@@ -279,26 +280,27 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
 
     backends = filter_backends_by_compute_capability(backends, args.routine, device)
     # Check for backend-specific constraints
+    head_grp_size = num_qo_heads // num_kv_heads  # If 5, FA2 backend is not supported.
     if "fa2" in backends:
         remove_fa2 = False
-        head_grp_size = (
-            num_qo_heads // num_kv_heads
-        )  # If 5, FA2 backend is not supported.
         if head_grp_size == 5:
             print(
                 "[INFO] FA2 backend is not supported for this configuration. Skipping."
             )
             remove_fa2 = True
-        if IS_HIP and head_grp_size not in HIP_DECODE_GQA_GROUP_SIZES:
-            # DISPATCH_GQA_GROUP_SIZE covers {1,2,3,4,8}; anything else raises
-            # from inside the kernel and takes the whole row down with it.
-            print(
-                f"[INFO] FA2 backend does not support GQA group size "
-                f"{head_grp_size} on ROCm. Skipping."
-            )
-            remove_fa2 = True
         if remove_fa2:
             backends.remove("fa2")
+    if IS_HIP:
+        # DISPATCH_GQA_GROUP_SIZE covers a fixed set; anything else raises from
+        # inside the kernel and takes the whole test case down. "auto" inherits
+        # the constraint because it resolves to fa2 whenever AITER is declined.
+        for name in fa2_backed_backends(backends, device, "batch_decode"):
+            if head_grp_size not in HIP_DECODE_GQA_GROUP_SIZES:
+                print(
+                    f"[INFO] {name} runs the HIP kernel, which does not support "
+                    f"GQA group size {head_grp_size}. Skipping."
+                )
+                backends.remove(name)
 
     if "fa2_tc" in backends:
         remove_fa2_tc = False
@@ -517,9 +519,11 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
             v_fp8 = (v_data / v_scale).to(kv_dtype)
             kv_cache_for_trt = torch.cat([k_fp8, v_fp8], dim=1)
 
+    nhd_kv_cache = as_nhd_paged_kv_cache(kv_cache)
+
     def run_backend_wrapper(backend):
         if backend in ["fa2", "fa2_tc", "trtllm-gen", "auto"]:
-            cache = as_nhd_paged_kv_cache(kv_cache) if backend == "auto" else kv_cache
+            cache = nhd_kv_cache if backend == "auto" else kv_cache
             return backend_wrappers[backend].run(
                 q, cache, k_scale=k_scale, v_scale=v_scale
             )
@@ -981,9 +985,11 @@ def testBatchPrefillWithPagedKVCacheWrapper(args):
         v_fp8 = (v_data / v_scale).to(kv_dtype)
         kv_cache = torch.cat([k_fp8, v_fp8], dim=1)
 
+    nhd_kv_cache = as_nhd_paged_kv_cache(kv_cache)
+
     def run_backend_wrapper(backend):
         if backend in ["fa2", "fa3", "trtllm-gen", "auto"]:
-            cache = as_nhd_paged_kv_cache(kv_cache) if backend == "auto" else kv_cache
+            cache = nhd_kv_cache if backend == "auto" else kv_cache
             return backend_wrappers[backend].run(
                 q, cache, k_scale=k_scale, v_scale=v_scale
             )
@@ -1893,11 +1899,7 @@ def testBatchMLAPagedAttentionWrapper(args):
             **bench_timing_kwargs(args, device),
             sleep_after_run=False,
             enable_cupti=args.use_cupti,
-            # "auto" may have resolved to AITER, whose launch grid is fixed at
-            # capture shapes; time it eagerly like fa2 rather than under a graph.
-            use_cuda_graph=(
-                is_cuda_graph_compatible and cur_backend not in ("fa2", "auto")
-            ),
+            use_cuda_graph=(is_cuda_graph_compatible and cur_backend != "fa2"),
         )
 
     # Perform reference check

--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -18,6 +18,7 @@ from .flashinfer_benchmark_utils import (
     filter_backends_by_compute_capability,
     as_nhd_paged_kv_cache,
     record_backend_resolution,
+    bench_timing_kwargs,
 )
 
 
@@ -554,11 +555,7 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
         # Unified benchmark entry: prefer graph if compatible and not using CUPTI
         backend_times[cur_backend] = bench_gpu_time(
             fn=lambda: run_backend_wrapper(cur_backend),
-            dry_run_iters=args.dry_run_iters,
-            repeat_iters=args.num_iters,
-            l2_flush=True,
-            l2_flush_size_mb=256,
-            l2_flush_device=device,
+            **bench_timing_kwargs(args, device),
             sleep_after_run=False,
             enable_cupti=args.use_cupti,
             # "auto" may have resolved to AITER, whose launch grid is fixed at
@@ -1029,11 +1026,7 @@ def testBatchPrefillWithPagedKVCacheWrapper(args):
                 reference_output = outputs[cur_backend]
         backend_times[cur_backend] = bench_gpu_time(
             fn=lambda: run_backend_wrapper(cur_backend),
-            dry_run_iters=args.dry_run_iters,
-            repeat_iters=args.num_iters,
-            l2_flush=True,
-            l2_flush_size_mb=256,
-            l2_flush_device=device,
+            **bench_timing_kwargs(args, device),
             sleep_after_run=False,
             enable_cupti=args.use_cupti,
             # "auto" may have resolved to AITER, whose launch grid is fixed at
@@ -1489,11 +1482,7 @@ def testBatchPrefillWithRaggedKVCacheWrapper(args):
                 reference_output = outputs[cur_backend]
         backend_times[cur_backend] = bench_gpu_time(
             fn=lambda: run_backend_wrapper(cur_backend),
-            dry_run_iters=args.dry_run_iters,
-            repeat_iters=args.num_iters,
-            l2_flush=True,
-            l2_flush_size_mb=256,
-            l2_flush_device=device,
+            **bench_timing_kwargs(args, device),
             sleep_after_run=True,
             enable_cupti=args.use_cupti,
             # "auto" may have resolved to AITER, whose launch grid is fixed at
@@ -1891,11 +1880,7 @@ def testBatchMLAPagedAttentionWrapper(args):
                 reference_output = outputs[cur_backend]
         backend_times[cur_backend] = bench_gpu_time(
             fn=lambda: run_backend_wrapper(cur_backend),
-            dry_run_iters=args.dry_run_iters,
-            repeat_iters=args.num_iters,
-            l2_flush=True,
-            l2_flush_size_mb=256,
-            l2_flush_device=device,
+            **bench_timing_kwargs(args, device),
             sleep_after_run=False,
             enable_cupti=args.use_cupti,
             # "auto" may have resolved to AITER, whose launch grid is fixed at

--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -19,7 +19,9 @@ from .flashinfer_benchmark_utils import (
     as_nhd_paged_kv_cache,
     record_backend_resolution,
     bench_timing_kwargs,
+    HIP_DECODE_GQA_GROUP_SIZES,
 )
+from flashinfer.device_utils import IS_HIP
 
 
 def normalize_backends(backends):
@@ -285,6 +287,14 @@ def testBatchDecodeWithPagedKVCacheWrapper(args):
         if head_grp_size == 5:
             print(
                 "[INFO] FA2 backend is not supported for this configuration. Skipping."
+            )
+            remove_fa2 = True
+        if IS_HIP and head_grp_size not in HIP_DECODE_GQA_GROUP_SIZES:
+            # DISPATCH_GQA_GROUP_SIZE covers {1,2,3,4,8}; anything else raises
+            # from inside the kernel and takes the whole row down with it.
+            print(
+                f"[INFO] FA2 backend does not support GQA group size "
+                f"{head_grp_size} on ROCm. Skipping."
             )
             remove_fa2 = True
         if remove_fa2:

--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -314,6 +314,40 @@ def get_device_arch(device):
     return normalize_arch(torch.cuda.get_device_properties(device).gcnArchName)
 
 
+def l2_flush_size_mb():
+    """Flush-buffer size large enough to evict the device's last-level cache.
+
+    CDNA3 and CDNA4 both carry 256 MB of memory-side Infinity Cache, so the
+    upstream 256 MB buffer exactly equals capacity and leaves its own tail
+    resident. NVIDIA L2 is 40-126 MB, where 256 MB is already >= 2x.
+    """
+    return 512 if IS_HIP else 256
+
+
+def bench_timing_kwargs(args, device):
+    """Timing arguments shared by every bench_gpu_time call site.
+
+    `bench_gpu_time` honours a `*_time_ms` budget only when the matching
+    `*_iters` is None, so the two are mutually exclusive per phase. Passing
+    neither `--dry_run_time_ms` nor `--repeat_time_ms` reproduces the previous
+    iteration-count behaviour exactly.
+    """
+    kwargs = {
+        "dry_run_iters": args.dry_run_iters,
+        "repeat_iters": args.num_iters,
+        "l2_flush": True,
+        "l2_flush_size_mb": l2_flush_size_mb(),
+        "l2_flush_device": device,
+    }
+    if getattr(args, "dry_run_time_ms", None) is not None:
+        kwargs["dry_run_iters"] = None
+        kwargs["dry_run_time_ms"] = args.dry_run_time_ms
+    if getattr(args, "repeat_time_ms", None) is not None:
+        kwargs["repeat_iters"] = None
+        kwargs["repeat_time_ms"] = args.repeat_time_ms
+    return kwargs
+
+
 def as_nhd_paged_kv_cache(kv_cache):
     """View an HND-shaped ``[pages, 2, heads, page_size, dim]`` paged cache as NHD.
 

--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -14,6 +14,10 @@ output_column_dict = {
         "tflops",
         "tb_per_sec",
         "backend",
+        # What backend="auto" actually resolved to, and why it declined AITER.
+        # Empty on CUDA and for explicitly-named backends.
+        "backend_resolved",
+        "backend_fallback_reason",
     ],
     "attention": [
         "page_size",
@@ -310,6 +314,32 @@ def get_device_arch(device):
     return normalize_arch(torch.cuda.get_device_properties(device).gcnArchName)
 
 
+def as_nhd_paged_kv_cache(kv_cache):
+    """View an HND-shaped ``[pages, 2, heads, page_size, dim]`` paged cache as NHD.
+
+    A pure view: ``result[p, i, s, h]`` is ``kv_cache[p, i, h, s]``, the same
+    logical KV entry. The harness already lays this cache out NHD-ordered behind
+    an HND-shaped view, so the transpose is contiguous and copies nothing.
+    """
+    return kv_cache.transpose(2, 3)
+
+
+def record_backend_resolution(cur_res, wrapper):
+    """Record which backend a wrapper resolved to, and why it declined AITER.
+
+    Only the ROCm wrappers expose these; on CUDA both stay empty, as they do for
+    backends dispatched through a free function rather than a wrapper object.
+    """
+    if wrapper is None:
+        return
+    # `or ""` matters: the attribute exists and is None when auto did not decline,
+    # and str(None) would write the literal "None" into the CSV.
+    cur_res["backend_resolved"] = getattr(wrapper, "backend", "") or ""
+    cur_res["backend_fallback_reason"] = (
+        getattr(wrapper, "backend_fallback_reason", "") or ""
+    )
+
+
 def rocm_supported_backends(routine, device):
     """Backends this harness can run for ``routine`` on a ROCm ``device``.
 
@@ -319,7 +349,15 @@ def rocm_supported_backends(routine, device):
     op = _ROCM_ROUTINE_TO_CAP_OP.get(routine)
     if op is None:
         return []
-    return ["fa2"] if capability_available(device, op, "hip") else []
+    backends = []
+    if capability_available(device, op, "hip"):
+        # "auto" is always offered alongside fa2: when AITER is unavailable the
+        # selector falls back to fa2 and records why, which is a result worth
+        # having rather than a row that cannot run.
+        backends += ["fa2", "auto"]
+    if capability_available(device, op, "aiter"):
+        backends.append("aiter")
+    return backends
 
 
 def filter_backends_by_compute_capability(backends, routine, device):

--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -1,5 +1,7 @@
 import torch
 
+from flashinfer.arch_caps import capability_available, normalize_arch
+from flashinfer.device_utils import IS_HIP
 from flashinfer.testing.utils import set_seed
 from flashinfer.utils import get_compute_capability
 
@@ -291,15 +293,49 @@ routine_cc_to_supported_backends = {
 }
 
 
+# Benchmark routine -> the CAPABILITIES op key in flashinfer/arch_caps.py.
+# Deriving the ROCm backend list from that table rather than restating it keeps
+# this in step with the arch-support matrix its pre-commit hook guards.
+# BatchMLAPagedAttentionWrapper maps to op "mla", but is deliberately absent
+# until the mla_rocm ctor/run() divergence from the CUDA wrapper is resolved.
+_ROCM_ROUTINE_TO_CAP_OP = {
+    "BatchDecodeWithPagedKVCacheWrapper": "batch_decode",
+    "BatchPrefillWithPagedKVCacheWrapper": "batch_prefill",
+    "BatchPrefillWithRaggedKVCacheWrapper": "batch_prefill",
+}
+
+
+def get_device_arch(device):
+    """Normalized gfx architecture of ``device``, e.g. ``"gfx950"``."""
+    return normalize_arch(torch.cuda.get_device_properties(device).gcnArchName)
+
+
+def rocm_supported_backends(routine, device):
+    """Backends this harness can run for ``routine`` on a ROCm ``device``.
+
+    "fa2" is the harness's name for the in-tree HIP kernel -- the same backend
+    arch_caps calls "hip" and declares as the AITER rows' ``fallback``.
+    """
+    op = _ROCM_ROUTINE_TO_CAP_OP.get(routine)
+    if op is None:
+        return []
+    return ["fa2"] if capability_available(device, op, "hip") else []
+
+
 def filter_backends_by_compute_capability(backends, routine, device):
     # FlashInfer currently does not have an isSupported() function that checks support.
     # WAR: Use helper function to check support.
-    major, minor = get_compute_capability(device)
-    compute_capability = f"{major}.{minor}"
+    if IS_HIP:
+        # gfx942/gfx950 report compute capability 9.4/9.5, which match no entry
+        # in the NVIDIA table -- every backend would be stripped, including fa2.
+        target = get_device_arch(device)
+        supported_backends = rocm_supported_backends(routine, device)
+    else:
+        major, minor = get_compute_capability(device)
+        target = f"{major}.{minor}"
+        # If the compute capability is not supported, return an empty list.
+        supported_backends = routine_cc_to_supported_backends[routine].get(target, [])
 
-    # If the compute capability is not supported, return an empty list.
-    cc_to_supported_backends = routine_cc_to_supported_backends[routine]
-    supported_backends = cc_to_supported_backends.get(compute_capability, [])
     backends_to_remove = []
     for backend in backends:
         if backend not in supported_backends:
@@ -307,6 +343,6 @@ def filter_backends_by_compute_capability(backends, routine, device):
     for backend in backends_to_remove:
         backends.remove(backend)
         print(
-            f"[WARNING] {backend} for routine {routine} is not supported on compute capability {compute_capability}. Skipping."
+            f"[WARNING] {backend} for routine {routine} is not supported on {target}. Skipping."
         )
     return backends

--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -1,5 +1,6 @@
 import torch
 
+from flashinfer.aiter_utils import is_aiter_available
 from flashinfer.arch_caps import capability_available, normalize_arch
 from flashinfer.device_utils import IS_HIP
 from flashinfer.testing.utils import set_seed
@@ -297,11 +298,9 @@ routine_cc_to_supported_backends = {
 }
 
 
-# Benchmark routine -> the CAPABILITIES op key in flashinfer/arch_caps.py.
-# Deriving the ROCm backend list from that table rather than restating it keeps
-# this in step with the arch-support matrix its pre-commit hook guards.
-# BatchMLAPagedAttentionWrapper maps to op "mla", but is deliberately absent
-# until the mla_rocm ctor/run() divergence from the CUDA wrapper is resolved.
+# Benchmark routine -> the CAPABILITIES op key in flashinfer/arch_caps.py, so
+# the ROCm backend list derives from the arch-support matrix rather than
+# restating it. MLA is absent until mla_rocm matches the CUDA wrapper.
 _ROCM_ROUTINE_TO_CAP_OP = {
     "BatchDecodeWithPagedKVCacheWrapper": "batch_decode",
     "BatchPrefillWithPagedKVCacheWrapper": "batch_prefill",
@@ -310,8 +309,11 @@ _ROCM_ROUTINE_TO_CAP_OP = {
 
 
 def get_device_arch(device):
-    """Normalized gfx architecture of ``device``, e.g. ``"gfx950"``."""
-    return normalize_arch(torch.cuda.get_device_properties(device).gcnArchName)
+    """Normalized gfx architecture of ``device``, or ``"unknown"``."""
+    try:
+        return normalize_arch(torch.cuda.get_device_properties(device).gcnArchName)
+    except Exception:
+        return "unknown"
 
 
 # GQA group sizes the HIP decode kernel instantiates; see DISPATCH_GQA_GROUP_SIZE
@@ -323,9 +325,8 @@ HIP_DECODE_GQA_GROUP_SIZES = frozenset({1, 2, 3, 4, 8})
 def l2_flush_size_mb():
     """Flush-buffer size large enough to evict the device's last-level cache.
 
-    CDNA3 and CDNA4 both carry 256 MB of memory-side Infinity Cache, so the
-    upstream 256 MB buffer exactly equals capacity and leaves its own tail
-    resident. NVIDIA L2 is 40-126 MB, where 256 MB is already >= 2x.
+    CDNA's 256 MB Infinity Cache exactly equals the upstream buffer, which would
+    leave its own tail resident.
     """
     return 512 if IS_HIP else 256
 
@@ -334,9 +335,7 @@ def bench_timing_kwargs(args, device):
     """Timing arguments shared by every bench_gpu_time call site.
 
     `bench_gpu_time` honours a `*_time_ms` budget only when the matching
-    `*_iters` is None, so the two are mutually exclusive per phase. Passing
-    neither `--dry_run_time_ms` nor `--repeat_time_ms` reproduces the previous
-    iteration-count behaviour exactly.
+    `*_iters` is None, so the two are mutually exclusive per phase.
     """
     kwargs = {
         "dry_run_iters": args.dry_run_iters,
@@ -357,20 +356,18 @@ def bench_timing_kwargs(args, device):
 def as_nhd_paged_kv_cache(kv_cache):
     """View an HND-shaped ``[pages, 2, heads, page_size, dim]`` paged cache as NHD.
 
-    A pure view: ``result[p, i, s, h]`` is ``kv_cache[p, i, h, s]``, the same
-    logical KV entry. The harness already lays this cache out NHD-ordered behind
-    an HND-shaped view, so the transpose is contiguous and copies nothing.
+    ``result[p, i, s, h]`` is ``kv_cache[p, i, h, s]`` -- the same logical entry.
+    Zero-copy, and contiguous when the caller built the cache NHD-ordered.
     """
     return kv_cache.transpose(2, 3)
 
 
 def record_backend_resolution(cur_res, wrapper):
-    """Record which backend a wrapper resolved to, and why it declined AITER.
+    """Record what ``auto`` resolved to, and why it declined AITER.
 
-    Only the ROCm wrappers expose these; on CUDA both stay empty, as they do for
-    backends dispatched through a free function rather than a wrapper object.
+    Only meaningful for ``auto``: an explicit backend resolves to itself.
     """
-    if wrapper is None:
+    if wrapper is None or cur_res.get("backend") != "auto":
         return
     # `or ""` matters: the attribute exists and is None when auto did not decline,
     # and str(None) would write the literal "None" into the CSV.
@@ -378,6 +375,29 @@ def record_backend_resolution(cur_res, wrapper):
     cur_res["backend_fallback_reason"] = (
         getattr(wrapper, "backend_fallback_reason", "") or ""
     )
+
+
+def aiter_serves(device, op):
+    """Whether ``auto`` can actually reach AITER for ``op`` on ``device``.
+
+    ``capability_available`` answers only the architecture and known-bad
+    question; ``is_aiter_available`` also requires the package to import, which
+    is what the selector really gates on.
+    """
+    return is_aiter_available(device, op)
+
+
+def fa2_backed_backends(backends, device, op):
+    """Requested backends that will execute the in-tree HIP kernel.
+
+    "auto" belongs here whenever AITER cannot serve the call, since the selector
+    then resolves it to fa2 -- so it inherits every fa2 constraint. Returns a
+    list so callers may mutate ``backends`` while iterating.
+    """
+    names = [b for b in backends if b == "fa2"]
+    if "auto" in backends and not aiter_serves(device, op):
+        names.append("auto")
+    return names
 
 
 def rocm_supported_backends(routine, device):
@@ -395,7 +415,7 @@ def rocm_supported_backends(routine, device):
         # selector falls back to fa2 and records why, which is a result worth
         # having rather than a row that cannot run.
         backends += ["fa2", "auto"]
-    if capability_available(device, op, "aiter"):
+    if aiter_serves(device, op):
         backends.append("aiter")
     return backends
 
@@ -406,11 +426,11 @@ def filter_backends_by_compute_capability(backends, routine, device):
     if IS_HIP:
         # gfx942/gfx950 report compute capability 9.4/9.5, which match no entry
         # in the NVIDIA table -- every backend would be stripped, including fa2.
-        target = get_device_arch(device)
+        target = f"architecture {get_device_arch(device)}"
         supported_backends = rocm_supported_backends(routine, device)
     else:
         major, minor = get_compute_capability(device)
-        target = f"{major}.{minor}"
+        target = f"compute capability {major}.{minor}"
         # If the compute capability is not supported, return an empty list.
         supported_backends = routine_cc_to_supported_backends[routine].get(target, [])
 

--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -314,6 +314,12 @@ def get_device_arch(device):
     return normalize_arch(torch.cuda.get_device_properties(device).gcnArchName)
 
 
+# GQA group sizes the HIP decode kernel instantiates; see DISPATCH_GQA_GROUP_SIZE
+# in include/flashinfer/utils.cuh. Others raise "Unsupported group_size" from the
+# kernel, which aborts the whole test case rather than skipping one backend.
+HIP_DECODE_GQA_GROUP_SIZES = frozenset({1, 2, 3, 4, 8})
+
+
 def l2_flush_size_mb():
     """Flush-buffer size large enough to evict the device's last-level cache.
 

--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -409,15 +409,13 @@ def rocm_supported_backends(routine, device):
     op = _ROCM_ROUTINE_TO_CAP_OP.get(routine)
     if op is None:
         return []
-    backends = []
+    # AITER is reached through "auto", which records what it resolved to, so
+    # "aiter" is deliberately not offered: the attention routines have no
+    # construction or dispatch path for it, and advertising it here would let a
+    # backend through the filter that argparse rejects and no wrapper builds.
     if capability_available(device, op, "hip"):
-        # "auto" is always offered alongside fa2: when AITER is unavailable the
-        # selector falls back to fa2 and records why, which is a result worth
-        # having rather than a row that cannot run.
-        backends += ["fa2", "auto"]
-    if aiter_serves(device, op):
-        backends.append("aiter")
-    return backends
+        return ["fa2", "auto"]
+    return []
 
 
 def filter_backends_by_compute_capability(backends, routine, device):

--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -426,11 +426,13 @@ def filter_backends_by_compute_capability(backends, routine, device):
     if IS_HIP:
         # gfx942/gfx950 report compute capability 9.4/9.5, which match no entry
         # in the NVIDIA table -- every backend would be stripped, including fa2.
-        target = f"architecture {get_device_arch(device)}"
+        target = get_device_arch(device)
+        label = f"architecture {target}"
         supported_backends = rocm_supported_backends(routine, device)
     else:
         major, minor = get_compute_capability(device)
-        target = f"compute capability {major}.{minor}"
+        target = f"{major}.{minor}"
+        label = f"compute capability {target}"
         # If the compute capability is not supported, return an empty list.
         supported_backends = routine_cc_to_supported_backends[routine].get(target, [])
 
@@ -441,6 +443,6 @@ def filter_backends_by_compute_capability(backends, routine, device):
     for backend in backends_to_remove:
         backends.remove(backend)
         print(
-            f"[WARNING] {backend} for routine {routine} is not supported on {target}. Skipping."
+            f"[WARNING] {backend} for routine {routine} is not supported on {label}. Skipping."
         )
     return backends

--- a/flashinfer/decode_rocm.py
+++ b/flashinfer/decode_rocm.py
@@ -935,6 +935,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     device=float_workspace_buffer.device,
                 )
         self._backend = backend
+        self._backend_fallback_reason: Optional[str] = None
         # ROCm never supports PDL; cache once to avoid per-call device property lookup.
         self._pdl_supported = device_support_pdl(float_workspace_buffer.device)
 
@@ -945,6 +946,21 @@ class BatchDecodeWithPagedKVCacheWrapper:
     @property
     def is_cuda_graph_enabled(self) -> bool:
         return self._use_cuda_graph
+
+    @property
+    def backend(self) -> str:
+        """The backend in use -- concrete after :meth:`plan`, ``"auto"`` before it."""
+        return self._backend
+
+    @property
+    def backend_fallback_reason(self) -> Optional[str]:
+        """Why ``auto`` declined AITER, or ``None`` if it did not.
+
+        Only set by the ``auto`` constraint check. An explicit ``backend=`` leaves
+        it ``None``, as do the short-circuits that keep ``auto`` on fa2 under
+        ``use_tensor_cores`` or CUDA-graph capture.
+        """
+        return self._backend_fallback_reason
 
     def reset_workspace_buffer(
         self, float_workspace_buffer: torch.Tensor, int_workspace_buffer: torch.Tensor
@@ -1140,18 +1156,20 @@ class BatchDecodeWithPagedKVCacheWrapper:
             if self.use_tensor_cores or self.is_cuda_graph_enabled:
                 self._backend = "fa2"
             else:
-                self._backend = _auto_select_prefill_backend(
-                    self.device,
-                    dtype_q=q_data_type,
-                    dtype_kv=kv_data_type,
-                    kv_layout=self._kv_layout,
-                    has_custom_mask=False,
-                    head_dim_qk=head_dim,
-                    head_dim_vo=head_dim,
-                    pos_encoding_mode=pos_encoding_mode,
-                    # Decode borrows the prefill selector, but it is a distinct
-                    # capability row -- the gates are not the same op.
-                    op="batch_decode",
+                self._backend, self._backend_fallback_reason = (
+                    _auto_select_prefill_backend(
+                        self.device,
+                        dtype_q=q_data_type,
+                        dtype_kv=kv_data_type,
+                        kv_layout=self._kv_layout,
+                        has_custom_mask=False,
+                        head_dim_qk=head_dim,
+                        head_dim_vo=head_dim,
+                        pos_encoding_mode=pos_encoding_mode,
+                        # Decode borrows the prefill selector, but it is a distinct
+                        # capability row -- the gates are not the same op.
+                        op="batch_decode",
+                    )
                 )
         if self._backend == "aiter":
             if self.use_tensor_cores:

--- a/flashinfer/decode_rocm.py
+++ b/flashinfer/decode_rocm.py
@@ -956,9 +956,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
     def backend_fallback_reason(self) -> Optional[str]:
         """Why ``auto`` declined AITER, or ``None`` if it did not.
 
-        Only set by the ``auto`` constraint check. An explicit ``backend=`` leaves
-        it ``None``, as do the short-circuits that keep ``auto`` on fa2 under
-        ``use_tensor_cores`` or CUDA-graph capture.
+        Set only by the ``auto`` constraint check; an explicit ``backend=`` and
+        the ``use_tensor_cores`` / graph-capture short-circuits leave it ``None``.
         """
         return self._backend_fallback_reason
 

--- a/flashinfer/prefill_rocm.py
+++ b/flashinfer/prefill_rocm.py
@@ -339,8 +339,9 @@ def _auto_select_prefill_backend(
     head_dim_vo: int,
     pos_encoding_mode: str = "NONE",
     op: str = "batch_prefill",
-) -> str:
-    """Return 'aiter' when the GPU and call parameters satisfy AITER's constraints; else 'fa2'.
+) -> Tuple[str, Optional[str]]:
+    """Return ``(backend, reason)``: 'aiter' when the GPU and call parameters satisfy
+    AITER's constraints, else 'fa2' plus the reason AITER was declined.
 
     On gfx942/gfx950, checks NHD layout, no custom mask, fp16/bf16, equal dtypes and head dims.
     Falls back to 'fa2' with a one-time warning for each distinct skip reason.
@@ -349,6 +350,10 @@ def _auto_select_prefill_backend(
     uniform across ops: the ROCm 7.2 causal miscompile on gfx950 applies to batch
     prefill only, so checking a single shared "is AITER supported here" would
     either under- or over-block.
+
+    The warning fires once per ``(device, reason)`` for the process lifetime, so a
+    caller that needs the reason on *every* call must read it from the return
+    value -- the log carries it only the first time.
     """
     # The capability gate is just one more reason, so an architecture or
     # toolchain that cannot serve this op warns once and falls back like any
@@ -377,19 +382,20 @@ def _auto_select_prefill_backend(
         if key not in _aiter_auto_warned:
             _aiter_auto_warned.add(key)
             logger.warning("auto backend falling back to fa2: %s", reason)
-        return "fa2"
+        return "fa2", reason
 
     if not _aiter_ops_importable():
+        reason = (
+            "aiter package not installed "
+            "(see https://github.com/ROCm/aiter for install instructions)"
+        )
         key = (device, "import_failed")
         if key not in _aiter_auto_warned:
             _aiter_auto_warned.add(key)
-            logger.warning(
-                "auto backend falling back to fa2: aiter package not installed "
-                "(see https://github.com/ROCm/aiter for install instructions)"
-            )
-        return "fa2"
+            logger.warning("auto backend falling back to fa2: %s", reason)
+        return "fa2", reason
 
-    return "aiter"
+    return "aiter", None
 
 
 _aiter_bootstrap_lock = threading.Lock()
@@ -1431,7 +1437,7 @@ def single_prefill_with_kv_cache(
             scale_v = torch.ones(v.shape[1], dtype=torch.float32, device=q.device)
 
     if backend == "auto":
-        backend = _auto_select_prefill_backend(
+        backend, _ = _auto_select_prefill_backend(
             q.device,
             dtype_q=q.dtype,
             dtype_kv=k.dtype,
@@ -1793,6 +1799,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._mask_indptr_buf = mask_indptr_buf
         self._max_total_num_rows = None
         self._backend = backend
+        self._backend_fallback_reason: Optional[str] = None
         self._plan_info: Optional[torch.Tensor] = None
         self._cached_module = None
         self._seq_lens_kv = None
@@ -1806,6 +1813,20 @@ class BatchPrefillWithPagedKVCacheWrapper:
     @property
     def is_cuda_graph_enabled(self) -> bool:
         return self._use_cuda_graph
+
+    @property
+    def backend(self) -> str:
+        """The backend in use -- concrete after :meth:`plan`, ``"auto"`` before it."""
+        return self._backend
+
+    @property
+    def backend_fallback_reason(self) -> Optional[str]:
+        """Why ``auto`` declined AITER, or ``None`` if it did not.
+
+        Only set by the ``auto`` constraint check; an explicit ``backend=``
+        leaves it ``None``.
+        """
+        return self._backend_fallback_reason
 
     def reset_workspace_buffer(
         self, float_workspace_buffer: torch.Tensor, int_workspace_buffer: torch.Tensor
@@ -2114,16 +2135,18 @@ class BatchPrefillWithPagedKVCacheWrapper:
             self._cached_module = self._jit_module
         else:
             if self._backend == "auto":
-                self._backend = _auto_select_prefill_backend(
-                    self.device,
-                    dtype_q=q_data_type,
-                    dtype_kv=kv_data_type,
-                    kv_layout=self._kv_layout,
-                    has_custom_mask=self._custom_mask_buf is not None,
-                    head_dim_qk=head_dim_qk,
-                    head_dim_vo=head_dim_vo,
-                    pos_encoding_mode=pos_encoding_mode,
-                    op="batch_prefill",
+                self._backend, self._backend_fallback_reason = (
+                    _auto_select_prefill_backend(
+                        self.device,
+                        dtype_q=q_data_type,
+                        dtype_kv=kv_data_type,
+                        kv_layout=self._kv_layout,
+                        has_custom_mask=self._custom_mask_buf is not None,
+                        head_dim_qk=head_dim_qk,
+                        head_dim_vo=head_dim_vo,
+                        pos_encoding_mode=pos_encoding_mode,
+                        op="batch_prefill",
+                    )
                 )
             if self._backend == "aiter" and pos_encoding_mode != "NONE":
                 raise ValueError(
@@ -2832,12 +2855,27 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._mask_indptr_buf = mask_indptr_buf
         self._max_total_num_rows = None
         self._backend = backend
+        self._backend_fallback_reason: Optional[str] = None
         self._plan_info: Optional[torch.Tensor] = None
         self._cached_module = None
 
     @property
     def is_cuda_graph_enabled(self) -> bool:
         return self._use_cuda_graph
+
+    @property
+    def backend(self) -> str:
+        """The backend in use -- concrete after :meth:`plan`, ``"auto"`` before it."""
+        return self._backend
+
+    @property
+    def backend_fallback_reason(self) -> Optional[str]:
+        """Why ``auto`` declined AITER, or ``None`` if it did not.
+
+        Only set by the ``auto`` constraint check; an explicit ``backend=``
+        leaves it ``None``.
+        """
+        return self._backend_fallback_reason
 
     def reset_workspace_buffer(
         self, float_workspace_buffer: torch.Tensor, int_workspace_buffer
@@ -3073,16 +3111,18 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             self._cached_module = self._jit_module
         else:
             if self._backend == "auto":
-                self._backend = _auto_select_prefill_backend(
-                    self.device,
-                    dtype_q=q_data_type,
-                    dtype_kv=kv_data_type,
-                    kv_layout=self._kv_layout,
-                    has_custom_mask=packed_custom_mask is not None,
-                    head_dim_qk=head_dim_qk,
-                    head_dim_vo=head_dim_vo,
-                    pos_encoding_mode=pos_encoding_mode,
-                    op="batch_prefill",
+                self._backend, self._backend_fallback_reason = (
+                    _auto_select_prefill_backend(
+                        self.device,
+                        dtype_q=q_data_type,
+                        dtype_kv=kv_data_type,
+                        kv_layout=self._kv_layout,
+                        has_custom_mask=packed_custom_mask is not None,
+                        head_dim_qk=head_dim_qk,
+                        head_dim_vo=head_dim_vo,
+                        pos_encoding_mode=pos_encoding_mode,
+                        op="batch_prefill",
+                    )
                 )
             if self._backend == "aiter" and pos_encoding_mode != "NONE":
                 raise ValueError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ filterwarnings = [
 # avoids __init__.py package-root walk.
 addopts = "-q -rfE --tb=short --import-mode=importlib"
 norecursedirs = ["test_helpers"]
-pythonpath = ["tests", "tests/test_helpers"]
+pythonpath = ["tests", "tests/test_helpers", "benchmarks"]
 # AMD/HIP test suite: rocm_tests/ directory for all AMD-authored tests,
 # plus explicit upstream test paths that are verified HIP-compatible.
 # Running 'pytest' with no args runs exactly these tests.

--- a/rocm_profiler/rocm_profiler.py
+++ b/rocm_profiler/rocm_profiler.py
@@ -162,6 +162,9 @@ class HardwareCeilings:
         return self.peak_tflops_fp16 / self.peak_bw_tbs
 
 
+# Peak FP16 matrix TFLOPS (dense) and HBM bandwidth. An arch key cannot separate
+# SKUs sharing it, so each entry is its arch's slower member -- utilisation
+# against these ceilings is an upper bound on the faster part.
 KNOWN_HW: dict[str, HardwareCeilings] = {
     # gfx950 covers both MI350X (1 kW air) and MI355X (1.4 kW liquid); they
     # differ only in clock, so the lower MI350X matrix peak is used and a
@@ -1016,7 +1019,38 @@ def _detect_rocm_lib_path() -> str | None:
 
 
 def _detect_hw_ceilings() -> HardwareCeilings | None:
-    """Query rocminfo to identify GPU arch and return matching hardware ceilings."""
+    """Identify the GPU arch and return matching hardware ceilings.
+
+    Prefers torch's device properties over rocminfo: it reports the device this
+    process will actually run on, whereas the rocminfo scrape takes whichever
+    agent is listed first and ignores HIP_VISIBLE_DEVICES.
+    """
+    try:
+        import torch
+
+        from flashinfer.arch_caps import normalize_arch
+
+        arch = normalize_arch(torch.cuda.get_device_properties(0).gcnArchName)
+    except Exception:
+        arch = None
+
+    if arch is not None:
+        if arch in KNOWN_HW:
+            hw = KNOWN_HW[arch]
+            print(
+                f"[rocm_profiler] Detected GPU: {hw.gpu_name} ({arch})  "
+                f"peak={hw.peak_tflops_fp16:.0f} TFLOPS  "
+                f"BW={hw.peak_bw_tbs:.1f} TB/s  "
+                f"ridge≈{hw.ridge_flops_per_byte:.0f} FLOPs/B"
+            )
+            return hw
+        print(
+            f"[rocm_profiler] WARNING: GPU arch '{arch}' not in KNOWN_HW. "
+            "Roofline will not show hardware ceilings.",
+            file=sys.stderr,
+        )
+        return None
+
     try:
         result = subprocess.run(
             ["rocminfo"],

--- a/rocm_profiler/rocm_profiler.py
+++ b/rocm_profiler/rocm_profiler.py
@@ -1018,6 +1018,25 @@ def _detect_rocm_lib_path() -> str | None:
     return None
 
 
+def _report_ceilings(arch: str) -> HardwareCeilings | None:
+    """Announce the ceilings for ``arch``, or warn that there are none."""
+    hw = KNOWN_HW.get(arch)
+    if hw is None:
+        print(
+            f"[rocm_profiler] WARNING: GPU arch '{arch}' not in KNOWN_HW. "
+            "Roofline will not show hardware ceilings.",
+            file=sys.stderr,
+        )
+        return None
+    print(
+        f"[rocm_profiler] Detected GPU: {hw.gpu_name} ({arch})  "
+        f"peak={hw.peak_tflops_fp16:.0f} TFLOPS  "
+        f"BW={hw.peak_bw_tbs:.1f} TB/s  "
+        f"ridge≈{hw.ridge_flops_per_byte:.0f} FLOPs/B"
+    )
+    return hw
+
+
 def _detect_hw_ceilings() -> HardwareCeilings | None:
     """Identify the GPU arch and return matching hardware ceilings.
 
@@ -1034,22 +1053,8 @@ def _detect_hw_ceilings() -> HardwareCeilings | None:
     except Exception:
         arch = None
 
-    if arch is not None:
-        if arch in KNOWN_HW:
-            hw = KNOWN_HW[arch]
-            print(
-                f"[rocm_profiler] Detected GPU: {hw.gpu_name} ({arch})  "
-                f"peak={hw.peak_tflops_fp16:.0f} TFLOPS  "
-                f"BW={hw.peak_bw_tbs:.1f} TB/s  "
-                f"ridge≈{hw.ridge_flops_per_byte:.0f} FLOPs/B"
-            )
-            return hw
-        print(
-            f"[rocm_profiler] WARNING: GPU arch '{arch}' not in KNOWN_HW. "
-            "Roofline will not show hardware ceilings.",
-            file=sys.stderr,
-        )
-        return None
+    if arch in KNOWN_HW:
+        return _report_ceilings(arch)
 
     try:
         result = subprocess.run(
@@ -1060,21 +1065,7 @@ def _detect_hw_ceilings() -> HardwareCeilings | None:
         )
         match = re.search(r"(gfx\w+)", result.stdout)
         if match:
-            arch = match.group(1)
-            if arch in KNOWN_HW:
-                hw = KNOWN_HW[arch]
-                print(
-                    f"[rocm_profiler] Detected GPU: {hw.gpu_name} ({arch})  "
-                    f"peak={hw.peak_tflops_fp16:.0f} TFLOPS  "
-                    f"BW={hw.peak_bw_tbs:.1f} TB/s  "
-                    f"ridge≈{hw.ridge_flops_per_byte:.0f} FLOPs/B"
-                )
-                return hw
-            print(
-                f"[rocm_profiler] WARNING: GPU arch '{arch}' not in KNOWN_HW. "
-                "Roofline will not show hardware ceilings.",
-                file=sys.stderr,
-            )
+            return _report_ceilings(match.group(1))
     except FileNotFoundError:
         print(
             "[rocm_profiler] WARNING: rocminfo not found. "

--- a/tests/rocm_tests/test_benchmark_harness_hip.py
+++ b/tests/rocm_tests/test_benchmark_harness_hip.py
@@ -142,6 +142,35 @@ def test_hip_gqa_group_sizes_match_the_kernel_dispatch():
     assert 128 // 8 not in from_kernel
 
 
+def test_auto_inherits_fa2_constraints_when_aiter_cannot_serve():
+    """`auto` resolves to fa2 when AITER is declined, so it inherits fa2's limits.
+
+    Guarding only the literal "fa2" leaves `auto` to reach a kernel that aborts
+    the whole test case -- exactly the crash the group-size guard prevents.
+    """
+    u = _utils()
+    device = torch.device("cuda")
+    for op in ("batch_decode", "batch_prefill"):
+        backed = u.fa2_backed_backends(["fa2", "auto"], device, op)
+        assert "fa2" in backed
+        assert ("auto" in backed) is not u.aiter_serves(device, op)
+
+
+def test_resolution_is_recorded_only_for_auto():
+    """An explicit backend resolves to itself; filling the column for it would
+    make every fa2 row match the README's "investigate this" signature."""
+    u = _utils()
+
+    class _Wrapper:
+        backend = "fa2"
+        backend_fallback_reason = None
+
+    for requested, expected in (("fa2", ""), ("auto", "fa2")):
+        row = {"backend": requested, "backend_resolved": "", "fallback": ""}
+        u.record_backend_resolution(row, _Wrapper())
+        assert row["backend_resolved"] == expected
+
+
 def test_timing_kwargs_default_to_iteration_counts():
     """Passing no time budget must reproduce the previous behaviour exactly."""
     u = _utils()

--- a/tests/rocm_tests/test_benchmark_harness_hip.py
+++ b/tests/rocm_tests/test_benchmark_harness_hip.py
@@ -142,6 +142,23 @@ def test_hip_gqa_group_sizes_match_the_kernel_dispatch():
     assert 128 // 8 not in from_kernel
 
 
+def test_cuda_path_still_matches_its_table(monkeypatch):
+    """The CUDA table is keyed "10.0", so the lookup may not use the warning text.
+
+    Forces the non-HIP branch on a ROCm box, since the defect is in the lookup
+    rather than the device: reusing one variable for both the dict key and the
+    "not supported on ..." message strips every backend on NVIDIA -- the exact
+    failure this branch exists to fix for AMD.
+    """
+    u = _utils()
+    monkeypatch.setattr(u, "IS_HIP", False)
+    monkeypatch.setattr(u, "get_compute_capability", lambda device: (10, 0))
+    kept = u.filter_backends_by_compute_capability(
+        ["fa2", "cudnn"], "BatchDecodeWithPagedKVCacheWrapper", torch.device("cuda")
+    )
+    assert kept == ["fa2", "cudnn"]
+
+
 def test_auto_inherits_fa2_constraints_when_aiter_cannot_serve():
     """`auto` resolves to fa2 when AITER is declined, so it inherits fa2's limits.
 

--- a/tests/rocm_tests/test_benchmark_harness_hip.py
+++ b/tests/rocm_tests/test_benchmark_harness_hip.py
@@ -142,6 +142,39 @@ def test_hip_gqa_group_sizes_match_the_kernel_dispatch():
     assert 128 // 8 not in from_kernel
 
 
+def _backend_choices():
+    """The values attention.py's `--backends` will accept."""
+    import argparse
+    import contextlib
+
+    import routines.attention as attention
+
+    parser = argparse.ArgumentParser()
+    # argparse may reject the stub argv; the action is registered either way.
+    with contextlib.suppress(SystemExit):
+        attention.parse_attention_args(
+            ["--routine", "BatchDecodeWithPagedKVCacheWrapper"], parser
+        )
+    for action in parser._actions:
+        if action.dest == "backends":
+            return set(action.choices)
+    raise AssertionError("--backends action not registered")
+
+
+@pytest.mark.parametrize("routine", ATTENTION_ROUTINES)
+def test_filter_only_offers_backends_the_cli_accepts(routine):
+    """Whatever survives the filter must be a backend attention.py can dispatch.
+
+    Offering one that argparse rejects, or that no wrapper branch constructs,
+    turns a supported configuration into a silently missing CSV row.
+    """
+    u = _utils()
+    offered = u.rocm_supported_backends(routine, torch.device("cuda"))
+    assert offered, f"{routine} offers no backend at all on this device"
+    unknown = set(offered) - _backend_choices()
+    assert not unknown, f"{unknown} survive the filter but --backends rejects them"
+
+
 def test_cuda_path_still_matches_its_table(monkeypatch):
     """The CUDA table is keyed "10.0", so the lookup may not use the warning text.
 

--- a/tests/rocm_tests/test_benchmark_harness_hip.py
+++ b/tests/rocm_tests/test_benchmark_harness_hip.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Guards for the ROCm path of benchmarks/flashinfer_benchmark.py. Each of these
+# covers a failure mode that is silent: a zero-row CSV, a mislabelled backend, or
+# a row whose fields have shifted. None of them announce themselves as errors.
+
+import csv
+import io
+
+import pytest
+import torch
+
+from flashinfer.device_utils import IS_HIP
+
+pytestmark = pytest.mark.skipif(not IS_HIP, reason="ROCm-only benchmark harness path")
+
+ATTENTION_ROUTINES = [
+    "BatchDecodeWithPagedKVCacheWrapper",
+    "BatchPrefillWithPagedKVCacheWrapper",
+    "BatchPrefillWithRaggedKVCacheWrapper",
+]
+
+
+def _utils():
+    from routines import flashinfer_benchmark_utils as u
+
+    return u
+
+
+@pytest.mark.parametrize("routine", ATTENTION_ROUTINES)
+def test_fa2_survives_the_backend_filter(routine):
+    """gfx942/gfx950 report CC 9.4/9.5, absent from the NVIDIA table.
+
+    Before the arch-keyed branch this stripped every backend including fa2, and
+    the run ended with "No backends to test" and a zero-row CSV rather than a
+    failure.
+    """
+    u = _utils()
+    device = torch.device("cuda")
+    assert "fa2" in u.filter_backends_by_compute_capability(["fa2"], routine, device)
+
+
+@pytest.mark.parametrize("routine", ["bmm_fp8", "cutlass_fused_moe"])
+def test_unported_routines_filter_to_empty(routine):
+    """Routines with no ROCm port resolve to an empty list, not a KeyError."""
+    u = _utils()
+    device = torch.device("cuda")
+    assert u.filter_backends_by_compute_capability(["cudnn"], routine, device) == []
+
+
+def test_benchmark_module_imports():
+    """routines.moe imports CUDA-only symbols; unguarded it broke every routine."""
+    import flashinfer_benchmark
+
+    assert callable(flashinfer_benchmark.run_test)
+
+
+def test_unavailable_routine_group_reports_the_original_error():
+    import flashinfer_benchmark
+
+    if "moe" not in flashinfer_benchmark._ROUTINE_IMPORT_ERRORS:
+        pytest.skip("routines.moe imported successfully on this build")
+    with pytest.raises(RuntimeError, match="unavailable on this platform"):
+        flashinfer_benchmark.require_routine_group("moe")
+
+
+def test_nhd_view_is_an_exact_zero_copy_permutation():
+    """The auto path feeds AITER this view instead of rebuilding the cache.
+
+    A wrong permutation would still run and still produce plausible timings, so
+    the exactness is the whole safety argument.
+    """
+    u = _utils()
+    pages, heads, page_size, dim = 3, 4, 8, 16
+    base = torch.randn(pages, 2, heads, page_size, dim)
+    hnd = base.as_strided(
+        base.shape,
+        (
+            2 * page_size * heads * dim,
+            page_size * heads * dim,
+            dim,
+            heads * dim,
+            1,
+        ),
+    )
+    nhd = u.as_nhd_paged_kv_cache(hnd)
+
+    assert nhd.shape == (pages, 2, page_size, heads, dim)
+    assert nhd.is_contiguous()
+    assert nhd.data_ptr() == hnd.data_ptr()
+    for h in range(heads):
+        for s in range(page_size):
+            assert torch.equal(nhd[:, :, s, h], hnd[:, :, h, s])
+
+
+def test_result_row_survives_a_comma_in_the_fallback_reason():
+    """arch_caps' known-bad reason contains commas; a bare "," join splits it."""
+    reason = (
+        "causal=True is miscompiled on ROCm 7.2.x (not an error), 97.6% of "
+        "elements off. Use ROCm 7.1, or backend='fa2'"
+    )
+    header = ["routine", "backend_fallback_reason", "tflops"]
+    values = ["BatchPrefill", reason, "5.4"]
+
+    buf = io.StringIO()
+    writer = csv.writer(buf, lineterminator="\n")
+    writer.writerow(header)
+    writer.writerow(values)
+
+    parsed = next(csv.DictReader(io.StringIO(buf.getvalue())))
+    assert parsed["backend_fallback_reason"] == reason
+    assert parsed["tflops"] == "5.4"
+    # The naive join this replaced produced 5 fields for these 3 columns.
+    assert len(",".join(values).split(",")) > len(header)
+
+
+def test_hip_gqa_group_sizes_match_the_kernel_dispatch():
+    """The harness constant must track DISPATCH_GQA_GROUP_SIZE, not just look right.
+
+    A group size outside the macro raises from inside the kernel and takes the
+    whole test case down, so the harness drops fa2 first. If someone extends the
+    macro and not the constant, the benchmark silently stops measuring shapes
+    that became supported -- read the header rather than restate its contents.
+    """
+    import re
+    from pathlib import Path
+
+    import flashinfer
+
+    header = Path(flashinfer.get_include()) / "flashinfer" / "utils.cuh"
+    if not header.is_file():
+        pytest.skip(f"kernel header not present at {header}")
+    body = header.read_text()
+    macro = body[body.index("#define DISPATCH_GQA_GROUP_SIZE") :]
+    macro = macro[: macro.index("#define", 1)]
+    from_kernel = {int(n) for n in re.findall(r"group_size == (\d+)", macro)}
+
+    assert from_kernel, "could not parse DISPATCH_GQA_GROUP_SIZE"
+    assert frozenset(from_kernel) == _utils().HIP_DECODE_GQA_GROUP_SIZES
+    # Llama-3.1-405B is 128 qo / 8 kv heads, i.e. group size 16.
+    assert 128 // 8 not in from_kernel
+
+
+def test_timing_kwargs_default_to_iteration_counts():
+    """Passing no time budget must reproduce the previous behaviour exactly."""
+    u = _utils()
+    args = pytest.importorskip("argparse").Namespace(
+        dry_run_iters=5, num_iters=30, dry_run_time_ms=None, repeat_time_ms=None
+    )
+    kwargs = u.bench_timing_kwargs(args, torch.device("cuda"))
+    assert kwargs["dry_run_iters"] == 5
+    assert kwargs["repeat_iters"] == 30
+    assert "dry_run_time_ms" not in kwargs
+    # 256 MB exactly equals CDNA's Infinity Cache, leaving its own tail resident.
+    assert kwargs["l2_flush_size_mb"] > 256
+
+
+def test_time_budget_overrides_the_matching_iteration_count():
+    """bench_gpu_time honours *_time_ms only when the matching *_iters is None."""
+    u = _utils()
+    args = pytest.importorskip("argparse").Namespace(
+        dry_run_iters=5, num_iters=30, dry_run_time_ms=250, repeat_time_ms=None
+    )
+    kwargs = u.bench_timing_kwargs(args, torch.device("cuda"))
+    assert kwargs["dry_run_iters"] is None
+    assert kwargs["dry_run_time_ms"] == 250
+    assert kwargs["repeat_iters"] == 30


### PR DESCRIPTION
## Summary

`benchmarks/flashinfer_benchmark.py` — upstream's testlist-driven runner, and the tool their CONTRIBUTING points contributors at for perf numbers — could not run on ROCm at all: it raised at import on `routines.moe`, and past that `filter_backends_by_compute_capability` stripped every backend including `fa2`, because gfx942/gfx950 report compute capability 9.4/9.5 and the lookup table is NVIDIA-only. The result was `No backends to test. Exiting.` and a zero-row CSV — a silent no-op rather than a failure.

This makes it work on both architectures, adds `backend="auto"` so rows measure what the library actually picks in production, and adds a 26-line ROCm attention testlist. One command now produces 46 refcheck-verified rows in ~3 minutes on a warm JIT cache. Two measurement defects it exposed are fixed here as well: the L2 flush was sized exactly to CDNA's Infinity Cache and so did not flush, and a GQA group size outside the HIP kernel's dispatch set aborted the whole test case instead of dropping one backend.

### What changed

- **`benchmarks/flashinfer_benchmark.py`** — `routines.gemm`/`routines.moe` are imported defensively with the original error re-raised only when such a routine is actually requested; result rows and the header go through `csv.writer`; adds `--dry_run_time_ms`/`--repeat_time_ms`, both defaulting to `None` so iteration-count behaviour is unchanged.
- **`benchmarks/routines/flashinfer_benchmark_utils.py`** — ROCm branch in `filter_backends_by_compute_capability` keyed on the gfx name; `rocm_supported_backends()` derives the list from `flashinfer/arch_caps.py`; `fa2_backed_backends()` classifies backends by what they *resolve to*; `as_nhd_paged_kv_cache()`, `record_backend_resolution()`, `l2_flush_size_mb()`, `bench_timing_kwargs()`; two new CSV columns.
- **`benchmarks/routines/attention.py`** — `"auto"` added to the backend choices and to the construction/dispatch lists of the three attention routines; `kv_layout`/`use_tensor_cores`/`use_cuda_graph` conditioned on it; the four timing sites share `bench_timing_kwargs()` instead of repeating five arguments each; GQA group-size guard.
- **`flashinfer/prefill_rocm.py`**, **`flashinfer/decode_rocm.py`** — `_auto_select_prefill_backend()` returns `(backend, reason)` instead of discarding the reason after logging it; the three wrappers gain `backend` and `backend_fallback_reason` properties. Private function, four in-tree call sites, no external contract change.
- **`rocm_profiler/rocm_profiler.py`** — adds the missing `gfx950` ceiling row (roofline plots silently lost their ceilings on MI350X/MI355X) and detects the architecture from torch device properties instead of scraping the first `gfx` token out of `rocminfo`, which ignored `HIP_VISIBLE_DEVICES`. The rocminfo path stays as a fallback; both now share `_report_ceilings()`.
- **`benchmarks/rocm_benchmarks/testlist_rocm.txt`** — new; 26 model-shaped configs across batch decode, paged prefill and ragged prefill, each running `fa2` and `auto`.
- **`benchmarks/README.md`** — ROCm section: per-arch backend table, how to run, how to read the two new columns, why `auto` rows are timed eagerly, and the split between this runner and `rocm_profiler`.
- **`tests/rocm_tests/test_benchmark_harness_hip.py`**, **`pyproject.toml`** — 15 tests; `benchmarks` added to `pythonpath` so a collected test can import the harness.

### Architecture / design notes

**The backend list derives from `arch_caps`, it does not restate it.** A second hand-written arch→backend table would drift from the arch-support matrix that already has a pre-commit conformance hook. `_ROCM_ROUTINE_TO_CAP_OP` maps harness vocabulary to `CAPABILITIES` op keys and is three lines; gfx942 and gfx950 both fall out of that table, and MLA drops in by adding one row once `mla_rocm` matches the CUDA wrapper.

**`auto` needed three harness-side obstacles removed, none of them AITER limitations.** `use_tensor_cores=(backend != "fa2")` encodes upstream's fa2-vs-fa2_tc split, so anything not literally `"fa2"` got `True` and AITER decode requires `False`. The decode and paged-prefill KV caches are built HND; AITER requires NHD. CUDA-graph capture is on by default, and `auto` deliberately stays on fa2 under capture because AITER's launch grid is fixed at capture shapes — that guard is correct and stays, so ROCm `auto` rows are timed eagerly. Left alone, every `auto` row would have measured fa2 while the CSV said "auto".

**The NHD switch is a relabel, not a rebuild.** The harness already lays the paged cache out NHD-ordered behind an HND-shaped view — strides `(2·S·H·D, S·H·D, D, H·D, 1)`, so the head stride is `D` and the sequence stride is `H·D`. `transpose(2, 3)` is therefore exact, contiguous and zero-copy, verified index-by-index and by `data_ptr()` identity. It is applied only when `backend == "auto"`, a name no CUDA backend list contains, so the CUDA path is untouched.

**The fallback reason has to come from the return value, not the log.** `_auto_select_prefill_backend` already built a precise reason string and passed it to `logger.warning`, which fires once per `(device, reason)` for the process lifetime. For a benchmark writing one row per configuration that means row 1 carries the reason and rows 2..N are blank — worse than no column. `backend_resolved` and `backend_fallback_reason` are what separate "AITER correctly rejected this shape" from "the harness got in the way"; both look like `fa2` otherwise.

**Guard by what a backend resolves to, not by its name.** The first version of the GQA guard removed the literal `"fa2"` and left `"auto"`, which resolves *to* fa2 whenever AITER is declined — so on a box without `amd-aiter`, or on gfx950 under ROCm 7.2.x where AITER prefill is gated off, it did not prevent the abort it was written for. `fa2_backed_backends()` returns the requested backends that will execute the HIP kernel, which includes `"auto"` exactly when AITER cannot serve the op.

**Library timing defaults are untouched.** `l2_flush_size_mb` is raised at the harness call sites, not in `flashinfer/testing/utils.py`, so the five existing `benchmarks/rocm_benchmarks/` scripts — which ride those defaults through `rocm_profiler` — keep producing numbers comparable with their recorded history.

## Benchmark results

MI350X (gfx950, CDNA4), ROCm 7.2.0, torch 2.9.1+rocm7.2, amd-aiter 0.1.10, bf16, page_size 16. **gfx942 is unverified — there is no CDNA3 box in this allocation.**

**Batch decode, median time, `fa2` vs what `auto` resolved to (AITER):**

| shape | fa2 | AITER | ratio |
|---|---|---|---|
| Llama-3.1-8B, batch 1, s_kv 1024 | 0.0430 ms | 0.1627 ms | 3.79× slower |
| Llama-3.1-8B, batch 16, s_kv 1024 | 0.0525 ms | 0.1668 ms | 3.18× |
| Llama-3.1-8B, batch 64, s_kv 1024 | 0.1262 ms | 0.1976 ms | 1.57× |
| Llama-3.1-8B, batch 16, s_kv 8192 | 0.2190 ms | 0.1925 ms | 0.88× |
| Llama-3.1-8B, batch 64, s_kv 8192 | 0.6822 ms | 0.4746 ms | 0.70× |
| Llama-3.1-70B, batch 1, s_kv 1024 | 0.0661 ms | 0.1598 ms | 2.42× |
| Llama-3.1-70B, batch 64, s_kv 8192 | 1.0486 ms | 0.5274 ms | **0.50× faster** |

AITER decode holds a roughly fixed ~0.16 ms floor across small shapes and only overtakes fa2 past s_kv 8192 — consistent with `batch_decode_aiter.cu` rebuilding the dense block table with `index_select` on every `run()`, inside the timed region. `auto` selects AITER at every decode shape, so short-sequence serving currently pays up to 3.8×.

> **Superseded by #303 (merged 2026-08-24).** The block-table rebuild named above as the suspected cause was confirmed and removed — it is now one fused kernel instead of ~11 ATen launches. The AITER decode column in the table above no longer holds: at 32/8 heads, batch 16, s_kv 1024 AITER went 0.0961 ms → 0.0403 ms on gfx950 (2.38×) and 0.0782 ms → 0.0524 ms on gfx942 (1.49×), which makes AITER **faster** than fa2 at the small shapes this table reported it losing. Run-to-run spread on that shape also collapsed from ±96.8% to ±2.1% on gfx950. fa2 is unchanged (it never used this path). The numbers below are left as measured at this PR's merge commit rather than rewritten; see #303 for the current ones.

**L2 flush sizing** — batch decode 32/8 heads, hd128, batch 16, s_kv 1024, a 64 MB KV working set that fits inside CDNA's 256 MB Infinity Cache. Three runs each:

| `l2_flush_size_mb` | medians | mean |
|---|---|---|
| 256 (before) | 0.0510 / 0.0510 / 0.0501 ms | 0.0507 ms |
| 512 (after) | 0.0526 / 0.0542 / 0.0532 ms | 0.0533 ms |

5.1% optimistic before, with no overlap between the two sets: the buffer equalled cache capacity and left its own tail resident, versus ~5× headroom on NVIDIA where the same constant is fine. Shapes whose working set already exceeds the cache are unaffected, which is why it went unnoticed.

**Llama-3.1-405B decode** (128 qo / 8 kv heads, GQA group size 16) went from `RuntimeError: Unsupported group_size: 16` and zero rows to an AITER measurement — 0.1217 ms at batch 16 / s_kv 1024. AITER serves group size 16 where the HIP kernel's `DISPATCH_GQA_GROUP_SIZE` does not, so fa2 is dropped and that row has no reference; it is marked in the testlist as not refcheck-verified.

### Measured, but deliberately not changed

**`--dry_run_time_ms` ships opt-in and the testlist does not use it.** AMD's ~250 ms warmup guidance comes from max-achievable-FLOPS work on large GEMMs and does not transfer to small attention kernels: at a 1 ms shape it moved within-run std only 3.8% → 3.2% with identical 1.2% cross-run spread, and at a 50 µs shape it made std *worse* (20.8% → 51.7%). The knob is worth exposing; the claim that it stabilises these measurements is not supported.

**Upstream's graph-vs-event flush asymmetry.** `bench_gpu_time_with_cudagraph` flushes L2 once per `g.replay()` while each replay runs `num_iters_within_graph=10` calls, so 1 iteration is cold and 9 are warm; the event path flushes before every call. The harness routes `fa2` to the event path and everything else to the graph path, so every fa2-vs-other number in this harness — on CUDA too — compares an all-cold backend against a mostly-warm one. Fixing it would move every CUDA number, so the ROCm path sidesteps it by never graph-timing and the upstream issue is left to file separately.

**`auto` promises a fallback it cannot deliver for single prefill.** `_aiter_ops_importable()` checks that the aiter *package* imports, not that the specific op module exists, so `single_prefill_with_kv_cache(..., backend="auto")` on bf16-with-mask resolves to `aiter` and raises `ModuleNotFoundError` rather than falling back — amd-aiter 0.1.10 ships 58 prebuilt modules and none are `mha_fwd*`. Single prefill is not a harness routine, so it is out of scope here.

**No DeepSeek-R1 row.** `head_dim_qk 192 / head_dim_vo 128` has no working backend on gfx950: AITER requires equal head dims and the fa2 fallback fails to compile (`static_assert` in `permuted_smem.cuh:125`). Including it would only add error rows.

**Every prefill row resolves to fa2 on this box.** `arch_caps` gates AITER batch prefill off on gfx950 under ROCm 7.2.x for the causal-miscompile known-bad entry. That is correct behaviour and the reason column carries the string, so those rows explain themselves rather than looking like missing measurements. They become AITER rows on ROCm 7.1 or once 7.3+ is validated.

**MoE stays unreachable from this harness even though ROCm now has it.** #295 landed `flashinfer.aiter_fused_moe`, but `routines/moe.py` drives the `flashinfer.fused_moe` trtllm/cutlass entry points, which are still CUDA-only — so the import guard is still required and no MoE row is possible here. Wiring a ROCm MoE routine onto the AITER surface is a reasonable follow-up; it is not a rename of the existing one.

## Test plan

- [x] `pytest tests/rocm_tests/test_benchmark_harness_hip.py` — 15 passed in 0.6 s (gfx950, no JIT required).
- [x] A/B'd each fix by reverting it and confirming the matching test fails: forcing the compute-capability branch fails all three filter tests; replacing `transpose(2, 3)` with a copy-based permute fails the zero-copy view test; restoring `l2_flush_size_mb=256` fails the timing test.
- [x] A/B'd the NHD view end-to-end against a real kernel: with the transpose replaced by the identity, `--refcheck` reports 55174/65536 (84.19%) elements different and the run fails; restored, it passes.
- [x] Full testlist end-to-end on MI350X — 46 rows, no `[ERROR]` lines, ~3 min warm. `backend_resolved` empty on all 23 `fa2` rows, populated on all 23 `auto` rows.
- [x] Re-ran the full testlist after the review fixes — still 46 rows, no errors.
- [x] Verified `--refcheck` runs without `--allow_output_mismatch` on every testlist line, so a wrong result fails the row rather than recording a fast-but-wrong number.
- [x] `/code-review` at high effort. Three real defects found and fixed in `966fadfc`: the GQA guard did not cover `"auto"`; `backend_resolved` was populated for explicit backends, making all 23 `fa2` rows match the README's own "investigate this" signature; and `aiter` passed the filter without checking the package imports.
- [x] Rebased onto `amd-integration` at `ed7495eb` (picks up #292 and #295) and re-verified the whole set on the new base: 15 tests pass, 46 rows, no errors. Confirmed the gemm/moe import guard is still load-bearing there — `routines.moe` still raises `ModuleNotFoundError`.
- [x] `pre-commit run -a` — clean, no files modified.

Not run: gfx942. The backend list derives from `arch_caps` so CDNA3 should follow without change, but no CDNA3 hardware was available and I am not claiming it as verified.
