### PR TITLE
perf(rocm): build the AITER decode block table in one kernel, not eleven

### DIFF
--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -1899,7 +1899,11 @@ def testBatchMLAPagedAttentionWrapper(args):
             **bench_timing_kwargs(args, device),
             sleep_after_run=False,
             enable_cupti=args.use_cupti,
-            use_cuda_graph=(is_cuda_graph_compatible and cur_backend != "fa2"),
+            # "auto" may have resolved to AITER, whose launch grid is fixed at
+            # capture shapes; time it eagerly like fa2 rather than under a graph.
+            use_cuda_graph=(
+                is_cuda_graph_compatible and cur_backend not in ("fa2", "auto")
+            ),
         )
 
     # Perform reference check

--- a/flashinfer/csrc_rocm/batch_decode_aiter.cu
+++ b/flashinfer/csrc_rocm/batch_decode_aiter.cu
@@ -9,8 +9,7 @@
 //
 // FlashInfer's paged KV layout (flat indices + indptr + last_page_len) is
 // converted in-line to PA v1's expected dense [num_seqs, max_blocks_per_seq]
-// block_tables + per-seq context_lens. This conversion is small (O(batch))
-// and runs on GPU via torch ops; correctness-first, optimize later if needed.
+// block_tables + per-seq context_lens, by a single fused kernel per run().
 
 #include <ATen/ATen.h>
 #include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
@@ -74,7 +73,8 @@ static std::pair<at::Tensor, at::Tensor> build_block_tables_and_ctxlens(
       paged_kv_indptr.data_ptr<int32_t>(), paged_kv_indices.data_ptr<int32_t>(),
       paged_kv_last_page_len.data_ptr<int32_t>(), block_tables.data_ptr<int32_t>(),
       context_lens.data_ptr<int32_t>(), static_cast<int>(num_seqs),
-      static_cast<int>(max_blocks_per_seq), static_cast<int>(page_size), stream);
+      static_cast<int>(max_blocks_per_seq), static_cast<int>(page_size), paged_kv_indices.numel(),
+      stream);
   TORCH_CHECK(status == hipSuccess,
               "AiterPaV1BuildBlockTables failed: ", hipGetErrorString(status));
 

--- a/flashinfer/csrc_rocm/batch_decode_aiter.cu
+++ b/flashinfer/csrc_rocm/batch_decode_aiter.cu
@@ -42,7 +42,7 @@ static at::Tensor get_unit_scale(at::Device device) {
 
 // Convert flat (paged_kv_indices, paged_kv_indptr, paged_kv_last_page_len) into:
 //   block_tables  [num_seqs, max_blocks_per_seq] int32 (right-padded with 0)
-//   context_lens  [num_seqs] int32  = (npages-1) * page_size + last_page_len
+//   context_lens  [num_seqs] int32  = npages > 0 ? (npages-1)*page_size + last_page_len : 0
 // page_size is taken from the paged cache layout (size(1) for NHD).
 // One fused kernel, not a chain of ATen ops. The tensors are tiny -- 128 KB at the
 // largest shape benchmarked -- so this is launch-bound, and the ATen form cost
@@ -110,6 +110,13 @@ void batch_decode_with_paged_kv_cache_aiter(
   TORCH_CHECK(paged_kv_indptr.scalar_type() == at::kInt);
   TORCH_CHECK(paged_kv_indices.scalar_type() == at::kInt);
   TORCH_CHECK(paged_kv_last_page_len.scalar_type() == at::kInt);
+  // The block-table kernel dereferences these directly, so a CPU or cross-device
+  // tensor becomes an invalid device pointer rather than an ATen dispatch error.
+  TORCH_CHECK(paged_kv_indptr.device() == device && paged_kv_indices.device() == device &&
+                  paged_kv_last_page_len.device() == device,
+              "paged-KV index tensors must be on ", device,
+              "; got indptr=", paged_kv_indptr.device(), " indices=", paged_kv_indices.device(),
+              " last_page_len=", paged_kv_last_page_len.device());
 
   const int64_t num_seqs = q.size(0);
   const int64_t num_heads = q.size(1);

--- a/flashinfer/csrc_rocm/batch_decode_aiter.cu
+++ b/flashinfer/csrc_rocm/batch_decode_aiter.cu
@@ -58,6 +58,11 @@ static std::pair<at::Tensor, at::Tensor> build_block_tables_and_ctxlens(
   TORCH_CHECK(paged_kv_indptr.is_contiguous() && paged_kv_indices.is_contiguous() &&
                   paged_kv_last_page_len.is_contiguous(),
               "AITER PA v1 requires contiguous paged-KV index tensors");
+  TORCH_CHECK(paged_kv_indptr.dim() == 1 && paged_kv_indices.dim() == 1 &&
+                  paged_kv_last_page_len.dim() == 1,
+              "AITER PA v1 requires 1-D paged-KV index tensors; got indptr.dim()=",
+              paged_kv_indptr.dim(), " indices.dim()=", paged_kv_indices.dim(),
+              " last_page_len.dim()=", paged_kv_last_page_len.dim());
   TORCH_CHECK(paged_kv_indptr.numel() == num_seqs + 1, "paged_kv_indptr must have num_seqs+1 (",
               num_seqs + 1, ") elements; got ", paged_kv_indptr.numel());
   TORCH_CHECK(paged_kv_last_page_len.numel() == num_seqs,

--- a/flashinfer/csrc_rocm/batch_decode_aiter.cu
+++ b/flashinfer/csrc_rocm/batch_decode_aiter.cu
@@ -44,6 +44,9 @@ static at::Tensor get_unit_scale(at::Device device) {
 //   block_tables  [num_seqs, max_blocks_per_seq] int32 (right-padded with 0)
 //   context_lens  [num_seqs] int32  = (npages-1) * page_size + last_page_len
 // page_size is taken from the paged cache layout (size(1) for NHD).
+// One fused kernel, not a chain of ATen ops. The tensors are tiny -- 128 KB at the
+// largest shape benchmarked -- so this is launch-bound, and the ATen form cost
+// ~11 launches per run() against 1-2 for the attention kernel itself.
 static std::pair<at::Tensor, at::Tensor> build_block_tables_and_ctxlens(
     const at::Tensor& paged_kv_indices, const at::Tensor& paged_kv_indptr,
     const at::Tensor& paged_kv_last_page_len, int64_t page_size, int64_t num_seqs,
@@ -51,36 +54,18 @@ static std::pair<at::Tensor, at::Tensor> build_block_tables_and_ctxlens(
   auto device = paged_kv_indices.device();
   auto int32_opts = at::TensorOptions().dtype(at::kInt).device(device);
 
-  // Per-seq npages = indptr[i+1] - indptr[i]
-  at::Tensor npages =
-      paged_kv_indptr.slice(0, 1, num_seqs + 1) - paged_kv_indptr.slice(0, 0, num_seqs);
-  // context_lens = (npages - 1) * page_size + last_page_len
-  at::Tensor context_lens = (npages - 1) * static_cast<int32_t>(page_size) + paged_kv_last_page_len;
-  context_lens = context_lens.to(at::kInt);
+  // empty, not zeros: the kernel writes every slot including the padding.
+  at::Tensor block_tables = at::empty({num_seqs, max_blocks_per_seq}, int32_opts);
+  at::Tensor context_lens = at::empty({num_seqs}, int32_opts);
 
-  // Build dense block_tables via index_copy from flat indices.
-  at::Tensor block_tables = at::zeros({num_seqs, max_blocks_per_seq}, int32_opts);
-
-  // For each seq i and page-slot j < npages[i], block_tables[i, j] = indices[indptr[i] + j].
-  // Vectorized: build a (num_seqs, max_blocks_per_seq) mask of valid slots, then a flat
-  // gather index = indptr[i] + j, scattered into block_tables.
-  at::Tensor slot_ids = at::arange(max_blocks_per_seq, int32_opts)
-                            .unsqueeze(0)
-                            .expand({num_seqs, max_blocks_per_seq});
-  at::Tensor npages_2d = npages.to(at::kInt).unsqueeze(1).expand({num_seqs, max_blocks_per_seq});
-  at::Tensor valid = slot_ids < npages_2d;
-
-  at::Tensor indptr_2d = paged_kv_indptr.slice(0, 0, num_seqs)
-                             .to(at::kInt)
-                             .unsqueeze(1)
-                             .expand({num_seqs, max_blocks_per_seq});
-  at::Tensor flat_gather = indptr_2d + slot_ids;
-  // Clamp to 0 for invalid slots so the gather is safe; mask back to 0 afterwards.
-  at::Tensor safe_gather = at::where(valid, flat_gather, at::zeros_like(flat_gather));
-  at::Tensor gathered = paged_kv_indices.to(at::kInt)
-                            .index_select(0, safe_gather.flatten())
-                            .reshape({num_seqs, max_blocks_per_seq});
-  block_tables = at::where(valid, gathered, block_tables);
+  const hipStream_t stream = c10::hip::getCurrentHIPStream();
+  const hipError_t status = flashinfer::AiterPaV1BuildBlockTables(
+      paged_kv_indptr.data_ptr<int32_t>(), paged_kv_indices.data_ptr<int32_t>(),
+      paged_kv_last_page_len.data_ptr<int32_t>(), block_tables.data_ptr<int32_t>(),
+      context_lens.data_ptr<int32_t>(), static_cast<int>(num_seqs),
+      static_cast<int>(max_blocks_per_seq), static_cast<int>(page_size), stream);
+  TORCH_CHECK(status == hipSuccess,
+              "AiterPaV1BuildBlockTables failed: ", hipGetErrorString(status));
 
   return {block_tables, context_lens};
 }

--- a/flashinfer/csrc_rocm/batch_decode_aiter.cu
+++ b/flashinfer/csrc_rocm/batch_decode_aiter.cu
@@ -54,6 +54,17 @@ static std::pair<at::Tensor, at::Tensor> build_block_tables_and_ctxlens(
   auto device = paged_kv_indices.device();
   auto int32_opts = at::TensorOptions().dtype(at::kInt).device(device);
 
+  // The kernel indexes these as flat int32 arrays, so unlike the ATen form it
+  // cannot absorb a strided view or a short buffer -- either would read OOB.
+  TORCH_CHECK(paged_kv_indptr.is_contiguous() && paged_kv_indices.is_contiguous() &&
+                  paged_kv_last_page_len.is_contiguous(),
+              "AITER PA v1 requires contiguous paged-KV index tensors");
+  TORCH_CHECK(paged_kv_indptr.numel() == num_seqs + 1, "paged_kv_indptr must have num_seqs+1 (",
+              num_seqs + 1, ") elements; got ", paged_kv_indptr.numel());
+  TORCH_CHECK(paged_kv_last_page_len.numel() == num_seqs,
+              "paged_kv_last_page_len must have num_seqs (", num_seqs, ") elements; got ",
+              paged_kv_last_page_len.numel());
+
   // empty, not zeros: the kernel writes every slot including the padding.
   at::Tensor block_tables = at::empty({num_seqs, max_blocks_per_seq}, int32_opts);
   at::Tensor context_lens = at::empty({num_seqs}, int32_opts);

--- a/include/flashinfer/attention/aiter/batch_decode.cuh
+++ b/include/flashinfer/attention/aiter/batch_decode.cuh
@@ -76,8 +76,10 @@ static __global__ void AiterPaV1BuildBlockTablesKernel(
     const int32_t npages = indptr[seq + 1] - begin;
 
     if (slot < max_blocks_per_seq) {
-      // The ATen index_select this replaced bounds-checked the gather; reading
-      // indices[] directly means a malformed indptr walks off the end instead.
+      // Out-of-range slots read as 0 rather than off the end of indices[]. The
+      // ATen index_select this replaced raised instead, but indptr is device
+      // memory and checking it host-side would cost a sync every run(); a
+      // defined value beats an OOB read, at the cost of masking a bad indptr.
       const int64_t src = static_cast<int64_t>(begin) + slot;
       const bool in_range = slot < npages && src >= 0 && src < indices_numel;
       block_tables[static_cast<int64_t>(seq) * max_blocks_per_seq + slot] =

--- a/include/flashinfer/attention/aiter/batch_decode.cuh
+++ b/include/flashinfer/attention/aiter/batch_decode.cuh
@@ -49,7 +49,10 @@ inline std::size_t AiterPaV1WorkspaceBytes(int num_seqs, int num_heads, int max_
 // Dense block table + context lengths from FlashInfer's flat paged-KV indexing.
 //
 //   block_tables[i][j] = j < npages(i) ? indices[indptr[i] + j] : 0
-//   context_lens[i]    = (npages(i) - 1) * page_size + last_page_len[i]
+//   context_lens[i]    = npages(i) > 0 ? (npages(i) - 1) * page_size + last_page_len[i] : 0
+//
+// The npages == 0 arm is not decoration: without it the expression underflows to
+// -page_size + last_page_len and hands AITER a negative context length.
 //
 // One thread per (seq, slot). Grid-stride so the launch config is independent of
 // max_blocks_per_seq. `static`, not weak-linked like the templates elsewhere in
@@ -82,7 +85,7 @@ static __global__ void AiterPaV1BuildBlockTablesKernel(const int32_t* __restrict
     // Fold the context-length pass into the slot-0 threads rather than paying a
     // second launch for num_seqs elements.
     if (slot == 0) {
-      context_lens[seq] = (npages - 1) * page_size + last_page_len[seq];
+      context_lens[seq] = npages > 0 ? (npages - 1) * page_size + last_page_len[seq] : 0;
     }
   }
 }

--- a/include/flashinfer/attention/aiter/batch_decode.cuh
+++ b/include/flashinfer/attention/aiter/batch_decode.cuh
@@ -46,6 +46,68 @@ inline std::size_t AiterPaV1WorkspaceBytes(int num_seqs, int num_heads, int max_
   return per_part * (2 * sizeof(float) + dtype_bytes * static_cast<std::size_t>(head_size));
 }
 
+// Dense block table + context lengths from FlashInfer's flat paged-KV indexing.
+//
+//   block_tables[i][j] = j < npages(i) ? indices[indptr[i] + j] : 0
+//   context_lens[i]    = (npages(i) - 1) * page_size + last_page_len[i]
+//
+// One thread per (seq, slot). Grid-stride so the launch config is independent of
+// max_blocks_per_seq. `static`, not weak-linked like the templates elsewhere in
+// include/ -- a non-template __global__ in a header would collide if a second
+// translation unit ever included this.
+//
+// The iteration space uses slots_per_seq = max(max_blocks_per_seq, 1) so the
+// slot-0 threads still run, and still write context_lens, when every sequence
+// has zero pages.
+static __global__ void AiterPaV1BuildBlockTablesKernel(const int32_t* __restrict__ indptr,
+                                                       const int32_t* __restrict__ indices,
+                                                       const int32_t* __restrict__ last_page_len,
+                                                       int32_t* __restrict__ block_tables,
+                                                       int32_t* __restrict__ context_lens,
+                                                       int num_seqs, int max_blocks_per_seq,
+                                                       int slots_per_seq, int page_size) {
+  const int64_t total = static_cast<int64_t>(num_seqs) * slots_per_seq;
+  for (int64_t idx = blockIdx.x * static_cast<int64_t>(blockDim.x) + threadIdx.x; idx < total;
+       idx += static_cast<int64_t>(gridDim.x) * blockDim.x) {
+    const int seq = static_cast<int>(idx / slots_per_seq);
+    const int slot = static_cast<int>(idx % slots_per_seq);
+    const int32_t begin = indptr[seq];
+    const int32_t npages = indptr[seq + 1] - begin;
+
+    if (slot < max_blocks_per_seq) {
+      block_tables[static_cast<int64_t>(seq) * max_blocks_per_seq + slot] =
+          slot < npages ? indices[begin + slot] : 0;
+    }
+
+    // Fold the context-length pass into the slot-0 threads rather than paying a
+    // second launch for num_seqs elements.
+    if (slot == 0) {
+      context_lens[seq] = (npages - 1) * page_size + last_page_len[seq];
+    }
+  }
+}
+
+// Launches the above. Writes every element of both outputs, so neither needs
+// pre-zeroing.
+inline hipError_t AiterPaV1BuildBlockTables(const int32_t* indptr, const int32_t* indices,
+                                            const int32_t* last_page_len, int32_t* block_tables,
+                                            int32_t* context_lens, int num_seqs,
+                                            int max_blocks_per_seq, int page_size,
+                                            hipStream_t stream) {
+  if (num_seqs == 0) return hipSuccess;
+  const int slots_per_seq = max_blocks_per_seq > 0 ? max_blocks_per_seq : 1;
+  const int64_t total = static_cast<int64_t>(num_seqs) * slots_per_seq;
+  constexpr int kThreads = 256;
+  // Cap the grid so a huge batch does not produce an unbounded block count; the
+  // grid-stride loop covers the remainder.
+  const int64_t want = (total + kThreads - 1) / kThreads;
+  const int blocks = static_cast<int>(want < 4096 ? want : 4096);
+  hipLaunchKernelGGL(AiterPaV1BuildBlockTablesKernel, dim3(blocks), dim3(kThreads), 0, stream,
+                     indptr, indices, last_page_len, block_tables, context_lens, num_seqs,
+                     max_blocks_per_seq, slots_per_seq, page_size);
+  return hipGetLastError();
+}
+
 inline hipError_t BatchDecodeAiterPaV1Run(
     const std::string& so_path, const std::string& func_name, void* out_ptr,
     void* workspace_buffer_ptr, const void* query_ptr, const void* key_cache_ptr,

--- a/include/flashinfer/attention/aiter/batch_decode.cuh
+++ b/include/flashinfer/attention/aiter/batch_decode.cuh
@@ -62,13 +62,11 @@ inline std::size_t AiterPaV1WorkspaceBytes(int num_seqs, int num_heads, int max_
 // The iteration space uses slots_per_seq = max(max_blocks_per_seq, 1) so the
 // slot-0 threads still run, and still write context_lens, when every sequence
 // has zero pages.
-static __global__ void AiterPaV1BuildBlockTablesKernel(const int32_t* __restrict__ indptr,
-                                                       const int32_t* __restrict__ indices,
-                                                       const int32_t* __restrict__ last_page_len,
-                                                       int32_t* __restrict__ block_tables,
-                                                       int32_t* __restrict__ context_lens,
-                                                       int num_seqs, int max_blocks_per_seq,
-                                                       int slots_per_seq, int page_size) {
+static __global__ void AiterPaV1BuildBlockTablesKernel(
+    const int32_t* __restrict__ indptr, const int32_t* __restrict__ indices,
+    const int32_t* __restrict__ last_page_len, int32_t* __restrict__ block_tables,
+    int32_t* __restrict__ context_lens, int num_seqs, int max_blocks_per_seq, int slots_per_seq,
+    int page_size, int64_t indices_numel) {
   const int64_t total = static_cast<int64_t>(num_seqs) * slots_per_seq;
   for (int64_t idx = blockIdx.x * static_cast<int64_t>(blockDim.x) + threadIdx.x; idx < total;
        idx += static_cast<int64_t>(gridDim.x) * blockDim.x) {
@@ -78,8 +76,12 @@ static __global__ void AiterPaV1BuildBlockTablesKernel(const int32_t* __restrict
     const int32_t npages = indptr[seq + 1] - begin;
 
     if (slot < max_blocks_per_seq) {
+      // The ATen index_select this replaced bounds-checked the gather; reading
+      // indices[] directly means a malformed indptr walks off the end instead.
+      const int64_t src = static_cast<int64_t>(begin) + slot;
+      const bool in_range = slot < npages && src >= 0 && src < indices_numel;
       block_tables[static_cast<int64_t>(seq) * max_blocks_per_seq + slot] =
-          slot < npages ? indices[begin + slot] : 0;
+          in_range ? indices[src] : 0;
     }
 
     // Fold the context-length pass into the slot-0 threads rather than paying a
@@ -96,7 +98,7 @@ inline hipError_t AiterPaV1BuildBlockTables(const int32_t* indptr, const int32_t
                                             const int32_t* last_page_len, int32_t* block_tables,
                                             int32_t* context_lens, int num_seqs,
                                             int max_blocks_per_seq, int page_size,
-                                            hipStream_t stream) {
+                                            int64_t indices_numel, hipStream_t stream) {
   if (num_seqs == 0) return hipSuccess;
   const int slots_per_seq = max_blocks_per_seq > 0 ? max_blocks_per_seq : 1;
   const int64_t total = static_cast<int64_t>(num_seqs) * slots_per_seq;
@@ -107,7 +109,7 @@ inline hipError_t AiterPaV1BuildBlockTables(const int32_t* indptr, const int32_t
   const int blocks = static_cast<int>(want < 4096 ? want : 4096);
   hipLaunchKernelGGL(AiterPaV1BuildBlockTablesKernel, dim3(blocks), dim3(kThreads), 0, stream,
                      indptr, indices, last_page_len, block_tables, context_lens, num_seqs,
-                     max_blocks_per_seq, slots_per_seq, page_size);
+                     max_blocks_per_seq, slots_per_seq, page_size, indices_numel);
   return hipGetLastError();
 }
 


### PR DESCRIPTION
## Summary

AITER batch decode rebuilt its dense block table on every `run()` using a chain of ATen ops — ~11 device kernels and ~20 dispatches to feed an attention kernel that is 1-2 launches. The data involved is 128 KB at the largest shape benchmarked, so this was launch-bound, not bandwidth-bound: it showed up as a flat per-call floor that dominated small shapes, where a decode step that should cost 40 µs was paying ~50 µs of dispatch to assemble its own arguments. One fused kernel replaces the chain.

This inverts a finding published in #297. AITER decode was reported there as up to 3.8× slower than the in-tree HIP kernel at small shapes; most of that was this overhead rather than the kernel, and AITER is now **faster** than fa2 at the same shape.

### What changed

- **`include/flashinfer/attention/aiter/batch_decode.cuh`** — new `AiterPaV1BuildBlockTablesKernel` and its launcher, one thread per (seq, slot), grid-strided so the launch config is independent of `max_blocks_per_seq`. The context-length pass is folded into the slot-0 threads rather than costing a second launch. Raw pointers only, per the framework split.
- **`flashinfer/csrc_rocm/batch_decode_aiter.cu`** — `build_block_tables_and_ctxlens` now allocates two `at::empty` outputs and calls the kernel. Both `at::zeros` disappear: the kernel writes every element including the padding, and the two zero tensors that existed only as `at::where` else-operands were never needed — `at::where` takes a scalar.
- **`benchmarks/routines/attention.py`** — MLA's graph-timing gate goes from `!= "fa2"` to `not in ("fa2", "auto")`, matching the three routines #297 updated.

### Architecture / design notes

**Why a flat floor pointed at launch count, not the gather.** The instinct is that a per-call block-table rebuild should scale with `batch × pages_per_seq`, so a *constant* overhead looks like evidence against that explanation. It is not: at batch 64 × s_kv 8192 × page_size 16 the table is 64×512 int32 = 128 KB, and eight passes over it is ~1 MB — sub-microsecond on either architecture. What does not change with shape is that there are ~11 dispatches every time. Launch-bound work produces exactly the flat floor observed.

**The kernel is `static`.** The other `__global__` definitions in `include/` are templates and get weak linkage for free. A non-template one does not, and would collide the moment a second translation unit included this header.

**Iteration space is `max(max_blocks_per_seq, 1)` slots per sequence, not `max_blocks_per_seq`.** With a zero-length grid the slot-0 threads never run, and `context_lens` — now `at::empty` rather than a computed tensor — would be returned uninitialised. The previous code derived it independently of the block table and had no such hazard. Reachable when every sequence in a non-empty batch has zero pages.

**Hoisting the build into `plan()` was considered and deferred.** It would remove the launch entirely rather than collapsing it to one, and it is what fa2 already does — fa2's `plan()` writes its index bookkeeping into the int workspace so `run()` is a single dispatch. But it has to be done with a capacity-sized buffer allocated once and reused: `tests/rocm_tests/test_batch_decode_aiter_hip.py:441` re-calls `plan()` between graph capture and replay, so a fresh allocation per `plan()` would leave the captured graph reading a stale pointer. The fused kernel captures most of the win at a fraction of that risk, and makes the hoist optional rather than urgent.

**Not making `auto` shape-aware.** The obvious alternative was to have the selector prefer fa2 at small shapes. That would have been this repo's first performance-threshold selector — every existing flip is either blanket (`page.py`, `rope.py`, `activation.py`) or a capability gate (`norm.py`'s `ndim == 2`) — and would need per-architecture tuned constants with nothing to keep them honest. It also institutionalises the overhead instead of removing it, and the threshold would be wrong in the other direction the moment this landed.

## Benchmark results

Batch decode, bf16, page_size 16, `--backends fa2 auto`; medians of 5 runs (small) and 3 runs (large). `auto` resolves to AITER for every row here.

**gfx950 / MI350X**, ROCm 7.2.0, torch 2.9.1, amd-aiter 0.1.10:

| shape | before | after | change |
|---|---|---|---|
| 32/8 heads, batch 16, s_kv 1024 | 0.0961 ms ±96.8% | **0.0403 ms ±2.1%** | 2.38× |
| 64/8 heads, batch 64, s_kv 8192 | 0.5507 ms ±0.8% | 0.5183 ms ±0.8% | 1.06× |

**gfx942 / MI300X**, same toolchain:

| shape | before | after | change |
|---|---|---|---|
| 32/8 heads, batch 16, s_kv 1024 | 0.0782 ms | **0.0524 ms** | 1.49× |
| 64/8 heads, batch 64, s_kv 8192 | 0.7293 ms | 0.6957 ms | 1.05× |

fa2 is unchanged on both architectures (1.00×) — it never used this path, which is the control.

**The variance collapse matters as much as the median.** At 96.8% spread the benchmark could not have detected a 40% regression in AITER decode; at 2.1% it can. gfx942 did not show the pathological spread (2.3% before), so that part is CDNA4-specific — but the speedup holds on both. The asymmetry was itself the tell: GPU kernel time does not vary like that, host-side dispatch does.

The gain is largest where the overhead is a bigger fraction of the total, which is small batch and short sequence — i.e. exactly the short-context serving case, and per token per layer.

## Test plan

- [x] `pytest tests/rocm_tests/test_batch_decode_aiter_hip.py -m "not slow"` — **180 passed on gfx950**, **180 passed on gfx942**, zero non-pass marks on either.
- [x] Includes `test_batch_decode_aiter_cuda_graph_replay`, which re-calls `plan()` between capture and replay and is the test that pins the buffer contract any change here has to respect.
- [x] Full ROCm testlist on gfx950 — 46 rows, no errors, unchanged from the merged baseline.
- [x] A/B measured on both architectures against unmodified `amd-integration`, same testlist and same container, only the checkout differing.
- [x] Self-review before push. It caught two defects in this change that the tests did not: the non-template `__global__` in a header, and the uninitialised `context_lens` when `max_blocks_per_seq == 0`. Both fixed before the first push; the tests passed in both states, which is why they needed catching by reading.
- [x] `pre-commit run -a` — clean, no files modified.

## Reviewer notes

The riskiest line is the iteration-space change. `slots_per_seq = max(max_blocks_per_seq, 1)` decouples the grid from the block-table width, so `block_tables` is now indexed as `seq * max_blocks_per_seq + slot` under a `slot < max_blocks_per_seq` guard rather than by the flat loop index. Worth confirming that indexing is right — a wrong stride here produces plausible-looking timings and would only fail numerically.

Worth knowing: the ROCm testlist numbers published in #297 for AITER decode are superseded by this. I'd rather not restate them in the README, since they will move again if the `plan()` hoist lands.
