### PR TITLE
test(rocm): make CTA_TILE_Q=128 reachable, and record that 64 is right

### DIFF
--- a/include/gpu_iface/utils.cuh
+++ b/include/gpu_iface/utils.cuh
@@ -5,8 +5,10 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdlib>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 #include <type_traits>
 #include <vector>
 
@@ -63,6 +65,38 @@ inline void DebugPrintCUDAArray(T* device_ptr, size_t size, std::string prefix =
   std::cout << std::endl;
 }
 
+/*!
+ * \brief CTA_TILE_Q override from FLASHINFER_ROCM_FORCE_CTA_TILE_Q, or 0 when unset.
+ *
+ * The HIP heuristic never selects 128, so that arm is compiled into every ROCm
+ * build but unreachable and cannot otherwise be benchmarked. Forcing bypasses the
+ * heuristic's guards and can therefore produce configurations it exists to avoid:
+ * 128 at head_dim >= 256 raises from IsInvalid(); 16 at head_dim >= 256 needs 72 KB
+ * of smem, which only the single-prefill path range-checks; and 128 can exceed the
+ * workspace PrefillPlan sized from its own conservative_cta_tile_q estimate.
+ */
+inline uint32_t FA2ForcedCtaTileQ() {
+  static const uint32_t forced = [] {
+    const char* env = std::getenv("FLASHINFER_ROCM_FORCE_CTA_TILE_Q");
+    if (env == nullptr || *env == '\0') return 0u;
+    char* end = nullptr;
+    const unsigned long value = std::strtoul(env, &end, 10);
+    // Digits only, end to end: "64,128" must not silently benchmark 64, and strtoul
+    // would otherwise skip leading space and a '+' while still rejecting "64 ".
+    const bool digits_only = (env[0] >= '0' && env[0] <= '9');
+    if (!digits_only || *end != '\0' || (value != 16ul && value != 64ul && value != 128ul)) {
+      // Throw std:: directly: gpu_iface/exception.h shares the FLASHINFER_EXCEPTION_H_
+      // guard with flashinfer/exception.h, so including it here could suppress that
+      // header's variadic FLASHINFER_CHECK.
+      std::ostringstream err_msg;
+      err_msg << "FLASHINFER_ROCM_FORCE_CTA_TILE_Q must be 16, 64, or 128, got \"" << env << "\"";
+      throw std::invalid_argument(err_msg.str());
+    }
+    return static_cast<uint32_t>(value);
+  }();
+  return forced;
+}
+
 inline uint32_t FA2DetermineCtaTileQ(int64_t avg_packed_qo_len, uint32_t head_dim) {
 #if defined(PLATFORM_CUDA_DEVICE)
   if (avg_packed_qo_len > 64 && head_dim < 256) {
@@ -85,21 +119,14 @@ inline uint32_t FA2DetermineCtaTileQ(int64_t avg_packed_qo_len, uint32_t head_di
     }
   }
 #elif defined(PLATFORM_HIP_DEVICE)
-  // CDNA3 (MI300X) occupancy-aware tile selection.
+  if (const uint32_t forced = FA2ForcedCtaTileQ(); forced != 0u) return forced;
+  // 64 is measured-optimal on gfx942 and gfx950 alike, not a CDNA3 leftover: at
+  // head_dim=128 the 128 tile is slower on both, by up to 51% (gfx942, causal,
+  // seq 4096). Re-measure with FLASHINFER_ROCM_FORCE_CTA_TILE_Q before changing.
   //
-  // LDS per CU on gfx942 is 64 KB. SharedStorageQKVO with CTA_TILE_Q=128 and
-  // head_dim=128 occupies 48 KB, fitting only 1 block/CU → 4 wavefronts/CU
-  // (12.5% of the 32-wavefront HW maximum), leaving MFMA units idle >93% of
-  // the time.
-  //
-  // CTA_TILE_Q=64 with head_dim=128 → 32 KB smem → 2 blocks/CU → 8 wavefronts,
-  // doubling latency-hiding capacity and MFMA utilization.
-  //
-  // For head_dim >= 256, CTA_TILE_Q=16 is non-viable on CDNA3: get_num_warps_q(16)=1
-  // forces NUM_WARPS_KV=4, so even the minimum NUM_MMA_KV=1 configuration produces
-  // smem = Q(8 KB) + K(32 KB) + V(32 KB) = 72 KB, exceeding the 64 KB LDS ceiling.
-  // 2 blocks/CU is also impossible since the Q tile alone occupies 32 KB = half of LDS,
-  // so CTA_TILE_Q=64 is the correct choice for all sequence lengths at head_dim >= 256.
+  // head_dim >= 256 must return 64 for structural reasons, not measured ones:
+  // CTA_TILE_Q=16 forces NUM_WARPS_KV=4 and 72 KB of smem, over gfx942's 64 KB,
+  // and 128 gives NUM_MMA_Q=2 with NUM_MMA_D_VO=16, which IsInvalid() rejects.
   if (head_dim >= 256) return 64;
   // CTA_TILE_Q=16 is retained for very short sequences (avg ≤ 16 rows) with head_dim < 256
   // to avoid launching an excessive number of near-empty threadblocks.

--- a/include/gpu_iface/utils.cuh
+++ b/include/gpu_iface/utils.cuh
@@ -66,7 +66,7 @@ inline void DebugPrintCUDAArray(T* device_ptr, size_t size, std::string prefix =
 }
 
 /*!
- * \brief CTA_TILE_Q override from FLASHINFER_ROCM_FORCE_CTA_TILE_Q, or 0 when unset.
+ * \brief CTA_TILE_Q override from FLASHINFER_ROCM_FORCE_CTA_TILE_Q, or 0 when unset/empty.
  *
  * The HIP heuristic never selects 128, so that arm is compiled into every ROCm
  * build but unreachable and cannot otherwise be benchmarked. Forcing bypasses the

--- a/include/gpu_iface/utils.cuh
+++ b/include/gpu_iface/utils.cuh
@@ -71,9 +71,8 @@ inline void DebugPrintCUDAArray(T* device_ptr, size_t size, std::string prefix =
  * The HIP heuristic never selects 128, so that arm is compiled into every ROCm
  * build but unreachable and cannot otherwise be benchmarked. Forcing bypasses the
  * heuristic's guards and can therefore produce configurations it exists to avoid:
- * 128 at head_dim >= 256 raises from IsInvalid(); 16 at head_dim >= 256 needs 72 KB
- * of smem, which only the single-prefill path range-checks; and 128 can exceed the
- * workspace PrefillPlan sized from its own conservative_cta_tile_q estimate.
+ * 128 at head_dim >= 256 raises from IsInvalid(); and 16 at head_dim >= 256 needs 72 KB
+ * of smem, which only the single-prefill path range-checks.
  */
 inline uint32_t FA2ForcedCtaTileQ() {
   static const uint32_t forced = [] {

--- a/tests/rocm_tests/test_force_cta_tile_q_hip.py
+++ b/tests/rocm_tests/test_force_cta_tile_q_hip.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2025 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""FLASHINFER_ROCM_FORCE_CTA_TILE_Q, the CTA_TILE_Q measurement override.
+
+The override is read once into a function-local static, so each value needs its
+own process — hence subprocess rather than monkeypatch.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(
+    not torch.version.hip, reason="FLASHINFER_ROCM_FORCE_CTA_TILE_Q is HIP-only"
+)
+
+# head_dim 256 is excluded deliberately: forcing bypasses the heuristic's guards,
+# and 128 there is rejected by IsInvalid() while 16 needs 72 KB of smem.
+_RUN = textwrap.dedent(
+    """
+    import torch, flashinfer
+    qo_len, kv_len, heads, head_dim = 128, 512, 4, {head_dim}
+    torch.manual_seed(0)
+    q = torch.randn(qo_len, heads, head_dim, dtype=torch.bfloat16, device="cuda")
+    k = torch.randn(kv_len, heads, head_dim, dtype=torch.bfloat16, device="cuda")
+    v = torch.randn(kv_len, heads, head_dim, dtype=torch.bfloat16, device="cuda")
+    out = flashinfer.single_prefill_with_kv_cache(q, k, v, causal=True, backend="fa2")
+    qf, kf, vf = q.float(), k.float(), v.float()
+    s = torch.einsum("qhd,khd->hqk", qf, kf) / (head_dim ** 0.5)
+    mask = torch.arange(qo_len, device=q.device)[:, None] + (kv_len - qo_len) < \\
+        torch.arange(kv_len, device=q.device)[None, :]
+    p = torch.softmax(s.masked_fill(mask, float("-inf")), dim=-1)
+    ref = torch.einsum("hqk,khd->qhd", p, vf)
+    err = (out.float() - ref).abs().max().item()
+    assert err < 0.06, f"max_abs_err={{err}}"
+    print("OK", err)
+    """
+)
+
+
+def _run(source, **env):
+    # A None value unsets the variable rather than overriding it. Without this the
+    # unset-case test inherits an exported override, exercises the forced path and
+    # still passes — verifying the opposite of what it claims.
+    child = {**os.environ, **env}
+    return subprocess.run(
+        [sys.executable, "-c", source],
+        env={k: v for k, v in child.items() if v is not None},
+        capture_output=True,
+        text=True,
+        timeout=1800,
+    )
+
+
+@pytest.mark.parametrize("tile", ["16", "64", "128"])
+@pytest.mark.parametrize("head_dim", [64, 128])
+def test_forced_tile_matches_reference(tile, head_dim):
+    """Every forced tile must agree with a torch reference, including the 128 arm
+    that the HIP heuristic never selects on its own."""
+    proc = _run(_RUN.format(head_dim=head_dim), FLASHINFER_ROCM_FORCE_CTA_TILE_Q=tile)
+    assert proc.returncode == 0, (
+        f"tile={tile} hd={head_dim}\n{proc.stdout}\n{proc.stderr}"
+    )
+    assert "OK" in proc.stdout
+
+
+@pytest.mark.parametrize(
+    "bad",
+    # " 64"/"+64"/"\t64" are accepted by a bare strtoul, which would still reject
+    # "64 " — the asymmetry is the bug, not the leniency.
+    [
+        "0",
+        "32",
+        "64abc",
+        "64,128",
+        "-1",
+        "0x80",
+        " ",
+        "abc",
+        " 64",
+        "+64",
+        "64 ",
+        "\t64",
+    ],
+)
+def test_invalid_override_is_rejected(bad):
+    """A typo must fail loudly. Silently benchmarking a different tile than the one
+    requested is the failure this harness exists to prevent."""
+    proc = _run(_RUN.format(head_dim=128), FLASHINFER_ROCM_FORCE_CTA_TILE_Q=bad)
+    assert proc.returncode != 0, f"{bad!r} was accepted:\n{proc.stdout}"
+    assert "FLASHINFER_ROCM_FORCE_CTA_TILE_Q" in proc.stderr
+
+
+@pytest.mark.parametrize("value", [None, ""])
+def test_unset_override_uses_the_heuristic(value):
+    """Absent the variable the heuristic is untouched; an empty value is also unset.
+
+    None explicitly unsets, so an exported override in the caller's shell cannot
+    turn this into a second test of the forced path.
+    """
+    proc = _run(_RUN.format(head_dim=128), FLASHINFER_ROCM_FORCE_CTA_TILE_Q=value)
+    assert proc.returncode == 0, f"{value!r}\n{proc.stdout}\n{proc.stderr}"

--- a/tests/rocm_tests/test_force_cta_tile_q_hip.py
+++ b/tests/rocm_tests/test_force_cta_tile_q_hip.py
@@ -52,7 +52,7 @@ def _run(source, **env):
         env={k: v for k, v in child.items() if v is not None},
         capture_output=True,
         text=True,
-        timeout=1800,
+        timeout=900,
     )
 
 


### PR DESCRIPTION
## Summary

This started as an investigation into a suspected class of bug: tile and wavefront constants in the ROCm kernel path inherited from CUDA (warp = 32) or tuned on CDNA3 (64 KB LDS) and then applied unchanged to CDNA4 (160 KB LDS). If real, gfx950 would have been benchmarked on gfx942's tuning, and every published ROCm number would be suspect.

**Measured on both architectures, it is not happening.** That negative result is the deliverable. What ships is the harness that establishes it, a test, and a corrected comment — no tuning change, because the measurements do not support one.

## CTA_TILE_Q

`FA2DetermineCtaTileQ`'s HIP branch returns only 16 or 64, so the `CTA_TILE_Q=128` arm — instantiated by `batch_prefill_{paged,ragged}_kernel_inst.jinja` and expanded internally by single-prefill — is compiled into every ROCm build but unreachable, and could be neither correctness-tested nor benchmarked. `FLASHINFER_ROCM_FORCE_CTA_TILE_Q` makes it reachable.

Single prefill, bf16, 32 heads, backend pinned to `fa2`, median of 50, two independent runs agreeing to <1% for seq ≥ 1024:

| config | tile 128 vs 64, seq 1k→8k |
|---|---|
| gfx942 head_dim=128 non-causal | −22% −22% −28% −20% |
| gfx942 head_dim=128 causal | −23% −34% −51% −33% |
| gfx950 head_dim=128 non-causal | −14% −18% −18% −19% |
| gfx950 head_dim=128 causal | −16% −19% −34% −37% |
| gfx942 head_dim=64 non-causal | +8% +14% +10% +10% |
| gfx950 head_dim=64 non-causal | +9% +20% +22% +23% |

The larger tile is a monotone loss at head_dim=128 on both parts, so 64 is measured-optimal rather than a CDNA3 leftover. It wins at head_dim=64, but not as anything a threshold can express: the causal case alternates with grid quantization — qo_len 768 −11%/−16%, 1024 +33%/+31%, 1536 −15%/−13%, 2048 +47%/+47%, reproducible across runs — because at 32 heads those shapes give 192/256/384/512 workgroups against 256 CUs, so powers of two fill the machine and 1.5×2^k underfill. That is a property of the shape, not the architecture. **No tile-selection change is proposed.**

## The wave-32 constants are non-binding, unreachable, or free

Checked the same way, and none of them justified a change:

- In `vec_size = max(16/sizeof(DTypeKV), HEAD_DIM/32)`, raising the `/32` cap to the wavefront changes geometry in 1 of 8 decode configs (head_dim=512, 2-byte KV). fa2 ships head_dim 64/128/256 only (`aot_hip.py:307`); everywhere else the byte term binds. The `16→8` byte edit is what actually moves `bdx`, and `decode.cuh:643-644` says plainly that it is a smem-reduction measure, not a wavefront fix.
- MLA cute_sm80 decode (`decode.cuh:1083`) and `scheduler.cuh:285` are instantiated only from `csrc/batch_decode_mla_cute_sm80.cu` — the CUDA tree — and are unreachable from `csrc_rocm/`.
- `norm.cuh`'s `warp_size = 32` costs nothing: `nthrs(32, num_warps)` with `thread_id = tx + ty*32` linearizes to contiguous threads, so wavefronts are full, and the kernel is bandwidth-saturated at ~6.1 TB/s for 16384×4096 on MI355X counting the second-pass re-read at `norm.cuh:82` — HBM peak.
- `pod.cuh`'s `8 / NUM_MMA_Q_*` looked like the CUDA `16*16/32` value leaking in, since `prefill.cuh` derives `ELEMS_PER_FRAGMENT / NUM_MMA_Q` = 4 on wave-64. Changing it to match **regressed** POD by +26%/+25%/+11% on three small-prefill shapes against a 0.3% median noise floor (gfx942, idle box, two repeats per arm). Per-lane register cost is `NUM_MMA_KV × ELEMS_PER_FRAGMENT`, and a fragment costs 4 elems/lane on wave-64 versus 8 on wave-32, so POD's constant is register-equivalent to CUDA and prefill's is the conservative one. Reverted. Testing the converse — raising prefill's bound 2× and 4× — moved nothing (median +0.0% / −0.2%), because the smem bound binds first. Both values are right where they are.

## What ships

The override, scoped to the HIP branch so a `FLASHINFER_ROCM_`-prefixed variable cannot retune CUDA (whose branch does select 128, with guards of its own); strict parsing, because `strtoul("64,128")` returns 64 and would have silently benchmarked one tile while reporting two; a docstring naming the guards that forcing bypasses; and `tests/rocm_tests/test_force_cta_tile_q_hip.py`, which checks all three tiles against a torch reference and eight malformed values. Without the end-pointer check, `64abc` and `64,128` are accepted — verified by reverting it.

The `FA2DetermineCtaTileQ` comment is rewritten. It read as though 64 were a gfx942 concession derived from its 64 KB LDS, which is what invited this investigation; it now states the measured result and points at the harness. The `head_dim >= 256` case is labelled structural rather than measured — `CTA_TILE_Q=16` needs 72 KB of smem and 128 is rejected by `IsInvalid()` — because no head_dim ≥ 256 performance data was taken.

## Testing

`tests/rocm_tests/test_force_cta_tile_q_hip.py` on gfx950 (15 passed). Forced-tile correctness at 16/64/128 against a torch reference on both architectures, max abs error 0.0156 bf16 and identical across tiles. `pre-commit run` on the changed files. `scripts/upstream_canary.py` unchanged at 35 conflicts — `include/gpu_iface/` is ROCm-only and `include/flashinfer/attention/generic/` is the exempt fork.

gfx942 numbers are from `ctr-rack31-mi300x-2` (MI300X), gfx950 from a local MI355X, both ROCm 7.2.0 / torch 2.9.1. The gfx950 box acquired other tenants partway through, which invalidated one A/B; every number quoted here was taken on an idle box and repeated.
