### PR TITLE
fix(tools): validate the merge-tree record tail, not just its head

### DIFF
--- a/scripts/upstream_canary.py
+++ b/scripts/upstream_canary.py
@@ -190,10 +190,13 @@ def _merge_tree(repo: str, ours: str, theirs: str) -> List[Tuple[str, str]]:
             ) from exc
         paths = fields[idx + 1 : idx + 1 + n_paths]
         type_idx = idx + 1 + n_paths
-        if type_idx >= len(fields):
+        # A slice silently truncates, so check the count rather than infer it.
+        # Every record is <n-paths> <path>... <type> <message>; a short one means
+        # the stream was cut, and continuing would under-report.
+        if len(paths) != n_paths or type_idx + 1 >= len(fields):
             raise ToolError(
-                f"truncated merge-tree -z record at field {idx}: expected a conflict "
-                f"type after {n_paths} path(s) but the stream ended"
+                f"truncated merge-tree -z record at field {idx}: expected {n_paths} "
+                f"path(s), a conflict type and a message, but the stream ended"
             )
         kind = fields[type_idx]
         idx = type_idx + 2  # skip the human-readable message


### PR DESCRIPTION
## Summary

Follow-up to #301, which merged while this last fix was still in review. Closes the fourth and final silent-truncation path in `upstream_canary.py`'s `-z` parsers.

### What changed

- **`scripts/upstream_canary.py`** — `_merge_tree` now validates that a record carries its full path list *and* a trailing message field before advancing past it.

### Architecture / design notes

A `merge-tree -z` record is `<n-paths> <path>... <type> <message>`. The parser checked only that the type field existed before doing `idx = type_idx + 2`, so a stream cut immediately after the type field walked `idx` past the end, the `while` loop fell out, and parsing stopped without a word — the same "an under-count reads as good news" failure the other three paths were hardened against in #301.

The path slice is now checked for a short count directly rather than being caught as a side effect of the type-field bound. `fields[a:b]` truncates silently, and relying on one bound to imply another is precisely how these instances kept surviving review — this was the fourth report of one pattern, so the fix is an audit of every index advance in both parsers rather than another point patch. The `continue`/`break` statements that remain skip empty NUL separators or record an orphan header; neither drops data.

## Test plan

- [x] A/B against hand-built `-z` streams: cut mid-path-list and cut after the type field each returned partial results before and raise `ToolError` after
- [x] Well-formed stream reports the same 23 code conflicts and same forked-header drift as before
- [x] No pytest run: this is a standalone maintenance script that no test imports
- [x] `pre-commit run -a`
