### PR TITLE
perf(rocm): pick the MoE tile height from tokens per expert

### DIFF
--- a/benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py
+++ b/benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py
@@ -21,19 +21,21 @@ far more weight than activation and the roofline sits on HBM: the headline
 metric is expert-weight bytes/sec. Past roughly block_m tokens per expert the
 GEMMs fill their tiles and it becomes compute bound.
 
-Two numbers this exists to produce, both open questions in the shim:
+`aiter.fused_moe` runs alongside as the baseline: it selects block_m, ksplit and
+kernel names from a tuned CSV where the shim uses `_select_block_m` and AITER's
+heuristic dispatch. That comparison is what decides whether the CSV lookup is
+worth a dependency; it is skipped with a message if aiter is not importable.
 
-  1. The gap to `aiter.fused_moe`, which selects kernels from a tuned CSV while
-     the shim passes an empty kernelName and takes AITER's heuristic. If the gap
-     is small the CSV lookup is not worth building.
-  2. The cost of allocating the five sorting buffers per call, visible as the
-     shim's overhead over the same work at large M where allocation is amortized.
+`--block-m-sweep` times 32/64/128 per shape instead, which is what regenerates
+the table behind `_select_block_m`'s thresholds -- so they stay checkable rather
+than folklore.
 
 Run:
-    python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py                 # full pipeline
-    python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py --timing-only   # no profiling
-    python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py --replot        # regenerate plot
-    python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py --counters      # PMC passes
+    python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py                  # full pipeline
+    python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py --timing-only    # no profiling
+    python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py --block-m-sweep  # tile-size table
+    python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py --replot         # regenerate plot
+    python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py --counters       # PMC passes
 """
 
 import logging
@@ -43,7 +45,7 @@ from pathlib import Path
 import torch
 
 import flashinfer
-from flashinfer.fused_moe_rocm import shuffle_moe_weight
+from flashinfer.fused_moe_rocm import _SUPPORTED_BLOCK_M, shuffle_moe_weight
 from flashinfer.jit.core import logger as _jit_logger
 
 _jit_logger.setLevel(logging.WARNING)
@@ -66,8 +68,18 @@ _SHAPES = [
 _DTYPE = torch.bfloat16
 
 
+try:
+    from aiter.fused_moe import fused_moe as _aiter_fused_moe
+except Exception:  # noqa: BLE001 -- a half-installed aiter raises more than ImportError
+    # Matches aiter_utils._aiter_importable: importing aiter drives its JIT
+    # loader, so a missing ROCm dep surfaces as something other than ImportError.
+    # The baseline is optional; --replot and --list-presets need no aiter at all.
+    _aiter_fused_moe = None
+    print("note: aiter not importable, running without the tuned-CSV baseline")
+
+
 @torch.inference_mode()
-def _make_configs() -> list[KernelConfig]:
+def _make_configs(block_m_sweep: bool = False) -> list[KernelConfig]:
     itemsize = torch.tensor([], dtype=_DTYPE).element_size()
     configs = []
     for label, E, K, I, topk in _SHAPES:
@@ -92,34 +104,66 @@ def _make_configs() -> list[KernelConfig]:
                 experts_hit * (2 * I * K + K * I) * itemsize
                 + nt * (K + topk * I + K) * itemsize
             )
-            configs.append(
-                KernelConfig(
-                    name=f"moe_{label}_nt{nt}",
-                    run_fn=torch.inference_mode()(
-                        lambda x=x, w1=w1, w2=w2, ids=ids, weights=weights, out=out: (
-                            flashinfer.aiter_fused_moe(x, w1, w2, ids, weights, out=out)
-                        )
-                    ),
-                    theoretical_flops=theo_flops,
-                    theoretical_bytes=theo_bytes,
-                    num_tokens=nt,
-                    label=f"{label} nt={nt:>5d} E={E:>3d} topk={topk}",
+
+            def add(name, fn, suffix=""):
+                configs.append(
+                    KernelConfig(
+                        name=name,
+                        run_fn=torch.inference_mode()(fn),
+                        theoretical_flops=theo_flops,
+                        theoretical_bytes=theo_bytes,
+                        num_tokens=nt,
+                        label=f"{label} nt={nt:>5d} E={E:>3d} topk={topk}{suffix}",
+                    )
                 )
+
+            if block_m_sweep:
+                for bm in _SUPPORTED_BLOCK_M:
+                    add(
+                        f"moe_{label}_nt{nt}_bm{bm}",
+                        lambda x=x, w1=w1, w2=w2, ids=ids, w=weights, o=out, bm=bm: (
+                            flashinfer.aiter_fused_moe(
+                                x, w1, w2, ids, w, out=o, block_m=bm
+                            )
+                        ),
+                        suffix=f" bm={bm}",
+                    )
+                continue
+
+            # No out= here: aiter.fused_moe allocates its own output and has no
+            # way not to, so passing one only to the shim would charge the
+            # baseline an allocation and bias the very number this comparison
+            # exists to produce.
+            add(
+                f"moe_{label}_nt{nt}",
+                lambda x=x, w1=w1, w2=w2, ids=ids, w=weights: (
+                    flashinfer.aiter_fused_moe(x, w1, w2, ids, w)
+                ),
             )
+            if _aiter_fused_moe is not None:
+                add(
+                    f"moe_{label}_nt{nt}_aiter",
+                    lambda x=x, w1=w1, w2=w2, ids=ids, w=weights: (
+                        _aiter_fused_moe(x, w1, w2, w, ids)
+                    ),
+                    suffix=" [aiter baseline]",
+                )
     return configs
 
 
 if __name__ == "__main__":
     _skip_gpu = "--replot" in sys.argv or "--list-presets" in sys.argv
     profiler = RocmProfiler(
-        configs=[] if _skip_gpu else _make_configs(),
+        configs=[] if _skip_gpu else _make_configs("--block-m-sweep" in sys.argv),
         num_warmup=3,
         dry_run_ms=100,
         repeat_ms=1000,
         counters="roofline",
         kernel_name_regex="moe|gemm",
         output_dir=_OUTPUT_DIR,
-        label="fused_moe_aiter",
+        label="fused_moe_aiter_block_m"
+        if "--block-m-sweep" in sys.argv
+        else "fused_moe_aiter",
         roofline=True,
     )
     profiler.run()

--- a/benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py
+++ b/benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py
@@ -38,6 +38,7 @@ Run:
     python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py --counters       # PMC passes
 """
 
+import functools
 import logging
 import sys
 from pathlib import Path
@@ -68,14 +69,22 @@ _SHAPES = [
 _DTYPE = torch.bfloat16
 
 
-try:
-    from aiter.fused_moe import fused_moe as _aiter_fused_moe
-except Exception:  # noqa: BLE001 -- a half-installed aiter raises more than ImportError
-    # Matches aiter_utils._aiter_importable: importing aiter drives its JIT
-    # loader, so a missing ROCm dep surfaces as something other than ImportError.
-    # The baseline is optional; --replot and --list-presets need no aiter at all.
-    _aiter_fused_moe = None
-    print("note: aiter not importable, running without the tuned-CSV baseline")
+@functools.cache
+def _aiter_baseline():
+    """aiter.fused_moe, or None. Imported lazily and once.
+
+    Importing aiter drives its JIT loader, so this stays out of module scope:
+    --replot and --list-presets build no configs and must not pay for it. The
+    except is broad because a half-installed aiter raises more than ImportError
+    -- same reason as aiter_utils._aiter_importable.
+    """
+    try:
+        from aiter.fused_moe import fused_moe
+
+        return fused_moe
+    except Exception:  # noqa: BLE001
+        print("note: aiter not importable, running without the tuned-CSV baseline")
+        return None
 
 
 @torch.inference_mode()
@@ -142,11 +151,12 @@ def _make_configs(block_m_sweep: bool = False) -> list[KernelConfig]:
                     flashinfer.aiter_fused_moe(x, w1, w2, ids, w)
                 ),
             )
-            if _aiter_fused_moe is not None:
+            baseline = _aiter_baseline()
+            if baseline is not None:
                 add(
                     f"moe_{label}_nt{nt}_aiter",
-                    lambda x=x, w1=w1, w2=w2, ids=ids, w=weights: (
-                        _aiter_fused_moe(x, w1, w2, w, ids)
+                    lambda x=x, w1=w1, w2=w2, ids=ids, w=weights, f=baseline: (
+                        f(x, w1, w2, w, ids)
                     ),
                     suffix=" [aiter baseline]",
                 )

--- a/benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py
+++ b/benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py
@@ -93,7 +93,6 @@ def _make_configs(block_m_sweep: bool = False) -> list[KernelConfig]:
             weights, ids = torch.topk(torch.softmax(logits, dim=-1), topk, dim=-1)
             ids = ids.to(torch.int32).contiguous()
             weights = weights.contiguous()
-            out = torch.empty(nt, K, device="cuda", dtype=_DTYPE)
 
             # Two GEMMs per (token, expert): [1,K]x[K,2I] and [1,I]x[I,K].
             theo_flops = 2 * nt * topk * (K * 2 * I + I * K)
@@ -118,6 +117,9 @@ def _make_configs(block_m_sweep: bool = False) -> list[KernelConfig]:
                 )
 
             if block_m_sweep:
+                # Only the sweep reuses a buffer; the comparison path below
+                # deliberately lets both sides allocate.
+                out = torch.empty(nt, K, device="cuda", dtype=_DTYPE)
                 for bm in _SUPPORTED_BLOCK_M:
                     add(
                         f"moe_{label}_nt{nt}_bm{bm}",

--- a/flashinfer/fused_moe_rocm.py
+++ b/flashinfer/fused_moe_rocm.py
@@ -47,7 +47,7 @@ def _select_block_m(num_tokens: int, topk: int, num_experts: int) -> int:
     for limit, block_m in _BLOCK_M_THRESHOLDS:
         if per_expert < limit:
             return block_m
-    return 128
+    return _SUPPORTED_BLOCK_M[-1]
 
 
 # CK's MFMA tile for the weight operand: 16 rows x 16 columns per instruction.

--- a/flashinfer/fused_moe_rocm.py
+++ b/flashinfer/fused_moe_rocm.py
@@ -16,7 +16,7 @@ it would rebind the attribute from this function to that module.
 """
 
 import functools
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 
@@ -29,11 +29,26 @@ __all__ = ["aiter_fused_moe", "shuffle_moe_weight"]
 # are also the supported-activation set, here and in the JIT spec.
 _ACTIVATION_CODE = {"silu": 0, "gelu": 1}
 
-# CK's stage-1 tile height. 32 suits decode-shaped batches; larger tiles amortize
-# better once there are many tokens per expert. The heuristic dispatch enumerates
-# exactly {32, 64, 128}.
-_DEFAULT_BLOCK_M = 32
+# CK's stage-1 tile height; the heuristic dispatch enumerates exactly these.
 _SUPPORTED_BLOCK_M = (32, 64, 128)
+
+# What fills a stage-1 tile is the tokens routed to *one* expert, so the tile
+# height tracks num_tokens * topk / num_experts rather than num_tokens. Measured
+# optimum on gfx942 and gfx950 across two expert geometries; see the benchmark's
+# --block-m-sweep to regenerate.
+_BLOCK_M_THRESHOLDS = ((32, 32), (64, 64))
+
+
+def _select_block_m(num_tokens: int, topk: int, num_experts: int) -> int:
+    """Pick the CK tile height from the average tokens routed to one expert."""
+    # max(): a degenerate weight is the shim's error to report, not a
+    # ZeroDivisionError from here that would hide it.
+    per_expert = num_tokens * topk / max(num_experts, 1)
+    for limit, block_m in _BLOCK_M_THRESHOLDS:
+        if per_expert < limit:
+            return block_m
+    return 128
+
 
 # CK's MFMA tile for the weight operand: 16 rows x 16 columns per instruction.
 _SHUFFLE_LAYOUT = (16, 16)
@@ -88,7 +103,7 @@ def aiter_fused_moe(
     topk_weights: torch.Tensor,
     *,
     activation: str = "silu",
-    block_m: int = _DEFAULT_BLOCK_M,
+    block_m: Union[int, str] = "auto",
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     r"""Fused mixture-of-experts forward pass on ROCm.
@@ -114,7 +129,9 @@ def aiter_fused_moe(
             bounds. Validating on device would cost a synchronize per call.
         topk_weights: ``[num_tokens, topk]`` float32, the routing weights.
         activation: ``"silu"`` or ``"gelu"``.
-        block_m: CK tile height, one of ``(32, 64, 128)``.
+        block_m: CK tile height, one of ``(32, 64, 128)``, or ``"auto"`` to
+            pick it from the average tokens per expert. Explicit values are
+            honoured unchanged.
         out: Optional ``[num_tokens, model_dim]`` destination. Allocated if
             None. Overwritten, not accumulated into, and it may not overlap any
             input -- it is zero-filled before the activations are read.
@@ -134,8 +151,10 @@ def aiter_fused_moe(
         raise ValueError(
             f"activation must be one of {sorted(_ACTIVATION_CODE)}, got {activation!r}"
         )
-    if block_m not in _SUPPORTED_BLOCK_M:
-        raise ValueError(f"block_m must be one of {_SUPPORTED_BLOCK_M}, got {block_m}")
+    if block_m != "auto" and block_m not in _SUPPORTED_BLOCK_M:
+        raise ValueError(
+            f'block_m must be "auto" or one of {_SUPPORTED_BLOCK_M}, got {block_m!r}'
+        )
     if hidden_states.dtype not in SUPPORTED_DTYPES:
         # Ahead of _get_module: one module is built per dtype, so an unsupported
         # one would otherwise compile for minutes before anything rejected it.
@@ -143,6 +162,16 @@ def aiter_fused_moe(
             f"hidden_states must be one of {list(SUPPORTED_DTYPES)}, "
             f"got {hidden_states.dtype}"
         )
+
+    if block_m == "auto":
+        # Only when the ranks are sane. Indexing a degenerate shape here would
+        # raise IndexError and hide the shim's message naming the real problem.
+        if hidden_states.dim() == 2 and topk_ids.dim() == 2 and w1_shuffled.dim() == 3:
+            block_m = _select_block_m(
+                hidden_states.shape[0], topk_ids.shape[1], w1_shuffled.shape[0]
+            )
+        else:
+            block_m = _SUPPORTED_BLOCK_M[0]
 
     if out is None:
         out = torch.empty(

--- a/flashinfer/fused_moe_rocm.py
+++ b/flashinfer/fused_moe_rocm.py
@@ -174,11 +174,11 @@ def aiter_fused_moe(
             block_m = _SUPPORTED_BLOCK_M[0]
 
     if out is None:
-        out = torch.empty(
-            (hidden_states.shape[0], hidden_states.shape[1]),
-            dtype=hidden_states.dtype,
-            device=hidden_states.device,
-        )
+        # Shaped from hidden_states only when its rank is right. Indexing a
+        # degenerate one here raises IndexError before the shim can say
+        # "hidden_states must be 2-D"; an empty out reaches that check intact.
+        shape = tuple(hidden_states.shape) if hidden_states.dim() == 2 else (0, 0)
+        out = torch.empty(shape, dtype=hidden_states.dtype, device=hidden_states.device)
 
     module = _get_module(hidden_states.dtype, activation)
     # Skip torch custom-op dispatch, as the other AITER ROCm paths do: AITER is

--- a/tests/rocm_tests/test_fused_moe_aiter_hip.py
+++ b/tests/rocm_tests/test_fused_moe_aiter_hip.py
@@ -14,7 +14,7 @@ import pytest
 import torch
 
 import flashinfer
-from flashinfer.fused_moe_rocm import shuffle_moe_weight
+from flashinfer.fused_moe_rocm import _select_block_m, shuffle_moe_weight
 from tests.test_helpers.test_helpers import requires_aiter
 
 _ACT = {"silu": torch.nn.functional.silu, "gelu": torch.nn.functional.gelu}
@@ -68,6 +68,8 @@ def test_fused_moe_vs_ref(dtype, M, E, K, I, topk):
     device = torch.device("cuda:0")
     x, w1, w2, ids, weights = _make_case(M, E, K, I, topk, dtype, device)
 
+    # block_m defaults to "auto", so this sweep exercises the selected tile on
+    # every shape -- a different tile changes the accumulation order.
     got = flashinfer.aiter_fused_moe(
         x, shuffle_moe_weight(w1), shuffle_moe_weight(w2), ids, weights
     )
@@ -75,6 +77,56 @@ def test_fused_moe_vs_ref(dtype, M, E, K, I, topk):
     assert got.shape == (M, K) and got.dtype == dtype
     assert torch.isfinite(got).all()
     assert _rel_err(got, _moe_ref(x, w1, w2, ids, weights, "silu")) < 2e-2
+
+
+# The measured optimum, gfx942 and gfx950 agreeing at every point:
+# (num_tokens, topk, num_experts) -> block_m. Mixtral-8x7B is E=8/topk=2,
+# Qwen3-235B is E=128/topk=8. A threshold edit that contradicts this fails.
+_MEASURED_BLOCK_M = [
+    (1, 2, 8, 32),
+    (8, 2, 8, 32),
+    (32, 2, 8, 32),
+    (128, 2, 8, 64),
+    (512, 2, 8, 128),
+    (2048, 2, 8, 128),
+    (1, 8, 128, 32),
+    (8, 8, 128, 32),
+    (32, 8, 128, 32),
+    (128, 8, 128, 32),
+    (512, 8, 128, 64),
+    (2048, 8, 128, 128),
+    # The two boundary points, which are what the thresholds actually turn on.
+    # per_expert=16 still prefers 32 (by 2% on both shapes); per_expert=64 has
+    # already flipped to 128 (by 11% and 3%).
+    (64, 2, 8, 32),
+    (256, 8, 128, 32),
+    (256, 2, 8, 128),
+    (1024, 8, 128, 128),
+]
+
+
+@pytest.mark.parametrize("num_tokens,topk,num_experts,expected", _MEASURED_BLOCK_M)
+def test_select_block_m_matches_measurement(num_tokens, topk, num_experts, expected):
+    """Pure arithmetic: no GPU, no aiter."""
+    assert _select_block_m(num_tokens, topk, num_experts) == expected
+
+
+def test_select_block_m_tracks_tokens_per_expert_not_tokens():
+    """Same num_tokens, different expert geometry, different tile.
+
+    This is the whole point of the selector: keying on num_tokens alone would
+    give Mixtral's answer to Qwen3. The widest divergence is at M=256, two
+    steps apart -- and 128 measured 13% slower than 32 on Qwen3 there.
+    """
+    assert _select_block_m(256, 2, 8) == 128
+    assert _select_block_m(256, 8, 128) == 32
+    assert _select_block_m(512, 2, 8) == 128
+    assert _select_block_m(512, 8, 128) == 64
+
+
+def test_select_block_m_never_divides_by_zero():
+    """A degenerate weight is the shim's error to report, not ours to crash on."""
+    assert _select_block_m(64, 2, 0) in (32, 64, 128)
 
 
 @requires_aiter
@@ -207,7 +259,8 @@ def test_shuffle_moe_weight_rejects_bad_shapes():
     "kwargs,cast,match",
     [
         ({"activation": "relu"}, None, "activation must be one of"),
-        ({"block_m": 48}, None, "block_m must be one of"),
+        ({"block_m": 48}, None, 'block_m must be "auto" or one of'),
+        ({"block_m": "bogus"}, None, 'block_m must be "auto" or one of'),
         # Rejected in Python, before _get_module: one module is built per dtype,
         # so an unsupported dtype would otherwise trigger a multi-minute compile
         # only to fail afterwards.
@@ -235,6 +288,10 @@ def test_fused_moe_rejects_bad_arguments(kwargs, cast, match):
         (lambda t: {"w2": t["w2"][:, :, : t["w2"].shape[2] // 2]}, "expected w1"),
         (lambda t: {"w1": t["w1"][:-1]}, "experts"),
         (lambda t: {"x": t["x"].unsqueeze(0)}, "must be 2-D"),
+        # block_m="auto" reads these shapes; a degenerate rank must still reach
+        # the shim's message rather than raising IndexError from the selector.
+        (lambda t: {"ids": t["ids"][0, 0].clone()}, "must be 2-D"),
+        (lambda t: {"w1": t["w1"][0].clone()}, "must be 3-D"),
         # topk=0 divides by zero inside AITER: without this check the process
         # dies on SIGFPE, which no caller can catch. The upper bound below is
         # the other half of the same range check.

--- a/tests/rocm_tests/test_fused_moe_aiter_hip.py
+++ b/tests/rocm_tests/test_fused_moe_aiter_hip.py
@@ -332,6 +332,7 @@ def test_fused_moe_rejects_bad_arguments(kwargs, cast, match):
         # the shim's message rather than raising IndexError from the selector.
         (lambda t: {"ids": t["ids"][0, 0].clone()}, "must be 2-D"),
         (lambda t: {"w1": t["w1"][0].clone()}, "must be 3-D"),
+        (lambda t: {"x": t["x"][0].clone()}, "must be 2-D"),
         # topk=0 divides by zero inside AITER: without this check the process
         # dies on SIGFPE, which no caller can catch. The upper bound below is
         # the other half of the same range check.

--- a/tests/rocm_tests/test_fused_moe_aiter_hip.py
+++ b/tests/rocm_tests/test_fused_moe_aiter_hip.py
@@ -10,11 +10,19 @@
 # being loose enough to hide a wrong kernel (unshuffled weights, the failure this
 # suite exists to catch, land at ~1.3).
 
+import pathlib
+import re
+
 import pytest
 import torch
 
 import flashinfer
-from flashinfer.fused_moe_rocm import _select_block_m, shuffle_moe_weight
+from flashinfer.fused_moe_rocm import (
+    _BLOCK_M_THRESHOLDS,
+    _SUPPORTED_BLOCK_M,
+    _select_block_m,
+    shuffle_moe_weight,
+)
 from tests.test_helpers.test_helpers import requires_aiter
 
 _ACT = {"silu": torch.nn.functional.silu, "gelu": torch.nn.functional.gelu}
@@ -122,6 +130,38 @@ def test_select_block_m_tracks_tokens_per_expert_not_tokens():
     assert _select_block_m(256, 8, 128) == 32
     assert _select_block_m(512, 2, 8) == 128
     assert _select_block_m(512, 8, 128) == 64
+
+
+def test_supported_block_m_matches_the_shim():
+    """_SUPPORTED_BLOCK_M must equal the tiles the C++ shim accepts.
+
+    The shim's is_supported_block_m() is the authority -- CK's heuristic
+    dispatch TORCH_CHECKs anything else. Growing the Python tuple alone would
+    let _select_block_m return a tile that aborts on every large-batch call,
+    which no Python-side check can catch.
+    """
+    shim = (
+        pathlib.Path(__file__).parents[2]
+        / "flashinfer"
+        / "csrc_rocm"
+        / "fused_moe_aiter.cu"
+    ).read_text()
+    body = re.search(r"bool is_supported_block_m\([^)]*\)\s*\{(.*?)\}", shim, re.S)
+    assert body, "is_supported_block_m not found in the shim"
+    assert tuple(int(v) for v in re.findall(r"block_m == (\d+)", body.group(1))) == (
+        _SUPPORTED_BLOCK_M
+    )
+
+
+def test_select_block_m_only_returns_supported_tiles():
+    """Every tile the selector can return is one the shim accepts.
+
+    Paired with the conformance test above, this is what makes the thresholds
+    safe to edit: a threshold naming an unsupported tile is a runtime abort,
+    not a slow kernel.
+    """
+    returned = {bm for _, bm in _BLOCK_M_THRESHOLDS} | {_select_block_m(1 << 20, 8, 1)}
+    assert returned <= set(_SUPPORTED_BLOCK_M)
 
 
 def test_select_block_m_never_divides_by_zero():

--- a/tests/rocm_tests/test_fused_moe_aiter_hip.py
+++ b/tests/rocm_tests/test_fused_moe_aiter_hip.py
@@ -146,11 +146,11 @@ def test_supported_block_m_matches_the_shim():
         / "csrc_rocm"
         / "fused_moe_aiter.cu"
     ).read_text()
-    body = re.search(r"bool is_supported_block_m\([^)]*\)\s*\{(.*?)\}", shim, re.S)
+    body = re.search(r"bool\s+is_supported_block_m\s*\([^)]*\)\s*\{(.*?)\}", shim, re.S)
     assert body, "is_supported_block_m not found in the shim"
-    assert tuple(int(v) for v in re.findall(r"block_m == (\d+)", body.group(1))) == (
-        _SUPPORTED_BLOCK_M
-    )
+    assert tuple(
+        int(v) for v in re.findall(r"block_m\s*==\s*(\d+)", body.group(1))
+    ) == (_SUPPORTED_BLOCK_M)
 
 
 def test_select_block_m_only_returns_supported_tiles():
@@ -166,7 +166,7 @@ def test_select_block_m_only_returns_supported_tiles():
 
 def test_select_block_m_never_divides_by_zero():
     """A degenerate weight is the shim's error to report, not ours to crash on."""
-    assert _select_block_m(64, 2, 0) in (32, 64, 128)
+    assert _select_block_m(64, 2, 0) in _SUPPORTED_BLOCK_M
 
 
 @requires_aiter


### PR DESCRIPTION
## Summary

`aiter_fused_moe` shipped `block_m=32` for every shape. Benchmarked against `aiter.fused_moe` — which selects `block_m`, `ksplit` and kernel names from a tuned CSV — that measured up to **2.5× slower** at prefill sizes, which looked like the cost of not reading that CSV. It is not: almost all of it is the tile height. On gfx950, Mixtral M=2048 goes from 5302 µs at `block_m=32` to 2288 µs at 128, against AITER's 2087.

This makes `block_m` default to `"auto"` and derive it from the shape. Explicit values keep working unchanged.

### What changed

- **`flashinfer/fused_moe_rocm.py`** — `_select_block_m(num_tokens, topk, num_experts)` and `block_m="auto"`. Pure arithmetic, no device query, so it costs nothing per call and is unit-testable without a GPU. A degenerate tensor rank skips the selector rather than indexing it, so the shim's validation still reports what is actually wrong instead of an `IndexError` from here.
- **`tests/rocm_tests/test_fused_moe_aiter_hip.py`** — the measured points as a parametrized table, including both threshold boundaries, so a threshold edit that contradicts the data fails. Plus the degenerate-rank cases and `block_m="bogus"`.
- **`benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py`** — the `aiter.fused_moe` baseline the docstring always claimed but never actually ran, and a `--block-m-sweep` mode that regenerates the tables below.

### Architecture / design notes

**The optimum tracks average tokens per expert, not tokens.** `block_m` is the stage-1 tile height, and what fills a tile is the rows routed to *one* expert — so the variable is `num_tokens * topk / num_experts`. That is why the two shapes want different tiles at the same `M`: Qwen3 spreads 8 experts' worth of tokens over 128 experts, Mixtral over 8. At M=256 they are two steps apart (128 vs 32), which a `num_tokens`-keyed rule cannot express.

**Thresholds are `<32 → 32`, `32–64 → 64`, `≥64 → 128`**, measured at the boundaries on both architectures with 60 iterations × 3 repeats (spread <0.5%). Percentages are Mixtral/Qwen3:

| avg tokens/expert | 32 vs 64 | 64 vs 128 |
|---|---|---|
| 8 | 32 by 2% | — |
| 16 | 32 by 2% | — |
| 32 | **64** by 22% / 13% | 64 by 20% / 13% |
| 64 | — | **128** by 11% / 3% |
| 128 | — | 128 by 8% / 0% |

A first pass put the lower threshold at 16, fitted to a coarser single-run sweep. The repeated measurement moved it to 32 — the two tiles are within 2% at `per_expert` 8–16, and single runs disagreed about the winner there. Worth stating because the sparse sweep looked convincing.

**The tuned CSV is still not worth it.** After this change the worst measured point is 9% behind `aiter.fused_moe` and we are ahead at 11 of 18. That residual would cost a `pandas` dependency and a 13-column key including `cu_num`, which misses on parts absent from the shipped table and degrades to the same heuristic anyway.

## Benchmark results

bf16, ROCm 7.2.0 / aiter 0.1.10 / torch 2.9.1. `auto` = tile the selector picks, `best` = fastest of {32, 64, 128} measured; `vs` is `aiter / auto`, so >1.00 means we are faster.

**gfx950 (MI350X)** — 18/18 land on the measured optimum:

| shape | M | auto | best | µs (auto) | aiter | vs |
|---|---|---|---|---|---|---|
| mixtral8x7b | 1 | 32 | 32 | 182.8 | 240.8 | 1.32 |
| mixtral8x7b | 32 | 32 | 32 | 498.1 | 500.6 | 1.00 |
| mixtral8x7b | 128 | 64 | 64 | 526.9 | 600.9 | 1.14 |
| mixtral8x7b | 512 | 128 | 128 | 946.4 | 896.4 | 0.95 |
| mixtral8x7b | 2048 | 128 | 128 | **2287.9** | 2086.8 | 0.91 |
| qwen3-235b | 128 | 32 | 32 | 856.1 | 870.9 | 1.02 |
| qwen3-235b | 512 | 64 | 64 | 931.4 | 1002.1 | 1.08 |
| qwen3-235b | 2048 | 128 | 128 | 1573.5 | 1501.1 | 0.95 |

**gfx942 (MI300X)** — 18/18 land on the measured optimum:

| shape | M | auto | best | µs (auto) | aiter | vs |
|---|---|---|---|---|---|---|
| mixtral8x7b | 1 | 32 | 32 | 235.0 | 321.4 | 1.37 |
| mixtral8x7b | 128 | 64 | 64 | 802.2 | 830.0 | 1.03 |
| mixtral8x7b | 512 | 128 | 128 | 1415.6 | 1413.0 | 1.00 |
| mixtral8x7b | 2048 | 128 | 128 | **3549.2** | 3520.0 | 0.99 |
| qwen3-235b | 256 | 32 | 32 | 1372.7 | 1554.0 | 1.13 |
| qwen3-235b | 512 | 64 | 64 | 1452.5 | 1612.9 | 1.11 |
| qwen3-235b | 2048 | 128 | 128 | 2389.5 | 2363.2 | 0.99 |

Against the shipped `block_m=32`, Mixtral M=2048 improves 2.3× on gfx950 (5302 → 2288 µs) and 2.5× on gfx942 (8848 → 3549 µs).

Neither benchmark config passes `out=`: `aiter.fused_moe` allocates its own output and cannot accept one, so giving the shim a preallocated buffer would charge the baseline an allocation and bias the very comparison that decides the CSV question.

## Test plan

- [x] `pytest tests/rocm_tests/test_fused_moe_aiter_hip.py test_aiter_module_spec_hip.py test_arch_caps_hip.py` on MI300X and MI350X.
- [x] The selector's acceptance test is the benchmark, not the unit test: `auto` lands on the measured-best tile at 18/18 points per architecture. A selector that picks a legal-but-wrong tile passes every correctness test.
- [x] Correctness sweep runs with `block_m="auto"`, so the selected tile is exercised on every shape — a different tile changes the accumulation order, and the 2e-2 bound still holds.
- [x] A/B'd the degenerate-rank guard: without it, a 0-D `topk_ids` raises `IndexError: tuple index out of range` from the selector instead of the shim's "must be 2-D".
- [x] `pre-commit run -a`
