### PR TITLE
tools: measure upstream sync cost, and write down the additive-only policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,62 @@ provide a HIP implementation under `gpu_iface/backend/hip/`. Don't
 reach for `hipcub`, `__hip_*`, or inline asm from inside
 `include/flashinfer/` — go through `gpu_iface`.
 
+# Additive-Only: the rule that keeps upstream syncs cheap
+
+This is a **permanent downstream fork** that syncs from
+`flashinfer-ai/flashinfer` by merge. The cost of every sync is decided by one
+number: how many upstream files the port has edited in place. Additions —
+however large — are close to free at merge time, because upstream has nothing
+to merge them against. The exception is a path upstream later adds too: that
+conflicts as add/add, with no common ancestor to help resolve it, which is how
+`CLAUDE.md` and `.claude/skills/benchmark-kernel/SKILL.md` got onto the
+conflict list. Prefer a `_rocm`/`_aiter`-suffixed name for anything upstream
+might plausibly create.
+
+**So: add files, don't edit them.** Concretely, prefer in this order:
+
+1. **Source-path redirect.** `FLASHINFER_CSRC_DIR` already points at
+   `flashinfer/csrc_rocm/` on ROCm (see `flashinfer/jit/env.py` and
+   `flashinfer/get_include_paths.py`), so a shared JIT generator naming
+   `sampling.cu` picks up the HIP source with **zero Python diff**. This is why
+   `flashinfer/sampling.py` and `quantization.py` contain no HIP references at
+   all. Use it whenever only the kernel differs.
+2. **A ROCm module beside the upstream one**, swapped into `sys.modules` in
+   `flashinfer/__init__.py` — how `prefill_rocm.py` and `decode_rocm.py` are
+   reached.
+3. **A declared-unsupported gate**, so an op the port does not implement raises
+   a named error rather than `AttributeError`. See the meta-path loader in
+   `flashinfer/comm/__init__.py`.
+
+**Last resort: an `if IS_HIP:` branch inside an upstream file.** Every one of
+these is a permanent merge conflict, so it needs a reason that the three
+mechanisms above cannot serve. `scripts/upstream_canary.py` is the authoritative
+list — it reports exactly which files a merge would conflict on. The
+`[tool.coverage.run].include` block in `pyproject.toml` is *not* that list: it is
+generated for coverage, contains ROCm-only additions such as `prefill_rocm.py`
+that are not edits to anything, and its workflow only watches
+`flashinfer/**/*.py`, so an in-place edit under `csrc/` or `include/` never
+appears there at all.
+
+**Forked headers are exempt from conflicts and therefore from warnings.**
+`include/flashinfer/attention/generic/` is a fork of the upstream attention
+headers re-expressed on `gpu_iface`. It conflicts with nothing, so it goes
+stale silently instead — a fix that lands upstream will not reach it, and
+nothing will say so.
+
+**Check the cost before and after your change:**
+
+```bash
+git fetch upstream
+python3 scripts/upstream_canary.py          # conflicts, ranked; plus forked-header drift
+```
+
+It builds nothing, needs no GPU, and leaves your working tree and index
+untouched — the merge is resolved via `git merge-tree` into the object
+database. (It does leave unreferenced loose objects behind, so a long-lived CI
+checkout wants a periodic `git gc`.) A conflicting result is the normal steady
+state; what matters is that your change does not lengthen the list.
+
 # Adding a Kernel
 
 1. **Kernel implementation** — framework-agnostic header(s) in
@@ -91,6 +147,8 @@ CI rejects PRs that don't pass `pre-commit run -a`.
 # Submitting Changes
 
 Open PRs against the `amd-integration` branch of
-[`ROCm/flashinfer`](https://github.com/ROCm/flashinfer). For PR
+[`AMD-Ecosystem/flashinfer`](https://github.com/AMD-Ecosystem/flashinfer) —
+never against `flashinfer-ai/flashinfer`, which `gh pr create` will otherwise
+pick as the default base. For PR
 description conventions (sections, benchmarks, test plan), see the
 "PR Description" section of [`CLAUDE.md`](CLAUDE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ reach for `hipcub`, `__hip_*`, or inline asm from inside
 
 # Additive-Only: the rule that keeps upstream syncs cheap
 
-This is a **permanent downstream fork** that syncs from
+This is a **downstream fork** that syncs from
 `flashinfer-ai/flashinfer` by merge. The cost of every sync is decided by one
 number: how many upstream files the port has edited in place. Additions —
 however large — are close to free at merge time, because upstream has nothing
@@ -74,7 +74,7 @@ might plausibly create.
    `flashinfer/comm/__init__.py`.
 
 **Last resort: an `if IS_HIP:` branch inside an upstream file.** Every one of
-these is a permanent merge conflict, so it needs a reason that the three
+these is a recurring merge conflict, so it needs a reason that the three
 mechanisms above cannot serve. `scripts/upstream_canary.py` is the authoritative
 list — it reports exactly which files a merge would conflict on. The
 `[tool.coverage.run].include` block in `pyproject.toml` is *not* that list: it is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,8 +64,8 @@ might plausibly create.
    `flashinfer/csrc_rocm/` on ROCm (see `flashinfer/jit/env.py` and
    `flashinfer/get_include_paths.py`), so a shared JIT generator naming
    `sampling.cu` picks up the HIP source with **zero Python diff**. This is why
-   `flashinfer/sampling.py` and `quantization.py` contain no HIP references at
-   all. Use it whenever only the kernel differs.
+   `flashinfer/sampling.py` and `flashinfer/quantization.py` contain no HIP
+   references at all. Use it whenever only the kernel differs.
 2. **A ROCm module beside the upstream one**, swapped into `sys.modules` in
    `flashinfer/__init__.py` — how `prefill_rocm.py` and `decode_rocm.py` are
    reached.
@@ -151,4 +151,5 @@ Open PRs against the `amd-integration` branch of
 never against `flashinfer-ai/flashinfer`, which `gh pr create` will otherwise
 pick as the default base. For PR
 description conventions (sections, benchmarks, test plan), see the
-"PR Description" section of [`CLAUDE.md`](CLAUDE.md).
+"PR Description" section of the `pr-workflow` skill
+(`.claude/skills/pr-workflow/SKILL.md`).

--- a/scripts/upstream_canary.py
+++ b/scripts/upstream_canary.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Report what an upstream sync would cost, without performing one.
+
+Prints how far the fork and upstream have moved from the merge base, the
+conflicts a merge would raise, and upstream churn on the headers that
+``attention/generic/`` forked -- those conflict with nothing and go stale silently.
+
+Usage::
+
+    python3 scripts/upstream_canary.py --upstream-ref upstream/main
+    python3 scripts/upstream_canary.py --fail-over 14    # ratchet for CI
+
+Exit 0 clean, 1 if ``--fail-over`` is exceeded, 2 if the tool could not run.
+Leaves the working tree and index untouched, but does write unreferenced loose
+objects, so a long-lived CI checkout wants a periodic ``git gc``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import os
+import posixpath
+import subprocess
+import sys
+from typing import Dict, List, NamedTuple, Optional, Set, Tuple
+
+EXIT_OK, EXIT_RATCHET, EXIT_ERROR = 0, 1, 2
+
+# Conflicts here say nothing about design: the port keeps its own docs, build
+# metadata, and regenerated sample output.
+_EXPECTED_BASENAME_GLOBS = ("*.md", "*.toml")
+_EXPECTED_EXACT = (".gitignore", ".pre-commit-config.yaml", "version.txt")
+_EXPECTED_PREFIXES = ("benchmarks/samples/",)
+
+_GENERIC_DIR = "include/flashinfer/attention/generic"
+
+# generic/ flattens one level: it holds headers upstream keeps in attention/
+# and others it keeps directly under flashinfer/.
+_UPSTREAM_HEADER_DIRS = ("include/flashinfer/attention", "include/flashinfer")
+_HEADER_SUFFIXES = (".cuh", ".hpp", ".h")
+
+
+class ToolError(Exception):
+    """The canary could not produce a report -- distinct from a conflicting merge."""
+
+
+class Churn(NamedTuple):
+    added: int = 0
+    deleted: int = 0
+
+    def __str__(self) -> str:
+        return f"+{self.added}/-{self.deleted}"
+
+    @property
+    def total(self) -> int:
+        return self.added + self.deleted
+
+
+class Conflict(NamedTuple):
+    path: str
+    ours: Churn
+    theirs: Churn
+    kind: str
+
+    @property
+    def weight(self) -> int:
+        """Both sides' churn multiplied, so two-sided conflicts rank first."""
+        return self.ours.total * self.theirs.total
+
+    @property
+    def expected(self) -> bool:
+        base = posixpath.basename(self.path)
+        return (
+            any(fnmatch.fnmatch(base, g) for g in _EXPECTED_BASENAME_GLOBS)
+            or self.path in _EXPECTED_EXACT
+            or self.path.startswith(_EXPECTED_PREFIXES)
+        )
+
+
+def _run(
+    repo: Optional[str], *args: str, check: bool = True
+) -> subprocess.CompletedProcess:
+    """Run git at the repo root, in the C locale, tolerating undecodable paths."""
+    cmd = ["git"] + (["-C", repo] if repo else []) + list(args)
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="surrogateescape",
+        env={**os.environ, "LC_ALL": "C"},
+    )
+    if check and proc.returncode != 0:
+        raise ToolError(f"{' '.join(cmd)} failed:\n{proc.stderr.strip()}")
+    return proc
+
+
+def _git(repo: Optional[str], *args: str) -> str:
+    return _run(repo, *args).stdout.strip()
+
+
+def _ls_tree(repo: str, ref: str, path: str) -> Set[str]:
+    """Paths under `path` in `ref`. ``-z`` because the default C-quotes non-ASCII."""
+    args = ["ls-tree", "-r", "-z", "--name-only", ref]
+    if path:
+        args += ["--", path]
+    return {f for f in _run(repo, *args).stdout.split("\0") if f}
+
+
+def _churn_map(
+    repo: str, base: str, tip: str
+) -> Tuple[Dict[str, Churn], Dict[str, str]]:
+    """Per-path churn for a revision range, plus a new->old map of renames.
+
+    No pathspec: filtering by path suppresses git's rename detection.
+    """
+    fields = _run(repo, "diff", "--numstat", "-z", f"{base}..{tip}").stdout.split("\0")
+    churn: Dict[str, Churn] = {}
+    renames: Dict[str, str] = {}
+    i = 0
+    while i < len(fields):
+        record = fields[i]
+        i += 1
+        if not record:
+            continue
+        parts = record.split("\t")
+        if len(parts) < 3:
+            continue
+        added = int(parts[0]) if parts[0].isdigit() else 0  # "-" marks a binary file
+        deleted = int(parts[1]) if parts[1].isdigit() else 0
+        if parts[2]:
+            path = parts[2]
+        else:
+            # Rename/copy: path field empty, next two fields are old then new.
+            if i + 1 >= len(fields):
+                break
+            renames[fields[i + 1]] = fields[i]
+            path = fields[i + 1]
+            i += 2
+        churn[path] = Churn(added, deleted)
+    return churn, renames
+
+
+def _merge_tree(repo: str, ours: str, theirs: str) -> List[Tuple[str, str]]:
+    """(path, conflict-type) for a merge that is never made.
+
+    The ``-z`` info section is ``<n-paths> NUL <path>... NUL <type> NUL <message>``,
+    so the type is a field rather than something scraped from git's English prose.
+    """
+    proc = _run(repo, "merge-tree", "--write-tree", "-z", ours, theirs, check=False)
+    if proc.returncode == 0:
+        return []
+    if proc.returncode != 1:
+        raise ToolError(f"git merge-tree failed:\n{proc.stderr.strip()}")
+
+    fields = proc.stdout.split("\0")
+    idx = 1  # skip the tree OID
+    while idx < len(fields) and fields[idx]:
+        idx += 1
+    idx += 1
+
+    kinds: Dict[str, str] = {}
+    order: List[str] = []
+    while idx < len(fields):
+        if not fields[idx]:
+            idx += 1
+            continue
+        try:
+            n_paths = int(fields[idx])
+        except ValueError as exc:
+            # Never truncate silently: an under-count reads as good news.
+            raise ToolError(
+                f"unparsed merge-tree -z record at field {idx}: {fields[idx]!r}; "
+                f"the informational format may have changed ({_git(repo, 'version')})"
+            ) from exc
+        paths = fields[idx + 1 : idx + 1 + n_paths]
+        type_idx = idx + 1 + n_paths
+        if type_idx >= len(fields):
+            break
+        kind = fields[type_idx]
+        idx = type_idx + 2  # skip the human-readable message
+        if not kind.startswith("CONFLICT"):
+            continue  # "Auto-merging" and friends
+        label = kind[len("CONFLICT (") : -1] if kind.endswith(")") else kind
+        for path in paths:
+            if path not in kinds:
+                order.append(path)
+            kinds[path] = label
+    return [(p, kinds[p]) for p in order]
+
+
+def _report_position(
+    base_desc: str, ours: Tuple[int, int], theirs: Tuple[int, int]
+) -> None:
+    print("== position ==")
+    print(f"merge base : {base_desc}")
+    print(f"ours       : {ours[0]:>6} commits, {ours[1]:>5} files changed")
+    print(f"upstream   : {theirs[0]:>6} commits, {theirs[1]:>5} files changed")
+    print()
+
+
+def _report_conflicts(conflicts: List[Conflict]) -> int:
+    """Print the ranked conflict table; return the count of non-expected paths."""
+    print("== conflicts ==")
+    if not conflicts:
+        print("clean merge -- nothing to do")
+        print()
+        return 0
+
+    rows = sorted(conflicts, key=lambda c: (c.expected, -c.weight))
+    width = max(len(c.path) for c in rows)
+    for c in rows:
+        tag = "" if c.kind == "contents" else f" [{c.kind}]"
+        if c.expected:
+            tag += " [expected]"
+        print(
+            f"  {c.path:<{width}}  ours {str(c.ours):>12}"
+            f"  upstream {str(c.theirs):>12}{tag}"
+        )
+
+    code = sum(1 for c in rows if not c.expected)
+    print()
+    print(f"  {len(rows)} conflicted, {code} of them code")
+    print()
+    return code
+
+
+def _report_drift(repo: str, ours: str, theirs: str, churn: Dict[str, Churn]) -> None:
+    """Upstream churn on the headers that generic/ forked.
+
+    Read from `ours`, not the working tree, so --ours means what it says and a
+    checkout that predates or relocates generic/ still reports correctly.
+    """
+    print("== forked-header drift ==")
+    forked = sorted(
+        p for p in _ls_tree(repo, ours, _GENERIC_DIR) if p.endswith(_HEADER_SUFFIXES)
+    )
+    if not forked:
+        print(f"no forked headers under {_GENERIC_DIR} in {ours[:12]}")
+        print()
+        return
+
+    upstream_files = _ls_tree(repo, theirs, "include/flashinfer")
+    rows: List[Tuple[str, Churn]] = []
+    orphans: List[str] = []
+    for path in forked:
+        name = posixpath.basename(path)
+        candidates = [
+            f"{d}/{name}"
+            for d in _UPSTREAM_HEADER_DIRS
+            if f"{d}/{name}" in upstream_files
+        ]
+        if not candidates:
+            orphans.append(name)
+            continue
+        if len(candidates) > 1:
+            print(
+                f"  NOTE: {name} matches {len(candidates)} upstream paths; using {candidates[0]}"
+            )
+        c = churn.get(candidates[0])
+        if c and c.total:
+            rows.append((candidates[0], c))
+
+    tracked = len(forked) - len(orphans)
+    if rows:
+        rows.sort(key=lambda r: -r[1].total)
+        width = max(len(r[0]) for r in rows)
+        for path, c in rows:
+            print(f"  {path:<{width}}  upstream {c}")
+        print()
+        print(
+            f"  {len(rows)} of {tracked} forked headers have upstream changes to review"
+        )
+    else:
+        print(f"  no upstream changes to any of the {tracked} forked headers")
+    if orphans:
+        print(
+            f"  ({len(orphans)} ROCm-only, no upstream counterpart: {', '.join(orphans)})"
+        )
+    print()
+
+
+def _resolve(repo: str, ref: str, label: str) -> str:
+    probe = _run(
+        repo, "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}", check=False
+    )
+    if probe.returncode:
+        hint = (
+            "\nIf it names a remote you have not configured, add it first:\n"
+            "  git remote add upstream https://github.com/flashinfer-ai/flashinfer.git\n"
+            "  git fetch upstream"
+            if label == "--upstream-ref"
+            else ""
+        )
+        raise ToolError(f"unknown ref '{ref}' passed to {label}.{hint}")
+    return _git(repo, "rev-parse", ref)
+
+
+def run(args: argparse.Namespace) -> int:
+    repo = _git(None, "rev-parse", "--show-toplevel")
+    ours = _resolve(repo, args.ours, "--ours")
+    theirs = _resolve(repo, args.upstream_ref, "--upstream-ref")
+    base = _git(repo, "merge-base", ours, theirs)
+
+    if len(_git(repo, "merge-base", "--all", ours, theirs).split()) > 1:
+        print("NOTE: multiple merge bases -- churn is measured against one of them,")
+        print("      while the merge itself resolves against a virtual base.\n")
+
+    our_churn, _ = _churn_map(repo, base, ours)
+    their_churn, their_renames = _churn_map(repo, base, theirs)
+
+    _report_position(
+        _git(repo, "log", "-1", "--format=%h %ad %s", "--date=short", base),
+        (int(_git(repo, "rev-list", "--count", f"{base}..{ours}")), len(our_churn)),
+        (int(_git(repo, "rev-list", "--count", f"{base}..{theirs}")), len(their_churn)),
+    )
+
+    merged = _merge_tree(repo, ours, theirs)
+    at_base = _ls_tree(repo, base, "") if merged else set()
+    conflicts = []
+    for path, kind in merged:
+        # Follow an upstream rename back to the name our side still edits, or the
+        # most expensive case reports +0/-0 and sorts last.
+        old = their_renames.get(path)
+        ours_churn = our_churn.get(path) or (
+            our_churn.get(old, Churn()) if old else Churn()
+        )
+        if kind == "contents" and path not in at_base:
+            kind = "rename" if old else "add/add"
+        conflicts.append(
+            Conflict(path, ours_churn, their_churn.get(path, Churn()), kind)
+        )
+
+    code = _report_conflicts(conflicts)
+    _report_drift(repo, ours, theirs, their_churn)
+
+    if args.fail_over is not None and code > args.fail_over:
+        print(f"FAIL: {code} code conflicts exceeds --fail-over {args.fail_over}")
+        return EXIT_RATCHET
+    return EXIT_OK
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--upstream-ref",
+        default="upstream/main",
+        help="upstream ref to measure against (default: upstream/main)",
+    )
+    parser.add_argument(
+        "--ours", default="HEAD", help="our ref to measure (default: HEAD)"
+    )
+    parser.add_argument(
+        "--fail-over",
+        type=int,
+        default=None,
+        metavar="N",
+        help="exit 1 if more than N code files conflict, ignoring docs and build config",
+    )
+    try:
+        return run(parser.parse_args())
+    except ToolError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/upstream_canary.py
+++ b/scripts/upstream_canary.py
@@ -141,7 +141,10 @@ def _churn_map(
         else:
             # Rename/copy: path field empty, next two fields are old then new.
             if i + 1 >= len(fields):
-                break
+                raise ToolError(
+                    f"truncated numstat -z rename record at field {i}: expected an "
+                    "old and a new path but the stream ended"
+                )
             renames[fields[i + 1]] = fields[i]
             path = fields[i + 1]
             i += 2

--- a/scripts/upstream_canary.py
+++ b/scripts/upstream_canary.py
@@ -117,9 +117,12 @@ def _churn_map(
 ) -> Tuple[Dict[str, Churn], Dict[str, str]]:
     """Per-path churn for a revision range, plus a new->old map of renames.
 
-    No pathspec: filtering by path suppresses git's rename detection.
+    ``-M`` because rename detection is otherwise subject to diff.renames, and no
+    pathspec because filtering by path suppresses it outright.
     """
-    fields = _run(repo, "diff", "--numstat", "-z", f"{base}..{tip}").stdout.split("\0")
+    fields = _run(repo, "diff", "--numstat", "-z", "-M", f"{base}..{tip}").stdout.split(
+        "\0"
+    )
     churn: Dict[str, Churn] = {}
     renames: Dict[str, str] = {}
     i = 0
@@ -346,7 +349,8 @@ def run(args: argparse.Namespace) -> int:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    summary = (__doc__ or "Report what an upstream sync would cost.").splitlines()[0]
+    parser = argparse.ArgumentParser(description=summary)
     parser.add_argument(
         "--upstream-ref",
         default="upstream/main",

--- a/scripts/upstream_canary.py
+++ b/scripts/upstream_canary.py
@@ -184,7 +184,10 @@ def _merge_tree(repo: str, ours: str, theirs: str) -> List[Tuple[str, str]]:
         paths = fields[idx + 1 : idx + 1 + n_paths]
         type_idx = idx + 1 + n_paths
         if type_idx >= len(fields):
-            break
+            raise ToolError(
+                f"truncated merge-tree -z record at field {idx}: expected a conflict "
+                f"type after {n_paths} path(s) but the stream ended"
+            )
         kind = fields[type_idx]
         idx = type_idx + 2  # skip the human-readable message
         if not kind.startswith("CONFLICT"):

--- a/scripts/upstream_canary.py
+++ b/scripts/upstream_canary.py
@@ -31,8 +31,9 @@ from typing import Dict, List, NamedTuple, Optional, Set, Tuple
 
 EXIT_OK, EXIT_RATCHET, EXIT_ERROR = 0, 1, 2
 
-# Conflicts here say nothing about design: the port keeps its own docs, build
-# metadata, and regenerated sample output.
+# The port's own docs, packaging metadata, and regenerated sample output. Not a
+# general "docs and config" exemption: an edit to .github/workflows/ or docker/
+# is a real in-place edit to an upstream file, so it stays in the count.
 _EXPECTED_BASENAME_GLOBS = ("*.md", "*.toml")
 _EXPECTED_EXACT = (".gitignore", ".pre-commit-config.yaml", "version.txt")
 _EXPECTED_PREFIXES = ("benchmarks/samples/",)
@@ -133,7 +134,10 @@ def _churn_map(
             continue
         parts = record.split("\t")
         if len(parts) < 3:
-            continue
+            raise ToolError(
+                f"malformed numstat -z record at field {i - 1}: {record!r}; "
+                "expected added, deleted and path"
+            )
         added = int(parts[0]) if parts[0].isdigit() else 0  # "-" marks a binary file
         deleted = int(parts[1]) if parts[1].isdigit() else 0
         if parts[2]:
@@ -370,7 +374,8 @@ def main() -> int:
         type=int,
         default=None,
         metavar="N",
-        help="exit 1 if more than N code files conflict, ignoring docs and build config",
+        help="exit 1 if more than N conflicts are outside the port's own docs "
+        "and packaging metadata",
     )
     try:
         return run(parser.parse_args())


### PR DESCRIPTION
## Summary

Adds a script that reports what an upstream sync would cost without performing one, and writes down the additive-only policy that has until now been enforced structurally but stated nowhere. Both exist to make the fork's maintenance cost a number we watch rather than one we discover at merge time.

### What changed

- **`scripts/upstream_canary.py`** — new. Reports position relative to the merge base, the conflicts a merge would raise ranked by both sides' churn, and upstream churn on the headers `attention/generic/` forked. No GPU, no build, ~4s.
- **`CONTRIBUTING.md`** — new "Additive-Only" section: the rule, the three sanctioned mechanisms in preference order, and what to do when none of them serve. Also corrects the PR target from `ROCm/flashinfer` to `AMD-Ecosystem/flashinfer`.

### Architecture / design notes

The fork is ~1050 upstream commits and ~2170 files behind the merge base, and the last two syncs were big-bang (the v0.5.3 merge was 581 files / 74k lines). The tool's job is to make the cost visible continuously instead. The encouraging result it reports: the port is overwhelmingly additive — only **23 files are code a merge would actually conflict on**.

The third report exists because forked headers have the *opposite* problem from edited ones. An edited upstream file conflicts, which is annoying but self-announcing; a forked header conflicts with nothing and goes stale in silence. It immediately flagged `include/flashinfer/allocator.h` at +43/-2 upstream, which no conflict would ever have raised.

Three implementation choices worth recording, each of which was a bug first:

| Choice | Why |
|---|---|
| Every git call runs `-C <toplevel>` | git reports paths relative to the cwd, so without it a run from a subdirectory returned `../CHANGELOG.md`, missed the expected-path match, and counted docs as code conflicts |
| One `git diff --numstat -z -M` per side, no pathspec | Per-file invocation cost 118 subprocesses and ~30s against ~4s now; a pathspec also suppresses rename detection, and `-M` pins it against `diff.renames` |
| Conflict types read as `-z` structured fields | git's English prose is translated under a non-C locale; an unparsable record now raises rather than truncating, because an under-count reads as good news |

Upstream renames are followed back to the name our side still edits. Without that a rename conflict reports `ours +0/-0` and, being absent from the merge base, is mislabelled add/add — so the single most expensive sync case sorted last with weight 0.

`--fail-over` is for ratcheting this in CI once the conflict set has been evacuated. Nothing invokes it yet and the doc does not claim otherwise.

## Test plan

- [x] Tool run against `v0.6.18rc3` from the repo root and from a subdirectory — byte-identical output
- [x] Rename handling A/B'd on a synthetic repo — before: `bar.py ours +0/-0 [add/add]`; after: `bar.py ours +1/-1 [rename]`
- [x] Same A/B repeated with `diff.renames=false` to confirm `-M` pins the behaviour
- [x] `python3 -OO` run to confirm the argparse description survives stripped docstrings
- [x] Exit codes verified distinct: 0 clean, 1 ratchet breach, 2 tool error
- [x] No pytest run: this adds a script and a doc and touches no library code, so nothing in the suite reaches it
- [x] `pre-commit run -a`