### PR TITLE
docs(rocm): note that an fp8 MLA cache is write-only

### DIFF
--- a/flashinfer/page.py
+++ b/flashinfer/page.py
@@ -353,6 +353,10 @@ def append_paged_mla_kv_cache(
     r"""Append a batch of key-value pairs to a paged key-value cache,
     Note: current only support ckv=512 and kpe=64
 
+    On ROCm this accepts fp8 caches, but
+    :class:`~flashinfer.mla_rocm.BatchMLAPagedAttentionWrapper` takes only
+    fp16/bf16 -- an fp8 MLA cache is currently write-only.
+
     Parameters
     ----------
     append_ckv : torch.Tensor

--- a/flashinfer/page.py
+++ b/flashinfer/page.py
@@ -353,7 +353,7 @@ def append_paged_mla_kv_cache(
     r"""Append a batch of key-value pairs to a paged key-value cache,
     Note: current only support ckv=512 and kpe=64
 
-    On ROCm this accepts fp8 caches, but
+    On ROCm, this accepts fp8 caches, but
     :class:`~flashinfer.mla_rocm.BatchMLAPagedAttentionWrapper` takes only
     fp16/bf16 -- an fp8 MLA cache is currently write-only.
 


### PR DESCRIPTION
## Summary

`append_paged_mla_kv_cache` has no dtype gate — `DISPATCH_PYTORCH_DTYPE_TO_CTYPE` admits both fp8 types and they work, bit-exact and CI-covered. But `mla_rocm.BatchMLAPagedAttentionWrapper.plan()` rejects anything but fp16/bf16 (`mla_rocm.py:264`). A caller can therefore fill an fp8 MLA cache successfully and only discover at `plan()` time that nothing can read it.

Three lines of docstring saying so.

## Why not validate it

Rejecting fp8 in the append would remove a path that is correct and covered by `tests/rocm_tests/test_append_paged_mla_kv_cache_hip.py`. A runtime dtype check would sit in a per-layer per-step hot path (~11 µs measured in #299) to catch a mistake whose eventual error — `"AITER MLA requires q_data_type in {fp16, bf16}"` — is already explicit. The asymmetry is worth writing down; it is not worth a branch.

## Correction to #299

While assessing this, an independent review found the deferral rationale in #299's commit message is wrong on its evidence. It says `AppendPagedKVCache`'s `HEAD_DIM / 32` "lives in `include/flashinfer/page.cuh`, which is upstream-tracked (54 commits, zero HIP markers)". That file is not compiled on ROCm — only `csrc/` includes it, and `get_include_paths.py:50` pins the ROCm build to `csrc_rocm`, which includes the AMD fork at `include/flashinfer/attention/generic/page.cuh`. The policy blocker cited there never applied.

The conclusion still stands, for a better reason: `HEAD_DIM / 32` is arithmetically inert. Across the closed dispatch space (head_dim ∈ {64,128,256,512} × {f16, bf16, fp8_e4m3, fp8_e5m2}) it strictly wins in exactly one of eight cells — head_dim 512 with a 16-bit dtype, which MHA does not use — and even there it resolves to two 16-byte `uint4` copies rather than a wide misaligned access. `bdy = num_heads` also means no lanes are wasted at any head dim, unlike the MLA kernel which launches `dim3 nthrs(bdx)` with no second dimension.

## Test plan

- [x] 83 passed across `test_append_paged_mla_kv_cache_hip.py`, `test_mla_page.py`, `test_mla_aiter_hip.py` on MI350X.
- [x] `pre-commit` clean; docstring parses via `ast.get_docstring`.

Docs-only, no behaviour change.
