### PR TITLE
perf(rocm): widen the MLA paged-append to 16-byte accesses

### DIFF
--- a/include/flashinfer/attention/generic/page.cuh
+++ b/include/flashinfer/attention/generic/page.cuh
@@ -623,7 +623,9 @@ gpuError_t AppendPagedKVMlaCache(paged_kv_mla_t<DType, IdType> paged_kv, DType* 
   constexpr uint32_t HEAD_KPE_DIM = 64;
   FLASHINFER_CHECK(head_dim_ckv == HEAD_CKV_DIM, "head_dim_ckv must be equal to 512");
   FLASHINFER_CHECK(head_dim_kpe == HEAD_KPE_DIM, "head_dim_kpe must be equal to 64");
-  constexpr uint32_t vec_size = 2;
+  // 16-byte accesses instead of a fixed 2 elements (4 bytes at bf16). bdx is
+  // 64 at 16-bit dtypes, one CDNA wavefront; fp8 gives 32, half a wave.
+  constexpr uint32_t vec_size = 16 / sizeof(DType);
 
   uint32_t bdx = HEAD_CKV_DIM / vec_size;
   uint32_t num_threads = bdx;

--- a/tests/rocm_tests/test_append_paged_mla_kv_cache_hip.py
+++ b/tests/rocm_tests/test_append_paged_mla_kv_cache_hip.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Dtype coverage for the MLA paged-cache append on ROCm.
+#
+# AppendPagedKVMlaCache derives its access width from the dtype
+# (vec_size = 16 / sizeof(DType)), so each dtype takes a different vec_t
+# specialisation and a different block width. tests/attention/test_mla_page.py
+# is upstream and pins float16, which leaves three of the four dispatched
+# dtypes unexercised.
+
+import math
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer.device_utils import IS_HIP
+
+CKV_DIM = 512
+KPE_DIM = 64
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or not IS_HIP, reason="requires a ROCm GPU"
+)
+
+# vec_size = 16 / itemsize, bdx = 512 / vec_size. fp8 lands on 32, half a
+# wavefront; 16-bit dtypes on 64, one wavefront.
+_DTYPES = [
+    torch.float16,
+    torch.bfloat16,
+    torch.float8_e4m3fnuz,
+    torch.float8_e5m2fnuz,
+]
+
+
+def _random(shape, dtype, device):
+    """fp8 has no randn; round a small fp32 draw so values survive the cast."""
+    x = torch.randn(*shape, device=device, dtype=torch.float32) * 0.1
+    return x.to(dtype)
+
+
+@pytest.mark.parametrize("dtype", _DTYPES, ids=lambda d: str(d).split(".")[-1])
+@pytest.mark.parametrize("page_size", [1, 16, 64])
+@pytest.mark.parametrize("kv_len", [[45], [45, 8, 25, 22], [400]])
+def test_append_mla_paged_kv_cache_dtypes(dtype, page_size, kv_len):
+    """Appended values must land bit-exact, and padding must stay zero.
+
+    The append is a pure copy, so `torch.equal` on the bit pattern is the right
+    assertion -- a tolerance would hide a partial or misaligned vector write,
+    which is the failure mode a dtype-dependent vec_size introduces.
+    """
+    dev = torch.device("cuda:0")
+    nnz = sum(kv_len)
+
+    ckv_append = _random((nnz, CKV_DIM), dtype, dev)
+    kpe_append = _random((nnz, KPE_DIM), dtype, dev)
+
+    num_pages_per_req = torch.tensor(
+        [math.ceil(n / page_size) for n in kv_len], dtype=torch.int32, device=dev
+    )
+    kv_append_indptr = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32, device=dev),
+            torch.cumsum(torch.tensor(kv_len, dtype=torch.int32, device=dev), 0),
+        ]
+    ).int()
+
+    max_num_pages = int(num_pages_per_req.sum())
+    ckv_cache = torch.zeros(max_num_pages, page_size, CKV_DIM, dtype=dtype, device=dev)
+    kpe_cache = torch.zeros(max_num_pages, page_size, KPE_DIM, dtype=dtype, device=dev)
+    kv_page_indptr = torch.cat(
+        [
+            torch.zeros(1, dtype=torch.int32, device=dev),
+            torch.cumsum(num_pages_per_req, 0),
+        ]
+    ).int()
+    kv_page_indices = torch.arange(max_num_pages, dtype=torch.int32, device=dev)
+    kv_last_page_len = torch.tensor(
+        [n % page_size if n % page_size else page_size for n in kv_len],
+        dtype=torch.int32,
+        device=dev,
+    )
+
+    batch_indices, positions = flashinfer.get_batch_indices_positions(
+        kv_append_indptr,
+        flashinfer.get_seq_lens(kv_page_indptr, kv_last_page_len, page_size),
+        nnz,
+    )
+    flashinfer.append_paged_mla_kv_cache(
+        ckv_append,
+        kpe_append,
+        batch_indices,
+        positions,
+        ckv_cache,
+        kpe_cache,
+        kv_page_indices,
+        kv_page_indptr,
+        kv_last_page_len,
+    )
+
+    # Compare as raw bits: fp8 has no eq kernel on this torch build.
+    flat_ckv = ckv_cache.view(-1, CKV_DIM).view(torch.uint8)
+    flat_kpe = kpe_cache.view(-1, KPE_DIM).view(torch.uint8)
+    src_ckv = ckv_append.view(torch.uint8)
+    src_kpe = kpe_append.view(torch.uint8)
+
+    acc, acc_pad = 0, 0
+    for i, n in enumerate(kv_len):
+        assert torch.equal(src_ckv[acc : acc + n], flat_ckv[acc_pad : acc_pad + n])
+        assert torch.equal(src_kpe[acc : acc + n], flat_kpe[acc_pad : acc_pad + n])
+        # Tail of the last page must be untouched -- catches an over-wide write.
+        end = acc_pad + int(num_pages_per_req[i]) * page_size
+        assert not flat_ckv[acc_pad + n : end].any()
+        assert not flat_kpe[acc_pad + n : end].any()
+        acc += n
+        acc_pad = end


### PR DESCRIPTION
## Summary

`AppendPagedKVMlaCache` hardcoded `vec_size = 2` — 4-byte accesses at bf16, across `bdx = 512/2 = 256` threads. Deriving the width from the dtype instead gives 16-byte accesses and `bdx = 64`, exactly one CDNA wavefront. One line, in the AMD kernel fork.

This is the `vec_size` item #292 deferred and #296 listed as out of scope. Measuring it first changed the conclusion, so the framing here is different from both.

## Results

MI350X / ROCm 7.2.0 / torch 2.9.1, before and after run back to back, with a plain `torch.copy_` of the same bytes as the achievable floor:

| nnz | MB moved | before | after | speedup | before GB/s | after GB/s | `copy_` |
|---|---|---|---|---|---|---|---|
| 4096 | 4.7 | 7.98 µs | 9.75 µs | — | 1182 | 968 | 5.33 µs |
| 16384 | 18.9 | 12.65 µs | 8.58 µs | 1.47× | 2984 | 4401 | 5.86 µs |
| 65536 | 75.5 | 42.69 µs | 25.20 µs | 1.69× | 3537 | 5991 | 22.04 µs |
| 262144 | 302.0 | 279.66 µs | 117.75 µs | **2.38×** | 2160 | 5129 | 115.98 µs |

**Two regimes, and only one of them cares about access width.**

Below nnz ≈ 4096 the kernel is **launch-bound** — flat at ~8 µs across a 16× range of work — so `vec_size` is irrelevant there. The apparent regression at 4096 is drift, not the change: `copy_` moved by the same ~20% in the same runs, and the append/`copy_` ratio is unchanged (1.69–1.82 before, 1.75–1.83 after). At large nnz the `copy_` control is stable across both runs (21.8 vs 22.0 µs, 116.1 vs 116.0 µs), which is what makes those rows trustworthy.

Above nnz ≈ 16384 it is **bandwidth-bound** and the win is real: the append goes from 44% of MI350X's 8.0 TB/s peak to 75–77%, landing within 2% of what a plain `copy_` achieves.

### What this does not do

**It does not speed up decode.** A decode step appends one token per sequence, so `nnz == batch` and sits entirely in the launch-bound regime. Measured separately: the append is 13.6% of an MLA decode step at batch ≤ 32 and 2.4% at batch 256, but none of that is byte movement — it is flat at ~11 µs from batch 1 to 256.

The beneficiary is **chunked-prefill ingestion**, which appends a whole chunk per layer. #292 deferred this citing "68% of peak at nnz=65536"; that number was right, but the surrounding framing implied decode would benefit, and it does not.

## Scope

Only the MLA half moves. `AppendPagedKVCache`'s `HEAD_DIM / 32` — a CUDA warp-size constant, wrong on a 64-lane wavefront — lives in `include/flashinfer/page.cuh`, which is upstream-tracked (54 commits, zero HIP markers). Editing it would break the byte-identical-upstream rule and change CUDA behaviour that cannot be validated here. The file touched by this PR is the AMD kernel fork (`include/flashinfer/attention/generic/page.cuh`, one commit, 16 HIP markers), included only by `csrc_rocm`, so NVIDIA is untouched and there is no rebase cost.

## Test plan

- [x] **116/116** across `tests/attention/test_mla_page.py` and the ROCm mla / append / torch-compile suites, exit 0.
- [x] **A/B on the coverage**: disabling the kpe write fails all 18 `test_mla_page` cases, so those tests are load-bearing for this kernel rather than incidentally passing.
- [x] **Every instantiated dtype checked**, not just the measured one. `DISPATCH_PYTORCH_DTYPE_TO_CTYPE` yields F16, BF16, FP8_E4M3, FP8_E5M2. For each: `vec_size` divides 512 exactly; the `tx * vec_size < head_dim_kpe` guard covers elements 0..63 exactly with no partial or missing vector (fp16/bf16 → 8 threads × 8, fp8 → 4 × 16); and the resulting `vec_t` specialization exists.
- [x] `pre-commit` clean.

Two notes from review, neither blocking and both stated rather than buried. fp8 yields `bdx = 32`, half a wavefront — plausibly worth capping, but unmeasured here, so left alone rather than guessed at. And the 16-byte path tightens the implicit alignment contract from 4 bytes; that brings MLA to parity with the assumption the sibling non-MLA kernel already makes under the same `CHECK_LAST_DIM_CONTIGUOUS`, so it is not a new requirement in the codebase, but it is a stricter one for this kernel and no check produces a readable error if an external caller violates it.
