### PR TITLE
fix(rocm): name the AITER ABI pin when the loader fails

### DIFF
--- a/flashinfer/csrc_rocm/aiter_loader.cc
+++ b/flashinfer/csrc_rocm/aiter_loader.cc
@@ -19,6 +19,13 @@ namespace flashinfer::aiter {
 
 namespace {
 
+// Appended to failures on the paths that resolve the pinned mangled symbols
+// below. Keep the version in step with _AITER_LAST_VALIDATED in prefill_rocm.py.
+constexpr const char* kAbiPinNote =
+    "\n  These symbols and .so names are pinned to amd-aiter 0.1.10, which has no stable"
+    "\n  C++ ABI. If AITER was upgraded, that is the likely cause: either reinstall the"
+    "\n  pin (pip install amd-aiter==0.1.10) or re-pin the symbols in aiter_loader.cc.";
+
 std::string get_jit_dir() {
   if (const char* env = std::getenv("AITER_JIT_DIR")) return env;
 #ifdef FLASHINFER_AITER_JIT_DIR
@@ -82,7 +89,7 @@ void* load_and_cache_sym(std::shared_mutex& mu, std::unordered_map<Key, void*, H
     const char* err = dlerror();
     dlclose(handle);
     throw std::runtime_error("dlsym(" + std::string(sym_name) + ") failed in " + so_path + ": " +
-                             (err ? err : "unknown"));
+                             (err ? err : "unknown") + "\n" + hint_fn());
   }
 
   cache.emplace(key, sym);
@@ -169,7 +176,7 @@ void* get_aiter_mha_fwd_handle(VariantKey const& key) {
            "calling mha_fwd with matching (dtype=" +
            std::string(key.dtype == VariantKey::Dtype::kFp16 ? "fp16" : "bf16") +
            ", causal=" + (key.causal ? "true" : "false") +
-           ", has_lse=" + (key.has_lse ? "true" : "false") + ").";
+           ", has_lse=" + (key.has_lse ? "true" : "false") + ")." + kAbiPinNote;
   });
 }
 
@@ -180,7 +187,7 @@ void* get_aiter_mha_varlen_fwd_handle(VariantKey const& key) {
            "calling mha_varlen_fwd with matching (dtype=" +
            std::string(key.dtype == VariantKey::Dtype::kFp16 ? "fp16" : "bf16") +
            ", causal=" + (key.causal ? "true" : "false") +
-           ", has_lse=" + (key.has_lse ? "true" : "false") + ").";
+           ", has_lse=" + (key.has_lse ? "true" : "false") + ")." + kAbiPinNote;
   });
 }
 
@@ -195,7 +202,7 @@ void* get_aiter_mha_batch_prefill_handle(BatchPrefillVariantKey const& key) {
                ", has_lse=" + (key.has_lse ? "true" : "false") +
                ") before this C++ path.\n"
                "  If the .so exists but dlsym fails, run: nm -D " +
-               so_path + " | grep mha_batch_prefill";
+               so_path + " | grep mha_batch_prefill" + kAbiPinNote;
       });
 }
 

--- a/flashinfer/csrc_rocm/aiter_loader.cc
+++ b/flashinfer/csrc_rocm/aiter_loader.cc
@@ -23,8 +23,10 @@ namespace {
 // below. Keep the version in step with _AITER_LAST_VALIDATED in prefill_rocm.py.
 constexpr const char* kAbiPinNote =
     "\n  These symbols and .so names are pinned to amd-aiter 0.1.10, which has no stable"
-    "\n  C++ ABI. If AITER was upgraded, that is the likely cause: either reinstall the"
-    "\n  pin (pip install amd-aiter==0.1.10) or re-pin the symbols in aiter_loader.cc.";
+    "\n  C++ ABI. If AITER was upgraded, that is the likely cause. Reinstall the pin:"
+    "\n    pip install amd-aiter==0.1.10 \\"
+    "\n      --extra-index-url https://pypi.amd.com/rocm-7.1.1/simple"
+    "\n  or re-pin the symbols in flashinfer/csrc_rocm/aiter_loader.cc.";
 
 std::string get_jit_dir() {
   if (const char* env = std::getenv("AITER_JIT_DIR")) return env;


### PR DESCRIPTION
## Summary

When the AITER loader fails to find a symbol or a variant `.so`, the error now names the AITER version the loader is pinned to and gives a working command to reinstall it. Diagnostic only — the sole behaviour change is the text of an exception that was already being thrown.

### What changed

- **`flashinfer/csrc_rocm/aiter_loader.cc`** — adds `kAbiPinNote`, appended to failures on the three paths that resolve the pinned mangled symbols, and invokes the existing per-caller `hint_fn` on the `dlsym` path as well as `dlopen`.

### Architecture / design notes

The loader `dlopen`s AITER variant `.so` files and `dlsym`s two hard-coded Itanium-mangled symbols read off `nm -D` against amd-aiter 0.1.10. AITER has no stable C++ ABI, so any other release renames, hides, or drops them — and the only symptom is a null `dlsym` at first kernel call, with an error naming nothing but the mangled symbol. The version gap is by far the most likely cause and nothing pointed at it.

The note is attached **per-caller** through `hint_fn` rather than inside `load_and_cache_sym`. That helper is shared with `get_aiter_extern_c_handle`, which resolves arbitrary `extern "C"` names from runtime-JIT-compiled modules the pin does not govern — telling that caller to downgrade AITER would send it chasing a bug a downgrade cannot fix.

`hint_fn` now also fires on the `dlsym` path, not just `dlopen`. An upgrade past the pin frequently changes AITER's variant `.so` naming scheme, so it surfaces as "not found" about as often as a symbol miss.

An earlier version of this change baked the *installed* AITER version in as `-DFLASHINFER_AITER_VERSION` and compared it against the pin. It was reverted as self-defeating: none of the three call sites route through `refresh_aiter_jitspec`, and `JitSpec.build()` only writes `build.ninja` when the file is missing. On the upgrade path the define stays frozen at the old value, compares *equal* to the pin, and suppresses the advice — disarmed in precisely the case it was written for. The real fix is to key the JIT uri on the AITER version, as `_aiter_cache_tag` already does for `aiter_libs/`; that invalidates every cached AITER module and belongs in its own change.

## Test plan

- [x] Message text verified by compiling the constant standalone under `g++ -std=c++20 -Wall -Wextra` and printing it
- [x] Install command cross-checked against the `--extra-index-url` form documented in `CLAUDE.md` and `README.md`
- [x] No pytest run: the change is the text of an exception on an AITER failure path, which no test in the suite exercises
- [x] gfx942 (MI300X) and gfx950 (MI350X): unaffected by construction — no code path changes, and the file only compiles into AITER-backed modules
- [x] `pre-commit run -a`