### PR TITLE
docs: condense and refresh the README, split backend and build detail into their own pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,14 +53,26 @@ Details: `pr-workflow` skill.
 | Set target arch | `export FLASHINFER_ROCM_ARCH_LIST="gfx942,gfx950"` |
 | Limit parallel build | `export MAX_JOBS=4` |
 | Verbose JIT output | `export FLASHINFER_JIT_VERBOSE=1` |
+| Extra JIT link flags | `export FLASHINFER_EXTRA_LDFLAGS="-L/path -lfoo"` |
 | Run linting | `pre-commit run -a` |
 
 ## Installing Torch
 
-Torch must come from AMD's ROCm repo via `--index-url` (not `-f`, which can
-silently install a CPU-only wheel from PyPI). See the
-[GPU, ROCm, and PyTorch Support](README.md#gpu-rocm-and-pytorch-support) table
-in `README.md` for the version and command.
+Torch must come from AMD's ROCm repo at `repo.radeon.com`, via `-f`
+(`--find-links`) and **not** `--index-url` — that repo is a flat wheel listing
+rather than a PEP 503 index, so `--index-url` fails with "No matching
+distribution found".
+
+```bash
+pip install torch==2.9.1 -f https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/
+```
+
+`-f` also lets pip see PyPI, so verify you did not get the CPU-only wheel:
+`python -c "import torch; assert torch.version.hip, 'not a ROCm build'"`.
+In practice the ROCm wheel wins anyway, because its `+rocm<X.Y>` local version
+ranks higher than a same-version PyPI wheel. Supported versions are in the
+[Supported hardware and toolchain](README.md#supported-hardware-and-toolchain)
+table in `README.md`.
 
 ## Non-Obvious Gotchas
 
@@ -94,9 +106,9 @@ pip install amd-aiter==0.1.10 --extra-index-url https://pypi.amd.com/rocm-7.1.1/
 ```
 
 `0.1.10` is what this repo is built and tested against —
-`prefill_rocm.py` records it as `_AITER_LAST_VALIDATED`, and the README's
-[Install AITER wheel package](README.md#install-aiter-wheel-package) section
-explains the index choice. Note `amd-aiter` is **not** on the top-level
+`prefill_rocm.py` records it as `_AITER_LAST_VALIDATED`, and
+[`docs/rocm/backends.md`](docs/rocm/backends.md) explains the index choice.
+Note `amd-aiter` is **not** on the top-level
 `pypi.amd.com/simple` index, and it must be `--extra-index-url` rather than
 `--index-url` so AITER's own dependencies still resolve from PyPI.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ Note `amd-aiter` is **not** on the top-level
 `pypi.amd.com/simple` index, and it must be `--extra-index-url` rather than
 `--index-url` so AITER's own dependencies still resolve from PyPI.
 
-**Only cp310 and cp312 wheels exist** on that channel (verified 2026-08-20).
+**Only cp310 and cp312 wheels exist** on that channel.
 On any other interpreter — 3.11, 3.13, 3.14 — the command fails with
 `No matching distribution found`, and there is no pinned-version fallback:
 public PyPI tops out at a stale `0.1.7.post2.dev18`, and the nightlies index

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,118 @@ AMD Instinct GPUs — gfx942 (MI300X / MI325X, CDNA3) and gfx950
 <https://github.com/flashinfer-ai/flashinfer> uses different env vars,
 paths, and toolchains; its contribution guide does not transfer here.
 
-For project overview, install steps, running tests, AITER setup, and
-environment variables, see [`README.md`](README.md). This document
-covers only what's specific to contributing code.
+For the project overview, quick-start install, and the support matrix,
+see [`README.md`](README.md); for backend routing and AITER setup, see
+[`docs/rocm/backends.md`](docs/rocm/backends.md). This document covers
+building from source and everything else specific to contributing code.
+
+# Setting up a Development Environment
+
+Build the development image with the repository's Dockerfile:
+
+```bash
+docker build \
+  --build-arg ROCM_VERSION=7.2 \
+  --build-arg PY_VERSION=3.12 \
+  --build-arg TORCH_VERSION=2.9.1 \
+  --build-arg USERNAME=$USER \
+  --build-arg USER_UID=$(id -u) \
+  --build-arg USER_GID=$(id -g) \
+  -t flashinfer-dev:rocm7.2 \
+  -f .devcontainer/rocm/Dockerfile .
+```
+
+The `ROCM_VERSION`, `PY_VERSION`, and `TORCH_VERSION` defaults are 7.2,
+3.12, and 2.9.1. The `USER*` args match container file ownership to your
+host user; without them, build artifacts come out root-owned.
+
+```bash
+docker run -it \
+  --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+  --privileged --shm-size=128G --network=host \
+  --device=/dev/kfd --device=/dev/dri \
+  --group-add video --group-add render \
+  -v $PWD:/workspace \
+  --name flashinfer-dev-container \
+  flashinfer-dev:rocm7.2
+```
+
+Note the absence of `--ipc=host`: it shares the host IPC namespace, which
+silently overrides `--shm-size` and leaves the container able to exhaust
+host memory under a parallel test run.
+
+# Building and Installing
+
+**Editable install** — what you want for day-to-day work:
+
+```bash
+python -m pip install --no-build-isolation -ve .
+```
+
+**Wheel:**
+
+```bash
+python -m pip wheel . --wheel-dir=./dist/ --no-deps --no-build-isolation -v
+pip install dist/amd_flashinfer-*.whl
+```
+
+`--no-deps` assumes dependencies are already present; omit it to resolve
+them during the build. Nothing is compiled at build time — kernels are
+JIT-compiled on first use and cached under `~/.cache/flashinfer/`.
+
+**Ahead-of-time kernel build.** AOT is a separate step, not a flag on the
+wheel build. It compiles the kernel set up front so the first call does
+not pay for JIT:
+
+```bash
+python -m flashinfer.aot_hip --help
+```
+
+Pair an AOT-built install with `FLASHINFER_DISABLE_JIT=1` to fail loudly
+on a missing kernel instead of silently triggering a build.
+
+# Running Tests
+
+```bash
+# Fast path -- skips 1M-trial sampling-frequency tests and 4 GB
+# speculative-sampling cases (~7 min on a CPX 8-card host):
+pytest -n auto --reruns 2 -m "not slow"
+
+# Full coverage (~20 min):
+pytest -n auto --reruns 2
+
+# Slow tests only (~13 min):
+pytest -n auto --reruns 2 -m "slow"
+
+# One file, or a pattern:
+pytest tests/rocm_tests/test_batch_decode_kernels_hip.py
+pytest -k "test_batch_decode_kernels_hip"
+```
+
+`testpaths` in [pyproject.toml](pyproject.toml) sets the default
+selection. `pytest-rerunfailures` comes from the `dev` extra
+(`pip install -e ".[dev]"`).
+
+**Worker count.** `pytest -n auto` spawns **half as many xdist workers as
+physical AMD cards** (4 workers on a CPX-mode 8-card host) and pins each
+to its card via `HIP_VISIBLE_DEVICES`. One worker per card was tried first
+and produced sporadic failures across rope, single_prefill, and logits_cap
+under concurrent load. Pass an explicit `-n N` to override the halving.
+
+**Reruns.** `--reruns 2` absorbs the residual ~0.01% of transient HIP
+runtime crashes — HSA exceptions, HIPBLAS handle-pool exhaustion,
+intermittent generator non-determinism — that worker pinning cannot
+eliminate. Only failed tests are retried.
+
+**`slow` marker.** Registered in [pyproject.toml](pyproject.toml). It tags
+the 1M-trial sampling-frequency tests, the 4 GB-tensor speculative-sampling
+cases, and the whole `TestLogitsPipeCompilationHIP` class (each test runs
+the sampling kernel twice, for `compile=True` and `False`).
+
+**HIPBLAS retry.** The reference attention helper in
+`tests/attention_reference.py` wraps `torch.matmul` in a
+`_hipblas_safe_matmul` retry that catches `HIPBLAS_STATUS_ALLOC_FAILED`
+and backs off — needed under heavy concurrent xdist load.
 
 # Code Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,35 +16,25 @@ building from source and everything else specific to contributing code.
 Build the development image with the repository's Dockerfile:
 
 ```bash
-docker build \
-  --build-arg ROCM_VERSION=7.2 \
-  --build-arg PY_VERSION=3.12 \
-  --build-arg TORCH_VERSION=2.9.1 \
-  --build-arg USERNAME=$USER \
-  --build-arg USER_UID=$(id -u) \
-  --build-arg USER_GID=$(id -g) \
-  -t flashinfer-dev:rocm7.2 \
-  -f .devcontainer/rocm/Dockerfile .
+docker build -t flashinfer-dev:rocm7.2 -f .devcontainer/rocm/Dockerfile .
 ```
 
-The `ROCM_VERSION`, `PY_VERSION`, and `TORCH_VERSION` defaults are 7.2,
-3.12, and 2.9.1. The `USER*` args match container file ownership to your
-host user; without them, build artifacts come out root-owned.
+`ROCM_VERSION`, `PY_VERSION`, and `TORCH_VERSION` default to 7.2, 3.12, and
+2.9.1; override with `--build-arg` if you need a different combination. Pass
+`--build-arg USERNAME=$USER --build-arg USER_UID=$(id -u) --build-arg
+USER_GID=$(id -g)` to match container file ownership to your host user —
+without them, build artifacts come out root-owned.
 
 ```bash
 docker run -it \
   --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
-  --privileged --shm-size=128G --network=host \
+  --privileged --ipc=host --network=host \
   --device=/dev/kfd --device=/dev/dri \
   --group-add video --group-add render \
   -v $PWD:/workspace \
   --name flashinfer-dev-container \
   flashinfer-dev:rocm7.2
 ```
-
-Note the absence of `--ipc=host`: it shares the host IPC namespace, which
-silently overrides `--shm-size` and leaves the container able to exhaust
-host memory under a parallel test run.
 
 # Building and Installing
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Older ROCm / PyTorch / FlashInfer combinations are at
 ```bash
 docker run -it --privileged --network=host --device=/dev/kfd --device=/dev/dri \
   --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
-  --shm-size 128G --name=flashinfer-rocm \
+  --ipc=host --name=flashinfer-rocm \
   rocm/flashinfer:flashinfer-0.5.3.amd1_rocm7.2_ubuntu24.04_py3.12_pytorch2.9.1
 ```
 
@@ -169,19 +169,11 @@ decisions the library makes. Do not edit it by hand; run
 | `silu_and_mul` | `hip` | ◻️ | ◻️ | SiLU and GELU with fused gating; the default for `auto`. |
 | `quantization` | `hip` | ◻️ | ◻️ | `packbits` and `segment_packbits`. |
 
-* ✅ **validated** — a suite was run on that board, and the evidence is recorded below.
-* ◻️ **declared** — supported, but no per-op measurement has been recorded on that architecture.
+* ✅ **validated** — this op was exercised on this architecture, and the board, ROCm, AITER, and date are recorded in `flashinfer/arch_caps.py`.
+* ◻️ **supported** — the op runs here and the test suite covers it, but no run has been recorded against this specific op and architecture.
 * ⚠️ **broken on some toolchains** — usable, but not on every ROCm/AITER version; see the footnote.
 
 [^kb1]: `batch_prefill/aiter` on gfx950, ROCm [7.2, 7.3): ROCm 7.2.x miscompiles AITER's causal batch-prefill kernel on gfx950: causal=True with logits_soft_cap=0.0 returns wrong numbers (not an error), 97.6% of elements off. Use ROCm 7.1, or backend='fa2'. Override with `FLASHINFER_ARCH_ALLOW_KNOWN_BAD=1` if you have validated it yourself. <https://github.com/ROCm/aiter/blob/main/op_tests/test_batch_prefill.py>
-
-Measured on:
-
-* `gfx942` — MI300X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-19
-* `gfx942` — fused_moe: MI300X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-24
-* `gfx950` — MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-19
-* `gfx950` — fused_moe: MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-24
-* `gfx950` — mla: MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-24 (decode + prefill, heads 16/128)
 
 <!-- END GENERATED: arch support matrix -->
 
@@ -197,6 +189,7 @@ Requires PyTorch ≥ 2.4 and adds a small per-call dispatch overhead.
 Without it, `torch.compile` raises a clear error if it traces into a
 FlashInfer op rather than silently producing a wrong graph.
 
+<!--
 ## Benchmarking
 
 The unified runner drives every ROCm attention path from one testlist:
@@ -212,6 +205,7 @@ side by side. **Read the `backend_resolved` column** — `auto` is a
 request, not a result, and `backend_fallback_reason` says why AITER was
 declined. Per-op drivers live in
 [`benchmarks/rocm_benchmarks/`](https://github.com/AMD-Ecosystem/flashinfer/tree/amd-integration/benchmarks/rocm_benchmarks).
+-->
 
 ## Environment variables
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Then, inside the container:
 python -c "import flashinfer; print(flashinfer.__version__)"
 ```
 
-The container's micromamba environment activates on shell start — no
-manual `micromamba activate`.
+The container's micromamba environment activates on shell start, so no
+manual `micromamba activate` is required.
 
 ### pip
 
@@ -218,7 +218,7 @@ Read at runtime or import time:
 | `FLASHINFER_AITER_STRICT` | `0` | Raise instead of degrading when AITER cannot serve a page size natively. Set in CI to catch AITER coverage regressions rather than absorb them as a slowdown. |
 | `FLASHINFER_ARCH_ALLOW_KNOWN_BAD` | `0` | Run an (op, backend, arch) combination the capability table marks known-broken on your toolchain. Only if you have validated it yourself. |
 | `FLASHINFER_HIP_FUSED_CASCADE` | `0` | Use the fused single-kernel HIP cascade path instead of the two-level merge. Experimental. |
-| `FLASHINFER_WORKSPACE_BASE` | `~` | Parent of the JIT cache directory (`.cache/flashinfer/`). Point it at fast local disk when `$HOME` is on NFS. |
+| `FLASHINFER_WORKSPACE_BASE` | `$HOME` | Parent of the JIT cache directory (`.cache/flashinfer/`). Point it at fast local disk when `$HOME` is on NFS. Pass an absolute path — the value is not tilde-expanded, so `~` becomes a literal `./~` directory. |
 | `FLASHINFER_DISABLE_JIT` | unset | Set to **any non-empty value** — including `0` — to skip JIT compilation. Useful with an AOT-built install, to fail loudly on a missing kernel rather than trigger a build. |
 | `FLASHINFER_DISABLE_VERSION_CHECK` | unset | Any non-empty value skips the JIT-cache package version check. |
 | `FLASHINFER_LOGGING_LEVEL` | `INFO` | Logger verbosity (`DEBUG`, `INFO`, `WARNING`, …). Affects AITER fallback warnings and JIT build messages. |

--- a/README.md
+++ b/README.md
@@ -1,91 +1,142 @@
 # FlashInfer+ROCm: An AMD ROCm port of FlashInfer
 
 FlashInfer+ROCm brings the
-[FlashInfer](https://github.com/flashinfer-ai/flashinfer) inference
-kernel library to AMD Instinct GPUs — currently
-[CDNA3](https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-3-white-paper.pdf)
-(gfx942 — MI300X / MI325X) and
-[CDNA4](https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/white-papers/amd-cdna-4-architecture-whitepaper.pdf)
-(gfx950 — MI350X / MI355X). It ships in-tree HIP ports of the attention,
-KV-cache, RoPE, normalization, sampling, and logits-processor kernels,
-and transparently dispatches a subset of attention paths to AMD's
-[AITER](https://github.com/ROCm/aiter) backend when its compatibility
-conditions hold (see [Feature Support Matrix](#feature-support-matrix)).
+[FlashInfer](https://github.com/flashinfer-ai/flashinfer) inference kernel
+library to AMD Instinct GPUs — CDNA3 (gfx942, MI300X / MI325X) and CDNA4
+(gfx950, MI350X / MI355X). It ships in-tree HIP ports of the attention,
+KV-cache, RoPE, normalization, sampling, and logits-processor kernels, and
+transparently dispatches a subset of ops to AMD's
+[AITER](https://github.com/ROCm/aiter) backend when that is the faster or
+only path.
 
 The port is in active development and is aimed at developers embedding
 FlashInfer kernels into their own training or serving stack. See
-[CHANGELOG.md](CHANGELOG.md) for the full release history.
+[CHANGELOG.md](CHANGELOG.md) for the release history.
 
-**Versioning:** The release tag format `<upstream_version>+amd.<n>` ties
-each FlashInfer+ROCm release to its corresponding upstream tag (e.g.
-`0.5.3+amd.1` is the first AMD release based on upstream `v0.5.3`).
+**Versioning.** Release tags are `<upstream_version>+amd.<n>`, tying each
+FlashInfer+ROCm release to the upstream tag it is based on — `0.5.3+amd.1`
+is the first AMD release based on upstream `v0.5.3`.
 
-## Table of Contents
+## Quick start
 
-* [Feature Support Matrix](#feature-support-matrix)
-* [GPU, ROCm, and PyTorch Support](#gpu-rocm-and-pytorch-support)
-* [Getting Started](#getting-started)
-  * [Option 1: Get a Pre-built Docker Image](#option-1-get-a-pre-built-docker-image)
-  * [Option 2: Install from a Wheel Package](#option-2-install-from-a-wheel-package)
-  * [Trying the Examples](#trying-the-examples)
-* [Install from Source](#install-from-source)
-  * [Setting up a Development Environment](#setting-up-a-development-environment)
-  * [Building and Installing a Wheel Package](#building-and-installing-a-wheel-package)
-  * [Running Tests](#running-tests)
-* [AITER Support](#aiter-support)
-  * [Install AITER from source](#install-aiter-from-source)
-  * [Install AITER wheel package](#install-aiter-wheel-package)
-  * [Known Limitations](#known-limitations)
-* [Environment Variables](#environment-variables)
-* [Runtime Helpers](#runtime-helpers)
-* [Basic Usage](#basic-usage)
-* [License and Acknowledgements](#license-and-acknowledgements)
+### Docker
 
-## Feature Support Matrix
+AMD validates and publishes FlashInfer images on Docker Hub. The latest
+validated tag:
 
-Most kernels ship with an in-tree HIP implementation. A subset also has
-an AITER backend; for those, `backend="auto"` picks AITER when its
-compatibility conditions hold and falls back to HIP otherwise. The one
-AITER-only kernel today (MLA) has no HIP path — `backend="auto"`
-resolves directly to `"aiter"`.
+| Docker image | ROCm | FlashInfer | PyTorch | Ubuntu | Python | GPU |
+| ------------ | ---- | ---------- | ------- | ------ | ------ | --- |
+| `rocm/flashinfer:flashinfer-0.5.3.amd1_rocm7.2_ubuntu24.04_py3.12_pytorch2.9.1` | 7.2.0 | v0.5.3 | 2.9.1 | 24.04 | 3.12 | MI355X, MI325X, MI300X |
 
-Legend: **HIP** = in-tree kernel (`fa2` for attention, `native` JIT
-kernel for non-attention ops). **AITER** = ROCm AITER backend.
+Older ROCm / PyTorch / FlashInfer combinations are at
+<https://hub.docker.com/r/rocm/flashinfer/tags>.
 
-| Kernel | HIP | AITER | `backend="auto"` resolves to | Notes |
-| :--- | :---: | :---: | :--- | :--- |
-| **Single decode attention** | ✅ `fa2` | — | HIP | MHA / GQA / MQA |
-| **Batch decode attention (paged)** | ✅ `fa2` | ✅ | **AITER** when `fp16/bf16` + `NHD` + `pos_encoding_mode="NONE"` + no CUDA-graph + `use_tensor_cores=False`; else **HIP** | MHA / GQA / MQA; **fp8 KV-cache (E4M3FNUZ)** on the HIP path; sliding-window on the AITER path; CUDA-graph capture on the AITER path is **opt-in via `backend="aiter"`** (grid + `.so` fixed at capture-time shapes — capture at max seq len); `backend="auto"` uses HIP `fa2` under capture |
-| **Single prefill attention** | ✅ `fa2` | ✅ | **AITER** when `fp16/bf16` + `NHD` + no custom mask + equal Q/KV dtypes & head dims + `pos_encoding_mode="NONE"`; else **HIP** | MHA / GQA / MQA; fp8 WIP |
-| **Batch prefill attention (paged + ragged)** | ✅ `fa2` | ✅ | Same auto criteria as single prefill | MHA / GQA / MQA; fp8 WIP. AITER native page sizes: `{16, 1024}` (`{128, 256, 1024}` on `amd-aiter >= 0.1.10`); other sizes — and any "native" size the installed AITER turns out not to serve — go through a gather on the AITER path |
-| **Cascade attention** | ✅ | — | HIP | Two-level shared-prefix attention; a fused single-kernel HIP variant is gated behind `FLASHINFER_HIP_FUSED_CASCADE=1` |
-| **MLA (Multi-Latent Attention)** | — | ✅ | **AITER** (no HIP fallback) | DeepSeek-style 192/128 head-dim split; bf16 + `page_size=1`; `backend="auto"` (default) resolves to `"aiter"` |
-| **POD attention** | ✅ `fa2` | — | HIP | MHA / GQA / MQA; single + batch variants (`PODWithPagedKVCacheWrapper`, `BatchPODWithPagedKVCacheWrapper`); JIT-only (excluded from AOT, same as upstream CUDA) |
-| **RoPE (positional encoding)** | ✅ `native` | ✅ | **HIP `native`** (AITER is opt-in via `backend="aiter"`) | LLaMA-style + LLaMA 3.1 scaling; fused RoPE + fp8 quant + paged-KV append (E4M3FNUZ, E5M2FNUZ). The AITER backend covers `apply_rope_with_cos_sin_cache` and its inplace variant via AITER's C++ `rope_cached_positions_2c_fwd_impl` (linked at the C++ level, no runtime `import aiter`); cos/sin passed as float32. `backend="auto"` resolves to HIP `native` — the in-tree kernel is the better default; request AITER explicitly with `backend="aiter"` |
-| **Paged KV-cache append** | ✅ `native` | ✅ | **HIP `native`** (AITER is opt-in via `backend="aiter"`) | `append_paged_kv_cache`; fp8 KV-cache supported on the HIP path. `backend="auto"` resolves to HIP `native` — the in-tree kernel sustains 3.62 TB/s against AITER's 2.86 on identical work (gfx942), so AITER is slower at every size measured; request it explicitly with `backend="aiter"` (`fp16/bf16` + `NHD` only) |
-| **RMSNorm** | ✅ `native` | ✅ | **AITER** for 2-D fp16/bf16 inputs on gfx942/gfx950; else **HIP `native`** (3-D inputs, fp32, or AITER unavailable) | `rmsnorm`; AITER's C++ CK `rmsnorm2d` (the `rmsnorm2d_fwd` entry point, linked at the C++ level, no runtime `import aiter`); fp16/bf16, 2-D only, weight dtype must match input, slightly lower precision at `hidden_size >= 1024` |
-| **Fused add RMSNorm** | ✅ `native` | ✅ | **AITER** on gfx942/gfx950; else **HIP `native`** | `fused_add_rmsnorm`; AITER's C++ CK `rmsnorm2d_with_add` (linked at the C++ level, no runtime `import aiter`); 2-D only, slightly lower precision at `hidden_size >= 1024` |
-| **LayerNorm / Gemma RMSNorm** | ✅ | — | HIP | |
-| **Sampling** | ✅ | — | HIP | Top-K / Top-P / Min-P / OnlineSoftmax / SamplingFromLogits |
-| **Logits processor** | ✅ | — | HIP | Composable processor pipeline (cap, mask, temperature, …) |
-| **Activation** | ✅ `native` | ✅ | **HIP `native`** (AITER is opt-in via `backend="aiter"`) | SiLU / GELU with fused gating. AITER path (`silu_and_mul` only) via AITER's C++ `aiter::silu_and_mul` (linked at the C++ level, no runtime `import aiter`); matches native precision in fp16, lower in bf16. `backend="auto"` resolves to HIP `native` — the in-tree kernel is the better default; request AITER explicitly with `backend="aiter"` |
-| **Quantization** | ✅ | — | HIP | `packbits`, `segment_packbits` |
-| **`torch.compile`** | ✅ (opt-in) | n/a | n/a | Set `FLASHINFER_USE_TORCH_CUSTOM_OPS=1` **before** importing `flashinfer`; requires PyTorch ≥ 2.4. Without it, `torch.compile` raises a clear error if it traces into a flashinfer op |
+```bash
+docker run -it --privileged --network=host --device=/dev/kfd --device=/dev/dri \
+  --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+  --shm-size 128G --name=flashinfer-rocm \
+  rocm/flashinfer:flashinfer-0.5.3.amd1_rocm7.2_ubuntu24.04_py3.12_pytorch2.9.1
+```
 
-Every ✅ row above is exercised by a matching `tests/rocm_tests/test_*_hip.py`.
-The full set of conditions that cause AITER auto-routing to fall back to
-HIP is documented in [Known Limitations](#known-limitations) below.
+Then, inside the container:
 
-## GPU, ROCm, and PyTorch Support
+```bash
+python -c "import flashinfer; print(flashinfer.__version__)"
+```
 
-**Supported GPUs:** gfx942 (CDNA3 — MI300X, MI325X), gfx950 (CDNA4 — MI350X, MI355X).
+The container's micromamba environment activates on shell start — no
+manual `micromamba activate`.
 
-### Per-architecture support matrix
+### pip
 
-The two architectures are not interchangeable for every op. The table below is
-generated from [`flashinfer/arch_caps.py`](flashinfer/arch_caps.py), which is
-what `backend="auto"` actually consults at runtime — so it cannot drift from
-the routing decisions the library makes. Do not edit it by hand; run
+```bash
+pip install amd-flashinfer --index-url https://pypi.amd.com/simple/
+pip install torch==2.9.1 -f https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/
+```
+
+**Torch must come from `repo.radeon.com`, via `-f` and not `--index-url`.**
+That repo is a flat wheel listing rather than a PEP 503 index, so
+`--index-url` fails with "No matching distribution found". pip still
+prefers the ROCm wheel over a same-version PyPI wheel because its
+`+rocm<X.Y>` local version ranks higher. Confirm you got one:
+
+```bash
+python -c "import torch; assert torch.version.hip, 'not a ROCm build'"
+```
+
+Kernels are JIT-compiled on first use, which takes a few minutes. The
+optional [`amd-flashinfer-jit-cache`](amd-flashinfer-jit-cache/README.md)
+package ships them prebuilt for gfx942.
+
+## Basic usage
+
+```python
+import torch
+import flashinfer
+
+# PyTorch+ROCm still uses device="cuda" for AMD GPUs.
+q = torch.randn(1024, 32, 128, dtype=torch.float16, device="cuda")
+k = torch.randn(1024,  8, 128, dtype=torch.float16, device="cuda")  # GQA 4:1
+v = torch.randn(1024,  8, 128, dtype=torch.float16, device="cuda")
+
+# backend="auto" (default) routes to AITER when supported and falls back
+# to the in-tree fa2 HIP kernel otherwise.
+output = flashinfer.single_prefill_with_kv_cache(q, k, v, causal=True)
+```
+
+Runnable scripts for single/batch prefill and batch decode, plus
+`amd_flashinfer_rocm_tutorial.ipynb` walking through the public API on
+ROCm, are in
+[`examples/`](https://github.com/AMD-Ecosystem/flashinfer/tree/amd-integration/examples):
+
+```bash
+python examples/single_prefill_example.py
+```
+
+## Supported hardware and toolchain
+
+| | Supported |
+| :--- | :--- |
+| GPUs | gfx942 (CDNA3 — MI300X, MI325X), gfx950 (CDNA4 — MI350X, MI355X) |
+| ROCm | 7.0.2, 7.1.1, 7.2 |
+| PyTorch+ROCm | 2.8.0, 2.9.1 |
+| Python | 3.10+ (the published images and devcontainer use 3.12) |
+
+Other versions may work but are untested. Replace `7.2` in the torch
+install command with the ROCm version you need; see
+<https://repo.radeon.com/rocm/manylinux/> for what is available.
+
+## Support matrix
+
+Every op has an in-tree HIP kernel unless noted; a subset also has an
+AITER backend, selected by a `backend=` argument that defaults to
+`"auto"`. There are four policies for what `auto` picks:
+
+| `backend="auto"` picks | Ops |
+| :--- | :--- |
+| AITER when the call is compatible, else the in-tree kernel | `single_prefill`, `batch_prefill`, `batch_decode`, `fused_add_rmsnorm` |
+| AITER for 2-D fp16/bf16 whose weight dtype matches, else `native` | `rmsnorm` |
+| Always the in-tree `native` kernel — AITER is opt-in | `silu_and_mul`, `rope`, `append_paged_kv_cache` |
+| AITER only — no HIP kernel exists | `mla` |
+
+To override, pass `backend="aiter"`, or name the in-tree kernel:
+`backend="fa2"` for the attention wrappers, `backend="native"` for
+everything else.
+
+Two ops take no `backend=` argument: `single_decode_with_kv_cache` is
+HIP-only, and `aiter_fused_moe` is AITER-only. On gfx950 with ROCm 7.2.x,
+`batch_prefill` never resolves to AITER — see the footnote under the
+table.
+
+**The full routing rules, per-op constraints, and AITER install
+instructions are in [`docs/rocm/backends.md`](docs/rocm/backends.md).**
+Read it before relying on an AITER path — several attention kwargs are
+silently ignored there rather than rejected.
+
+The table below is generated from
+[`flashinfer/arch_caps.py`](flashinfer/arch_caps.py), which is what
+`backend="auto"` consults at runtime, so it cannot drift from the routing
+decisions the library makes. Do not edit it by hand; run
 `python3 scripts/gen_arch_support_matrix.py`.
 
 <!-- BEGIN GENERATED: arch support matrix -- scripts/gen_arch_support_matrix.py -->
@@ -134,404 +185,56 @@ Measured on:
 
 <!-- END GENERATED: arch support matrix -->
 
-**Supported ROCm versions:** 7.0.2, 7.1.1, 7.2.
+Most rows have a matching `tests/rocm_tests/test_*_hip.py`; `single_decode`
+and `quantization` are covered incidentally from other files rather than
+by one of their own.
 
-**Supported PyTorch+ROCm versions:** 2.8.0, 2.9.1.
+## `torch.compile`
 
-Install the matching ROCm-enabled PyTorch wheel from
-<https://repo.radeon.com>:
+Set `FLASHINFER_USE_TORCH_CUSTOM_OPS=1` **before** importing `flashinfer`
+to wrap the kernels in `torch.library.custom_op` so Dynamo can trace them.
+Requires PyTorch ≥ 2.4 and adds a small per-call dispatch overhead.
+Without it, `torch.compile` raises a clear error if it traces into a
+FlashInfer op rather than silently producing a wrong graph.
 
-```bash
-pip install torch==2.9.1 -f https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/
-```
+## Benchmarking
 
-Other versions may work but have not been tested. Replace `7.2` with the
-ROCm version you need; refer to
-<https://repo.radeon.com/rocm/manylinux/rocm-rel-{rocm-version}/> for
-available wheels.
-
-## Getting Started
-
-### Option 1: Get a Pre-built Docker Image
-
-AMD validates and publishes FlashInfer images with ROCm backends on
-Docker Hub. The latest validated tag is:
-
-| Docker image | ROCm | FlashInfer | PyTorch | Ubuntu | Python | GPU |
-| ------------ | ---- | ---------- | ------- | ------ | ------ | --- |
-| `rocm/flashinfer:flashinfer-0.5.3.amd1_rocm7.2_ubuntu24.04_py3.12_pytorch2.9.1` | 7.2.0 | v0.5.3 | 2.9.1 | 24.04 | 3.12 | MI355X, MI325X, MI300X |
-
-For older releases (earlier ROCm / PyTorch / FlashInfer combinations),
-see the full tag list at
-<https://hub.docker.com/r/rocm/flashinfer/tags>.
-
-**Start a container:**
+The unified runner drives every ROCm attention path from one testlist:
 
 ```bash
-docker run -it --privileged --network=host --device=/dev/kfd --device=/dev/dri \
-  --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
-  --ipc=host --shm-size 128G --name=flashinfer-rocm \
-  rocm/flashinfer:flashinfer-0.5.3.amd1_rocm7.2_ubuntu24.04_py3.12_pytorch2.9.1
+cd benchmarks
+python flashinfer_benchmark.py --testlist rocm_benchmarks/testlist_rocm.txt \
+    --output_path run-$(date +%F).csv
 ```
 
-**Verify the installation:**
-
-```bash
-python -c "import flashinfer; print(flashinfer.__version__)"
-```
-
-Expected output: `0.5.3+amd.1` (with a possible JIT backend message).
-The container's micromamba environment is activated automatically on
-shell start — no manual `micromamba activate` is required.
-
-### Option 2: Install from a Wheel Package
-
-Install from AMD's package repository:
-
-```bash
-pip install amd-flashinfer --index-url https://pypi.amd.com/simple/
-```
-
-Install the matching ROCm-enabled torch package from <https://repo.radeon.com>:
-
-```bash
-pip install torch==2.9.1 -f https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/
-```
-
-**NOTE:** The radeon repo is a flat wheel listing, not a PEP 503 index, so
-`--index-url` fails with "No matching distribution found" — use `-f`
-(`--find-links`). pip still prefers the ROCm wheel over a same-version PyPI
-wheel because its `+rocm<X.Y>` local version ranks higher. Confirm the result
-with `python -c "import torch; assert torch.version.hip, 'not a ROCm build'"`.
-
-### Trying the Examples
-
-Runnable scripts live in the [`examples/`](examples/) directory of this
-repository (single/batch prefill, batch decode, plus an
-`amd_flashinfer_rocm_tutorial.ipynb` Jupyter notebook). After cloning,
-run any of them directly, for example:
-
-```bash
-python examples/single_prefill_example.py
-```
-
-## Install from Source
-
-### Setting up a Development Environment
-
-Build the development Docker image with the repository's Dockerfile:
-
-```bash
-docker build \
-  --build-arg ROCM_VERSION=7.2 \
-  --build-arg PY_VERSION=3.12 \
-  --build-arg TORCH_VERSION=2.9.1 \
-  --build-arg USERNAME=$USER \
-  --build-arg USER_UID=$(id -u) \
-  --build-arg USER_GID=$(id -g) \
-  -t flashinfer-0.5.3.amd1_rocm7.2_ubuntu24.04_py3.12_pytorch2.9.1 \
-  -f .devcontainer/rocm/Dockerfile .
-```
-
-<!-- markdownlint-disable MD033 -->
-<details>
-<summary>Build argument descriptions</summary>
-
-* `ROCM_VERSION`: ROCm version (default: 7.2)
-* `PY_VERSION`: Python version (default: 3.12)
-* `TORCH_VERSION`: PyTorch version (default: 2.9.1)
-* `USERNAME`: Username inside container (default: devuser)
-* `USER_UID`: User ID for matching host permissions
-* `USER_GID`: Group ID for matching host permissions
-
-</details>
-<!-- markdownlint-enable MD033 -->
-
-**Run the development container:**
-
-```bash
-docker run -it \
-  --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
-  --ipc=host --privileged --shm-size=128G --network=host \
-  --device=/dev/kfd --device=/dev/dri \
-  --group-add video --group-add render \
-  -v $PWD:/workspace \
-  --name flashinfer-dev-container \
-  flashinfer-0.5.3.amd1_rocm7.2_ubuntu24.04_py3.12_pytorch2.9.1
-```
-
-<!-- markdownlint-disable MD033 -->
-<details>
-<summary>Docker run argument descriptions</summary>
-
-* `--cap-add=SYS_PTRACE`: Enables debugging
-* `--security-opt seccomp=unconfined`: Relaxes security for development
-* `--ipc=host`: Shares host IPC for better performance
-* `--privileged`: Required for GPU access
-* `--shm-size=128G`: Shared memory size (adjust as needed)
-* `--network=host`: Uses host networking
-* `--device=/dev/kfd --device=/dev/dri`: Exposes AMD GPU devices
-* `--group-add video --group-add render`: GPU access groups
-* `-v <host-path>:<container-path>`: Mounts source code
-
-</details>
-<!-- markdownlint-enable MD033 -->
-
-### Building and Installing a Wheel Package
-
-**Build with JIT (Just-in-Time) compilation only:**
-
-```bash
-python -m pip wheel . --wheel-dir=./dist/ --no-deps --no-build-isolation -v
-cd dist && pip install amd_flashinfer-*.whl
-```
-
-**Editable install for development:**
-
-```bash
-python -m pip install --no-build-isolation -ve .
-```
-
-**Note:** The `--no-deps` flag assumes dependencies are pre-installed.
-Omit it to download dependencies during build. AOT builds take longer
-and use more disk space but avoid JIT compilation at runtime.
-
-### Running Tests
-
-Run the Python test suite with pytest:
-
-```bash
-# Run default tests (configured in pyproject.toml)
-pytest
-
-# Run specific test file
-pytest tests/rocm_tests/test_batch_decode_kernels_hip.py
-
-# Run with pattern matching
-pytest -k "test_batch_decode_kernels_hip"
-
-# Verbose output
-pytest -v
-
-# Run tests in parallel across multiple GPUs
-pytest -n auto  # Uses all available GPUs
-pytest -n 2     # Use only two GPUs
-```
-
-The default test configuration is specified in [pyproject.toml](pyproject.toml)
-under the `testpaths` setting.
-
-#### Recommended invocation on AMD CPX systems
-
-`pytest-rerunfailures` (declared in the `dev` extra — `pip install -e ".[dev]"`)
-absorbs the residual transient HIP runtime crashes. Then for the full suite:
-
-```bash
-# Fast path — skips heavy 1M-trial sampling-frequency tests and 4 GB
-# speculative-sampling cases (~7 min on a CPX 8-card host):
-pytest -n auto --reruns 2 -m "not slow"
-
-# Full coverage — including the slow tests (~20 min):
-pytest -n auto --reruns 2
-
-# Slow path only (~13 min):
-pytest -n auto --reruns 2 -m "slow"
-```
-
-**Notes**
-
-* **Worker count.** `pytest -n auto` for the `tests/rocm_tests/` suite
-  spawns **half as many xdist workers as physical AMD cards** (e.g. 4
-  workers on a CPX-mode 8-card MI308X / MI325X host) and pins each
-  worker to its card via `HIP_VISIBLE_DEVICES`. One worker per physical
-  card was tried first but produced sporadic failures across rope,
-  single_prefill, and logits_cap under residual concurrent load.
-  Pass an explicit `-n N` to override the halving.
-* **Reruns.** `--reruns 2` (from `pytest-rerunfailures`) absorbs the
-  residual ~0.01 % of transient HIP runtime crashes (HSA exceptions,
-  HIPBLAS handle-pool exhaustion, intermittent generator
-  non-determinism) that worker pinning cannot fully eliminate. Only
-  failed tests are retried.
-* **`slow` marker.** Registered in [pyproject.toml](pyproject.toml). It
-  tags the 1M-trial sampling-frequency tests, the 4 GB-tensor
-  speculative-sampling cases, and the entire `TestLogitsPipeCompilationHIP`
-  class (each test runs the sampling kernel twice for compile=True/False).
-* **HIPBLAS retry.** The reference attention helper in
-  `tests/attention_reference.py` wraps `torch.matmul` in a
-  `_hipblas_safe_matmul` retry that catches `HIPBLAS_STATUS_ALLOC_FAILED`
-  and retries with a short back-off — needed under heavy concurrent
-  xdist load.
-
-## AITER Support
-
-FlashInfer+ROCm can dispatch the `single_prefill`, `batch_prefill`
-(paged and ragged), `batch_decode`, `append_paged_kv_cache`, `rmsnorm`,
-`fused_add_rmsnorm`, `silu_and_mul`, `rope` (cos/sin-cache path), and
-`MLA` paths to [AITER](https://github.com/ROCm/aiter). MLA on ROCm
-is **AITER-only** — there is no in-tree HIP MLA kernel yet, so
-`backend="auto"` (the default for the MLA wrapper) resolves directly
-to `"aiter"`.
-
-On gfx942/gfx950, `backend="auto"` (the default) selects AITER when the
-call is compatible (see [Known Limitations](#known-limitations) for the
-full list) and otherwise falls back to the in-tree HIP kernel, emitting
-a one-time `logger.warning`. Pass `backend="aiter"` to require AITER
-explicitly, or pass the in-tree backend string to skip it:
-`backend="fa2"` for the attention wrappers (single/batch
-prefill/decode), `backend="native"` for non-attention ops
-(`append_paged_kv_cache`, `rmsnorm`, `fused_add_rmsnorm`,
-`silu_and_mul`, `rope`).
-
-The `rmsnorm`, `fused_add_rmsnorm`, `silu_and_mul`, and `rope`
-(cos/sin-cache) AITER backends are integrated at the **C++ level**:
-FlashInfer's JIT compiles a small HIP shim that calls AITER's C++ kernels
-(`rmsnorm2d`, `rmsnorm2d_with_add`, `aiter::silu_and_mul`,
-`rope_cached_positions_2c_fwd_impl`) directly and links a symbol-visible
-AITER `.so` — there is no runtime `import aiter` on these paths. The first
-JIT build of each op builds the corresponding AITER module once with
-`AITER_SYMBOL_VISIBLE=1` and caches it under
-`~/.cache/flashinfer/aiter_libs/` (the CK `module_rmsnorm` build is large
-and can take many minutes the first time). Auto-routing differs per op:
-for `rmsnorm` and `fused_add_rmsnorm`, `backend="auto"` resolves to AITER
-on gfx942/gfx950 (subject to op-specific constraints — `rmsnorm` auto only
-routes 2-D fp16/bf16 inputs to AITER) and to HIP `native` elsewhere. For
-`silu_and_mul` and `rope` (cos/sin-cache), experimentation found the
-in-tree HIP `native` kernel to be the better default, so `backend="auto"`
-resolves to `native` on all platforms; the AITER C++ path for these two
-ops is opt-in via an explicit `backend="aiter"`.
-
-Backend-specific exceptions to "auto picks AITER when supported":
-
-* `silu_and_mul` and `rope` (cos/sin-cache): `backend="auto"` always resolves
-  to the HIP `native` kernel — experimentation found it the better default.
-  The AITER C++ path is reachable only via an explicit `backend="aiter"`.
-* `append_paged_kv_cache`: same, and for the same reason. AITER's
-  `reshape_and_cache_flash` is bit-exact against the in-tree kernel but
-  sustains 2.86 TB/s to its 3.62 on identical work (gfx942, nnz=262144), so
-  `backend="auto"` always resolves to `native`. Explicit `backend="aiter"`
-  additionally requires `fp16`/`bf16` and `NHD`.
-* `rmsnorm`: `backend="auto"` picks the AITER C++ path (CK `rmsnorm2d`) only
-  for 2-D fp16/bf16 inputs whose weight dtype matches; 3-D inputs, fp32, or a
-  mismatched weight dtype fall back to the HIP `native` kernel.
-* `batch_decode`: `use_cuda_graph=True` or `use_tensor_cores=True` force `auto`
-  back to `fa2`, and `pos_encoding_mode != "NONE"` raises under
-  `backend="aiter"`. CUDA-graph capture on the AITER decode path is available
-  via an explicit `backend="aiter"` (not `auto`): capture at your maximum
-  sequence length — the grid and `.so` variant are fixed at capture-time shapes
-  and the kernel early-exits per sequence, so replays *shorter* than captured
-  are correct but *longer* ones are not. fa2's graph path is capacity-based and
-  carries no such constraint.
-
-Unless you are using the prebuilt Docker image, install AITER separately
-via one of the options below.
-
-### Install AITER from source
-
-```bash
-git clone --recursive https://github.com/ROCm/aiter.git
-cd aiter
-python3 setup.py develop
-```
-
-### Install AITER wheel package
-
-Wheel packages are published per ROCm release on AMD's PyPI index. `amd-aiter`
-is **not** on the top-level `pypi.amd.com/simple` index — use the ROCm-versioned
-channel:
-
-```bash
-pip install amd-aiter==0.1.10 --extra-index-url https://pypi.amd.com/rocm-7.1.1/simple
-```
-
-Use `--extra-index-url`, not `--index-url`, so that AITER's own dependencies
-still resolve from PyPI.
-
-Pin `0.1.10`: it is the version this repo is built and tested against, and
-currently the only one published on that channel. FlashInfer links AITER's C++
-symbols by mangled name (`flashinfer/csrc_rocm/aiter_loader.cc`) and vendors its
-argument structs (`include/flashinfer/attention/aiter/`), so a different AITER
-build can fail at `dlsym` — or, if a struct layout changed, misinterpret kernel
-arguments silently. Both the CI image (`docker/Dockerfile.rocm_ci`) and the
-devcontainer install this exact version.
-
-### Known Limitations
-
-AITER constraints fall into two groups: hard incompatibilities (the call
-errors with `backend="aiter"` and triggers fallback under
-`backend="auto"`, for the ops whose `auto` can pick AITER at all), and
-silently-ignored kwargs (the call runs but the flag has no effect on
-AITER — pass the in-tree backend explicitly if you need any of them:
-`backend="fa2"` for attention wrappers, or `backend="native"` for
-`rmsnorm`). `append_paged_kv_cache` is outside both groups: its `auto`
-already resolves to `native`, so there is no fallback to trigger, and
-none of the ignored kwargs below are parameters of it.
-
-**Conditions that fall back to the in-tree HIP kernel under
-`backend="auto"`** (and raise under `backend="aiter"`):
-
-* GPU is not gfx942 or gfx950
-* `kv_layout` is not `NHD`
-* a custom attention mask tensor is supplied
-* `q_dtype` is not `float16` / `bfloat16` (no fp32, fp8, or int8)
-* `q_dtype != kv_dtype` (mixed-precision Q/KV is unsupported)
-* `head_dim_qk != head_dim_vo` (e.g. DeepSeek-style MLA with 192/128 head dims)
-* `pos_encoding_mode != "NONE"` (AITER attention paths only support `"NONE"`)
-* batch decode: `use_tensor_cores=True`
-* the `aiter` Python package is not importable
-
-**Features silently ignored on the AITER path** (kwargs are accepted by
-the FlashInfer wrapper but not forwarded to AITER, which can produce
-wrong results):
-
-* ALiBi slopes (`maybe_alibi_slopes`)
-* RoPE scaling kwargs (`rope_scale`, `rope_theta`) — these are only
-  consumed alongside `pos_encoding_mode != "NONE"`, which AITER
-  attention rejects outright; the kwargs themselves pass through
-  silently when the mode is `"NONE"`
-* attention sinks (`sinks`)
-* multi-modal / prefix-cache helpers (`maybe_prefix_len_ptr`,
-  `maybe_token_pos_in_items_ptr`, `maybe_max_item_len_ptr`)
-* FP8 dequant scales (`scale_q` / `scale_k` / `scale_v`)
-* `use_fp16_qk_reduction`, `enable_pdl`
-
-**Other notes:**
-
-* Batch prefill: AITER's CK FMHA kernels natively support page sizes
-  `{16, 1024}` (or `{128, 256, 1024}` on `amd-aiter >= 0.1.10`). Other page
-  sizes still work but go through an extra GPU gather to flatten paged KV
-  before the AITER call. That list is a starting point, not a guarantee —
-  `plan()` confirms it by building the kernel, and a page size the installed
-  AITER cannot actually serve also falls back to the gather, with a warning
-  naming the reason. Builds installed from an AITER source commit (as SGLang
-  and vLLM do) are the usual case where a "native" page size is rejected. Set
-  `FLASHINFER_AITER_STRICT=1` to raise instead of falling back.
-* Ragged (non-paged) batch prefill via AITER is supported through
-  `BatchPrefillWithRaggedKVCacheWrapper`. The wrapper auto-routes to
-  AITER under `backend="auto"` when the standard AITER compatibility
-  conditions are met and falls back to `fa2` otherwise.
-* MLA on ROCm currently supports only `bfloat16` and `page_size=1`
-  through the AITER backend.
-
-## Environment Variables
-
-FlashInfer+ROCm reads the following environment variables at runtime
-or import time. Build-time variables (`FLASHINFER_ROCM_ARCH_LIST`,
-`FLASHINFER_JIT_VERBOSE`, `FLASHINFER_JIT_DEBUG`, `MAX_JOBS`, …) are
-documented in [CLAUDE.md](CLAUDE.md).
+Each line requests both `fa2` and `auto`, so `--refcheck` compares them
+side by side. **Read the `backend_resolved` column** — `auto` is a
+request, not a result, and `backend_fallback_reason` says why AITER was
+declined. Per-op drivers live in
+[`benchmarks/rocm_benchmarks/`](https://github.com/AMD-Ecosystem/flashinfer/tree/amd-integration/benchmarks/rocm_benchmarks).
+
+## Environment variables
+
+Read at runtime or import time:
 
 | Variable | Default | Purpose |
 | :--- | :--- | :--- |
-| `FLASHINFER_USE_TORCH_CUSTOM_OPS` | `0` | Set to `1` **before** importing `flashinfer` to wrap kernels in `torch.library.custom_op` so `torch.compile` / Dynamo can trace them. Requires PyTorch ≥ 2.4. Adds a small per-call dispatch overhead. |
-| `FLASHINFER_HIP_FUSED_CASCADE` | `0` | Set to `1` to use a fused single-kernel HIP cascade attention path instead of the default two-level merge-based path. Experimental on ROCm. |
-| `FLASHINFER_AITER_STRICT` | `0` | Set to `1` to raise instead of degrading when AITER cannot serve a page size natively. By default batch prefill falls back to the slower flat-gather path (with a warning); set this in CI to catch AITER kernel-coverage regressions rather than absorb them as a slowdown. |
-| `FLASHINFER_LOGGING_LEVEL` | `INFO` | Logger verbosity (e.g. `DEBUG`, `INFO`, `WARNING`). Affects AITER auto-fallback warnings and JIT build messages. |
-| `FLASHINFER_DISABLE_JIT` | unset | Set to any non-empty value to skip JIT compilation. Useful when running an AOT-built wheel and you want to fail loudly on missing kernels rather than trigger a build. |
-| `ROCM_PATH` / `ROCM_HOME` | `/opt/rocm` | Used by `flashinfer.hip_utils` to locate the ROCm install. Override only for non-standard ROCm layouts. |
+| `FLASHINFER_USE_TORCH_CUSTOM_OPS` | `0` | Wrap kernels for `torch.compile`; set before importing `flashinfer`. See above. |
+| `FLASHINFER_AITER_STRICT` | `0` | Raise instead of degrading when AITER cannot serve a page size natively. Set in CI to catch AITER coverage regressions rather than absorb them as a slowdown. |
+| `FLASHINFER_ARCH_ALLOW_KNOWN_BAD` | `0` | Run an (op, backend, arch) combination the capability table marks known-broken on your toolchain. Only if you have validated it yourself. |
+| `FLASHINFER_HIP_FUSED_CASCADE` | `0` | Use the fused single-kernel HIP cascade path instead of the two-level merge. Experimental. |
+| `FLASHINFER_WORKSPACE_BASE` | `~` | Parent of the JIT cache directory (`.cache/flashinfer/`). Point it at fast local disk when `$HOME` is on NFS. |
+| `FLASHINFER_DISABLE_JIT` | unset | Set to **any non-empty value** — including `0` — to skip JIT compilation. Useful with an AOT-built install, to fail loudly on a missing kernel rather than trigger a build. |
+| `FLASHINFER_DISABLE_VERSION_CHECK` | unset | Any non-empty value skips the JIT-cache package version check. |
+| `FLASHINFER_LOGGING_LEVEL` | `INFO` | Logger verbosity (`DEBUG`, `INFO`, `WARNING`, …). Affects AITER fallback warnings and JIT build messages. |
+| `ROCM_PATH` / `ROCM_HOME` | `/opt/rocm` | Where `flashinfer.hip_utils` looks for ROCm. Override only for non-standard layouts. |
 
-## Runtime Helpers
+Build-time variables — `FLASHINFER_ROCM_ARCH_LIST`, `FLASHINFER_JIT_VERBOSE`,
+`FLASHINFER_EXTRA_LDFLAGS`, `MAX_JOBS` — are documented in
+[CLAUDE.md](CLAUDE.md). Note `FLASHINFER_JIT_DEBUG` is a **no-op on
+ROCm/HIP**; CLAUDE.md explains how to get a debug build instead.
 
-`flashinfer` ships a few ROCm-specific helpers that are useful when
-guarding code paths or diagnosing setup issues:
+## Runtime helpers
 
 ```python
 import torch
@@ -539,46 +242,27 @@ import torch
 from flashinfer.aiter_utils import is_aiter_supported
 from flashinfer.hip_utils import check_torch_rocm_compatibility
 
-# True on gfx942/gfx950 (a ROCm build + supported GPU arch). Does *not*
-# verify the `aiter` Python package is importable — wrap the actual
-# AITER call in a try/except ImportError if you need that guarantee.
+# True on gfx942/gfx950 with a ROCm torch build. Does *not* verify the
+# `aiter` package is importable — wrap the call in try/except ImportError
+# if you need that guarantee.
 if is_aiter_supported(torch.device("cuda")):
     ...
 
-# Raises a clear error if PyTorch + ROCm versions are incompatible
-# (e.g. a CPU-only torch wheel was picked up from PyPI).
+# Raises a clear error if PyTorch + ROCm are incompatible, e.g. a CPU-only
+# torch wheel was picked up from PyPI.
 check_torch_rocm_compatibility()
 ```
 
-`flashinfer.hip_utils.validate_flashinfer_rocm_arch` is a related
-build-time validator used by `setup.py` to cross-check
-`FLASHINFER_ROCM_ARCH_LIST` against ROCm and PyTorch — not typically
-called from application code.
+## Building from source
 
-## Basic Usage
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the development container, the
+editable and wheel builds, the ahead-of-time kernel build, and how to run
+the test suite.
 
-```python
-import torch
-import flashinfer
+## License and acknowledgements
 
-# PyTorch+ROCm still uses device="cuda" for AMD GPUs.
-q = torch.randn(1024, 32, 128, dtype=torch.float16, device="cuda")
-k = torch.randn(1024,  8, 128, dtype=torch.float16, device="cuda")  # GQA 4:1
-v = torch.randn(1024,  8, 128, dtype=torch.float16, device="cuda")
+Apache-2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE). Upstream
+project: [flashinfer-ai/flashinfer](https://github.com/flashinfer-ai/flashinfer).
 
-# backend="auto" (default) routes to AITER when supported on gfx942/gfx950
-# and falls back to the in-tree fa2 HIP kernel otherwise.
-output = flashinfer.single_prefill_with_kv_cache(q, k, v, causal=True)
-```
-
-See [`examples/`](examples/) for batch prefill, batch decode, and a
-Jupyter tutorial that walks through the full public API on ROCm.
-
-## License and Acknowledgements
-
-FlashInfer+ROCm is released under the Apache-2.0 License — see
-[LICENSE](LICENSE) and [NOTICE](NOTICE). Upstream project:
-[flashinfer-ai/flashinfer](https://github.com/flashinfer-ai/flashinfer).
-
-Contributions are welcome. Please run `pre-commit run -a` and the
-relevant `pytest` selection before opening a PR.
+Contributions are welcome. Please run `pre-commit run -a` and the relevant
+`pytest` selection before opening a PR.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ only path.
 
 The port is in active development and is aimed at developers embedding
 FlashInfer kernels into their own training or serving stack. See
-[CHANGELOG.md](CHANGELOG.md) for the release history.
+[CHANGELOG.md](https://github.com/AMD-Ecosystem/flashinfer/blob/amd-integration/CHANGELOG.md) for the release history.
 
 **Versioning.** Release tags are `<upstream_version>+amd.<n>`, tying each
 FlashInfer+ROCm release to the upstream tag it is based on — `0.5.3+amd.1`
@@ -65,7 +65,7 @@ python -c "import torch; assert torch.version.hip, 'not a ROCm build'"
 ```
 
 Kernels are JIT-compiled on first use, which takes a few minutes. The
-optional [`amd-flashinfer-jit-cache`](amd-flashinfer-jit-cache/README.md)
+optional [`amd-flashinfer-jit-cache`](https://github.com/AMD-Ecosystem/flashinfer/blob/amd-integration/amd-flashinfer-jit-cache/README.md)
 package ships them prebuilt for gfx942.
 
 ## Basic usage
@@ -129,12 +129,12 @@ HIP-only, and `aiter_fused_moe` is AITER-only. On gfx950 with ROCm 7.2.x,
 table.
 
 **The full routing rules, per-op constraints, and AITER install
-instructions are in [`docs/rocm/backends.md`](docs/rocm/backends.md).**
+instructions are in [`docs/rocm/backends.md`](https://github.com/AMD-Ecosystem/flashinfer/blob/amd-integration/docs/rocm/backends.md).**
 Read it before relying on an AITER path — several attention kwargs are
 silently ignored there rather than rejected.
 
 The table below is generated from
-[`flashinfer/arch_caps.py`](flashinfer/arch_caps.py), which is what
+[`flashinfer/arch_caps.py`](https://github.com/AMD-Ecosystem/flashinfer/blob/amd-integration/flashinfer/arch_caps.py), which is what
 `backend="auto"` consults at runtime, so it cannot drift from the routing
 decisions the library makes. Do not edit it by hand; run
 `python3 scripts/gen_arch_support_matrix.py`.
@@ -150,7 +150,7 @@ decisions the library makes. Do not edit it by hand; run
 | `rope` | `aiter` | ✅ | ✅ | `apply_rope_with_cos_sin_cache` and its inplace variant, linked at the C++ level. Opt-in. |
 | `append_paged_kv_cache` | `aiter` | ✅ | ✅ | fp16/bf16 + NHD. Bit-exact with the in-tree kernel but slower, so `auto` picks `native`. |
 | `rmsnorm` | `aiter` | ✅ | ✅ | CK `rmsnorm2d`. `auto` routes only 2-D fp16/bf16 with a matching weight dtype here. |
-| `fused_add_rmsnorm` | `aiter` | ✅ | ✅ | CK `rmsnorm2d_with_add`; 2-D only. Slightly lower precision at hidden_size >= 1024. |
+| `fused_add_rmsnorm` | `aiter` | ✅ | ✅ | CK `rmsnorm2d_with_add`; 2-D only. `auto` does NOT check weight dtype — a mismatch silently yields garbage. |
 | `silu_and_mul` | `aiter` | ✅ | ✅ | `aiter::silu_and_mul`, linked at the C++ level. Opt-in; matches native in fp16, lower in bf16. |
 | `fused_moe` | `aiter` | ✅ | ✅ | `aiter_fused_moe`; bf16/fp16. Weights must be pre-shuffled with `shuffle_moe_weight` or results are silently wrong. |
 | `single_decode` | `hip` | ◻️ | ◻️ | MHA / GQA / MQA. |
@@ -177,9 +177,10 @@ decisions the library makes. Do not edit it by hand; run
 
 <!-- END GENERATED: arch support matrix -->
 
-Most rows have a matching `tests/rocm_tests/test_*_hip.py`; `single_decode`
-and `quantization` are covered incidentally from other files rather than
-by one of their own.
+Every row is covered by the default `pytest` selection. Most have a
+matching `tests/rocm_tests/test_*_hip.py`; `single_decode` is exercised
+from the batch-decode, sliding-window, and logits-cap files, and
+`quantization` by `tests/utils/test_quantization.py`.
 
 ## `torch.compile`
 
@@ -225,7 +226,7 @@ Read at runtime or import time:
 
 Build-time variables — `FLASHINFER_ROCM_ARCH_LIST`, `FLASHINFER_JIT_VERBOSE`,
 `FLASHINFER_EXTRA_LDFLAGS`, `MAX_JOBS` — are documented in
-[CLAUDE.md](CLAUDE.md). Note `FLASHINFER_JIT_DEBUG` is a **no-op on
+[CLAUDE.md](https://github.com/AMD-Ecosystem/flashinfer/blob/amd-integration/CLAUDE.md). Note `FLASHINFER_JIT_DEBUG` is a **no-op on
 ROCm/HIP**; CLAUDE.md explains how to get a debug build instead.
 
 ## Runtime helpers
@@ -249,13 +250,13 @@ check_torch_rocm_compatibility()
 
 ## Building from source
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the development container, the
+See [CONTRIBUTING.md](https://github.com/AMD-Ecosystem/flashinfer/blob/amd-integration/CONTRIBUTING.md) for the development container, the
 editable and wheel builds, the ahead-of-time kernel build, and how to run
 the test suite.
 
 ## License and acknowledgements
 
-Apache-2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE). Upstream
+Apache-2.0 — see [LICENSE](https://github.com/AMD-Ecosystem/flashinfer/blob/amd-integration/LICENSE) and [NOTICE](https://github.com/AMD-Ecosystem/flashinfer/blob/amd-integration/NOTICE). Upstream
 project: [flashinfer-ai/flashinfer](https://github.com/flashinfer-ai/flashinfer).
 
 Contributions are welcome. Please run `pre-commit run -a` and the relevant

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ decisions the library makes. Do not edit it by hand; run
 | `silu_and_mul` | `hip` | ◻️ | ◻️ | SiLU and GELU with fused gating; the default for `auto`. |
 | `quantization` | `hip` | ◻️ | ◻️ | `packbits` and `segment_packbits`. |
 
-* ✅ **validated** — this op was exercised on this architecture, and the board, ROCm, AITER, and date are recorded in `flashinfer/arch_caps.py`.
+* ✅ **validated** — this op has been exercised on this architecture.
 * ◻️ **supported** — the op runs here and the test suite covers it, but no run has been recorded against this specific op and architecture.
 * ⚠️ **broken on some toolchains** — usable, but not on every ROCm/AITER version; see the footnote.
 

--- a/README.md
+++ b/README.md
@@ -90,38 +90,37 @@ the routing decisions the library makes. Do not edit it by hand; run
 
 <!-- BEGIN GENERATED: arch support matrix -- scripts/gen_arch_support_matrix.py -->
 
-| Op | Backend | gfx942 (CDNA3) | gfx950 (CDNA4) |
-| :--- | :--- | :---: | :---: |
-| `batch_decode` | `aiter` | ✅ | ✅ |
-| `single_prefill` | `aiter` | ✅ | ✅ |
-| `batch_prefill` | `aiter` | ✅ | ⚠️[^kb1] |
-| `mla` | `aiter` | ✅ | ✅ |
-| `rope` | `aiter` | ✅ | ✅ |
-| `append_paged_kv_cache` | `aiter` | ✅ | ✅ |
-| `rmsnorm` | `aiter` | ✅ | ✅ |
-| `fused_add_rmsnorm` | `aiter` | ✅ | ✅ |
-| `silu_and_mul` | `aiter` | ✅ | ✅ |
-| `fused_moe` | `aiter` | ✅ | ✅ |
-| `single_decode` | `hip` | ◻️ | ◻️ |
-| `batch_decode` | `hip` | ◻️ | ◻️ |
-| `single_prefill` | `hip` | ◻️ | ◻️ |
-| `batch_prefill` | `hip` | ◻️ | ◻️ |
-| `cascade` | `hip` | ◻️ | ◻️ |
-| `pod` | `hip` | ◻️ | ◻️ |
-| `rope` | `hip` | ◻️ | ◻️ |
-| `append_paged_kv_cache` | `hip` | ◻️ | ◻️ |
-| `rmsnorm` | `hip` | ◻️ | ◻️ |
-| `fused_add_rmsnorm` | `hip` | ◻️ | ◻️ |
-| `layernorm` | `hip` | ◻️ | ◻️ |
-| `sampling` | `hip` | ◻️ | ◻️ |
-| `logits_processor` | `hip` | ◻️ | ◻️ |
-| `silu_and_mul` | `hip` | ◻️ | ◻️ |
-| `quantization` | `hip` | ◻️ | ◻️ |
+| Op | Backend | gfx942 (CDNA3) | gfx950 (CDNA4) | Notes |
+| :--- | :--- | :---: | :---: | :--- |
+| `batch_decode` | `aiter` | ✅ | ✅ | MHA / GQA / MQA with sliding window; fp16/bf16 + NHD. Graph capture is opt-in via `backend="aiter"`. |
+| `single_prefill` | `aiter` | ✅ | ✅ | MHA / GQA / MQA; fp16/bf16 + NHD, equal Q/KV dtypes and head dims, no custom mask. fp8 WIP. |
+| `batch_prefill` | `aiter` | ✅ | ⚠️[^kb1] | Paged and ragged. Page sizes 128/256/1024 are native on amd-aiter >= 0.1.10; others take a flat gather. |
+| `mla` | `aiter` | ✅ | ✅ | DeepSeek-style 192/128 head-dim split; fp16/bf16. No HIP kernel exists, so `auto` resolves here. |
+| `rope` | `aiter` | ✅ | ✅ | `apply_rope_with_cos_sin_cache` and its inplace variant, linked at the C++ level. Opt-in. |
+| `append_paged_kv_cache` | `aiter` | ✅ | ✅ | fp16/bf16 + NHD. Bit-exact with the in-tree kernel but slower, so `auto` picks `native`. |
+| `rmsnorm` | `aiter` | ✅ | ✅ | CK `rmsnorm2d`. `auto` routes only 2-D fp16/bf16 with a matching weight dtype here. |
+| `fused_add_rmsnorm` | `aiter` | ✅ | ✅ | CK `rmsnorm2d_with_add`; 2-D only. Slightly lower precision at hidden_size >= 1024. |
+| `silu_and_mul` | `aiter` | ✅ | ✅ | `aiter::silu_and_mul`, linked at the C++ level. Opt-in; matches native in fp16, lower in bf16. |
+| `fused_moe` | `aiter` | ✅ | ✅ | `aiter_fused_moe`; bf16/fp16. Weights must be pre-shuffled with `shuffle_moe_weight` or results are silently wrong. |
+| `single_decode` | `hip` | ◻️ | ◻️ | MHA / GQA / MQA. |
+| `batch_decode` | `hip` | ◻️ | ◻️ | MHA / GQA / MQA; fp8 KV-cache (E4M3FNUZ) and CUDA-graph capture. |
+| `single_prefill` | `hip` | ◻️ | ◻️ | MHA / GQA / MQA, including custom attention masks. |
+| `batch_prefill` | `hip` | ◻️ | ◻️ | Paged and ragged; MHA / GQA / MQA, including custom attention masks. |
+| `cascade` | `hip` | ◻️ | ◻️ | Two-level shared-prefix attention; a fused single-kernel variant is gated behind `FLASHINFER_HIP_FUSED_CASCADE=1`. |
+| `pod` | `hip` | ◻️ | ◻️ | `PODWithPagedKVCacheWrapper` and the batch variant. JIT-only, excluded from AOT as upstream. |
+| `rope` | `hip` | ◻️ | ◻️ | LLaMA and LLaMA 3.1 scaling; fused RoPE + fp8 quant + paged-KV append (E4M3FNUZ, E5M2FNUZ). |
+| `append_paged_kv_cache` | `hip` | ◻️ | ◻️ | fp8 KV-cache supported. Sustains 3.62 TB/s against AITER's 2.86 on gfx942, so `auto` picks this. |
+| `rmsnorm` | `hip` | ◻️ | ◻️ | The fallback for 3-D inputs, fp32, or a weight dtype that does not match the input. |
+| `fused_add_rmsnorm` | `hip` | ◻️ | ◻️ | The fallback whenever the AITER path is unavailable. |
+| `layernorm` | `hip` | ◻️ | ◻️ | `layernorm` plus the Gemma RMSNorm variants. No AITER path. |
+| `sampling` | `hip` | ◻️ | ◻️ | Top-K / Top-P / Min-P / OnlineSoftmax / SamplingFromLogits. |
+| `logits_processor` | `hip` | ◻️ | ◻️ | Composable processor pipeline (cap, mask, temperature, ...). |
+| `silu_and_mul` | `hip` | ◻️ | ◻️ | SiLU and GELU with fused gating; the default for `auto`. |
+| `quantization` | `hip` | ◻️ | ◻️ | `packbits` and `segment_packbits`. |
 
 * ✅ **validated** — a suite was run on that board, and the evidence is recorded below.
 * ◻️ **declared** — supported, but no per-op measurement has been recorded on that architecture.
 * ⚠️ **broken on some toolchains** — usable, but not on every ROCm/AITER version; see the footnote.
-* ❌ **not available** on that architecture.
 
 [^kb1]: `batch_prefill/aiter` on gfx950, ROCm [7.2, 7.3): ROCm 7.2.x miscompiles AITER's causal batch-prefill kernel on gfx950: causal=True with logits_soft_cap=0.0 returns wrong numbers (not an error), 97.6% of elements off. Use ROCm 7.1, or backend='fa2'. Override with `FLASHINFER_ARCH_ALLOW_KNOWN_BAD=1` if you have validated it yourself. <https://github.com/ROCm/aiter/blob/main/op_tests/test_batch_prefill.py>
 

--- a/docs/rocm/backends.md
+++ b/docs/rocm/backends.md
@@ -81,22 +81,28 @@ with `AITER_SYMBOL_VISIBLE=1` and caches it under
 `~/.cache/flashinfer/aiter_libs/`. The CK `module_rmsnorm` build is large
 and can take many minutes the first time.
 
-### `mha_fwd` is the only AITER op not shipped prebuilt
+### `mha_fwd` ships no prebuilt kernels at all
 
 The 0.1.10 wheel carries 58 prebuilt `mha_varlen_fwd_*.so` files and zero
-`mha_fwd*` — only `mha_fwd_kernels.cu` source. Single prefill is the one op
-that routes through the non-varlen `mha_fwd` template (batch=1 needs no
-seqstart plumbing, see PR #246), so it is the one op that JIT-builds on
-first call, per `(dtype, causal, has_lse)`.
+`mha_fwd*` — only `mha_fwd_kernels.cu` source. Single prefill is the op that
+routes through the non-varlen `mha_fwd` template (batch=1 needs no seqstart
+plumbing, see PR #246), so **every** one of its `(dtype, causal, has_lse)`
+variants JIT-builds on first call.
 
 **Absence of `mha_fwd*.so` is expected, not a broken install.** AITER
 prebuilds what vLLM and SGLang call, which is the varlen path; the
 non-varlen variant space is not in that set.
 
+Those 58 varlen files are not full coverage either, so this is a difference
+of degree rather than a unique case: batch prefill lazily builds the varlen
+variants that are missing — on 0.1.10, bf16 ships only `nmask_lse` and
+`mask_nlse`, so both remaining `nlogits` arms build on first use. Single
+prefill builds every variant; batch prefill builds the gaps.
+
 Two consequences worth planning for:
 
-* Budget **20+ minutes** for a cold variant — not the `~90s` a docstring
-  claims.
+* Budget **20+ minutes** for a cold variant. This is the same first-build
+  cost as the C++ AITER modules above, not a separate surprise.
 * A read-only or foreign-owned `site-packages/aiter/jit/` lets the build
   succeed but the install step fail. That error currently propagates out of
   `backend="auto"` instead of falling back to `fa2`.

--- a/docs/rocm/backends.md
+++ b/docs/rocm/backends.md
@@ -81,6 +81,26 @@ with `AITER_SYMBOL_VISIBLE=1` and caches it under
 `~/.cache/flashinfer/aiter_libs/`. The CK `module_rmsnorm` build is large
 and can take many minutes the first time.
 
+### `mha_fwd` is the only AITER op not shipped prebuilt
+
+The 0.1.10 wheel carries 58 prebuilt `mha_varlen_fwd_*.so` files and zero
+`mha_fwd*` — only `mha_fwd_kernels.cu` source. Single prefill is the one op
+that routes through the non-varlen `mha_fwd` template (batch=1 needs no
+seqstart plumbing, see PR #246), so it is the one op that JIT-builds on
+first call, per `(dtype, causal, has_lse)`.
+
+**Absence of `mha_fwd*.so` is expected, not a broken install.** AITER
+prebuilds what vLLM and SGLang call, which is the varlen path; the
+non-varlen variant space is not in that set.
+
+Two consequences worth planning for:
+
+* Budget **20+ minutes** for a cold variant — not the `~90s` a docstring
+  claims.
+* A read-only or foreign-owned `site-packages/aiter/jit/` lets the build
+  succeed but the install step fail. That error currently propagates out of
+  `backend="auto"` instead of falling back to `fa2`.
+
 ## How `backend="auto"` resolves
 
 There are four policies. Which one applies is a property of the op, not of

--- a/docs/rocm/backends.md
+++ b/docs/rocm/backends.md
@@ -49,7 +49,7 @@ changed, misinterpret kernel arguments silently. Both the CI image
 (`docker/Dockerfile.rocm_ci`) and the devcontainer install this exact
 version.
 
-Only cp310 and cp312 wheels exist on that channel (verified 2026-08-20).
+Only cp310 and cp312 wheels exist on that channel.
 On any other interpreter the command fails with
 `No matching distribution found`, and there is no good fallback: public
 PyPI tops out at a stale `0.1.7.post2.dev18` and the nightlies index only

--- a/docs/rocm/backends.md
+++ b/docs/rocm/backends.md
@@ -265,8 +265,10 @@ fp8 on the AITER attention paths is work in progress.
 
 ## Tests
 
-Most rows in the README matrix have a matching
-`tests/rocm_tests/test_*_hip.py`. Two do not: `single_decode` is covered
-from `test_batch_decode_kernels_hip.py`, `test_sliding_window_hip.py`, and
-`test_logits_cap_hip.py`; `quantization` (`packbits`,
-`segment_packbits`) has no direct ROCm coverage.
+Every row in the README matrix is covered by the default `pytest`
+selection (`testpaths` in `pyproject.toml`). Most have a matching
+`tests/rocm_tests/test_*_hip.py`. Two are covered from elsewhere:
+`single_decode` from `test_batch_decode_kernels_hip.py`,
+`test_sliding_window_hip.py`, and `test_logits_cap_hip.py`; `quantization`
+(`packbits`, `segment_packbits`) from `tests/utils/test_quantization.py`,
+which is shared with the CUDA suite rather than ROCm-specific.

--- a/docs/rocm/backends.md
+++ b/docs/rocm/backends.md
@@ -1,0 +1,272 @@
+# Backends on ROCm
+
+FlashInfer+ROCm ships an in-tree HIP kernel for most ops and can dispatch
+a subset to AMD's [AITER](https://github.com/ROCm/aiter). This page is the
+long form of the support matrix in [README.md](../../README.md): what each
+backend can do, what makes `backend="auto"` decline AITER, and the per-op
+constraints that are easy to trip over.
+
+* [Choosing a backend](#choosing-a-backend)
+* [Installing AITER](#installing-aiter)
+* [How `backend="auto"` resolves](#how-backendauto-resolves)
+* [Known limitations](#known-limitations)
+* [Per-op notes](#per-op-notes)
+
+## Choosing a backend
+
+Four backend strings are accepted by the ops that take a `backend=`
+argument. Which one names the in-tree kernel depends on the op:
+
+| `backend=` | Meaning |
+| :--- | :--- |
+| `"auto"` (default) | Pick per call — see [below](#how-backendauto-resolves) |
+| `"aiter"` | Require AITER; raise if the call is not compatible |
+| `"fa2"` | The in-tree HIP kernel, for the attention wrappers (single/batch prefill and decode) |
+| `"native"` | The in-tree HIP kernel, for everything else (`append_paged_kv_cache`, `rmsnorm`, `fused_add_rmsnorm`, `silu_and_mul`, `rope`) |
+
+`mla` accepts only `"auto"` and `"aiter"` — there is no in-tree MLA kernel.
+
+## Installing AITER
+
+Unless you are using the prebuilt Docker image, AITER is a separate
+install. Wheels are published per ROCm release on AMD's PyPI index;
+`amd-aiter` is **not** on the top-level `pypi.amd.com/simple` index, so
+use the ROCm-versioned channel:
+
+```bash
+pip install amd-aiter==0.1.10 --extra-index-url https://pypi.amd.com/rocm-7.1.1/simple
+```
+
+Use `--extra-index-url`, not `--index-url`, so AITER's own dependencies
+still resolve from PyPI.
+
+**Pin `0.1.10`.** It is the version this repo is built and tested against,
+and the only one published on that channel. FlashInfer links AITER's C++
+symbols by mangled name (`flashinfer/csrc_rocm/aiter_loader.cc`) and
+vendors its argument structs (`include/flashinfer/attention/aiter/`), so a
+different AITER build can fail at `dlsym` — or, if a struct layout
+changed, misinterpret kernel arguments silently. Both the CI image
+(`docker/Dockerfile.rocm_ci`) and the devcontainer install this exact
+version.
+
+Only cp310 and cp312 wheels exist on that channel (verified 2026-08-20).
+On any other interpreter the command fails with
+`No matching distribution found`, and there is no good fallback: public
+PyPI tops out at a stale `0.1.7.post2.dev18` and the nightlies index only
+carries `>= 0.1.16`. Use CPython 3.12 unless you are prepared to run an
+unvalidated AITER.
+
+A source build tracks master, which is many releases ahead of the pin
+**with a different C ABI** — symbols the shim expects are renamed, hidden
+rather than `extern "C"`, or absent:
+
+```bash
+git clone --recursive https://github.com/ROCm/aiter.git
+cd aiter && python3 setup.py develop
+```
+
+Nothing stops you running one, but treat it as untested here.
+
+### C++-level integration
+
+The `rmsnorm`, `fused_add_rmsnorm`, `silu_and_mul`, and `rope`
+(cos/sin-cache) AITER backends are integrated at the **C++ level**: the
+JIT compiles a small HIP shim that calls AITER's C++ kernels
+(`rmsnorm2d`, `rmsnorm2d_with_add`, `aiter::silu_and_mul`,
+`rope_cached_positions_2c_fwd_impl`) and links a symbol-visible AITER
+`.so`. There is no runtime `import aiter` on these paths.
+
+The first JIT build of each op builds the corresponding AITER module once
+with `AITER_SYMBOL_VISIBLE=1` and caches it under
+`~/.cache/flashinfer/aiter_libs/`. The CK `module_rmsnorm` build is large
+and can take many minutes the first time.
+
+## How `backend="auto"` resolves
+
+There are four policies. Which one applies is a property of the op, not of
+the call:
+
+| Policy | Ops |
+| :--- | :--- |
+| AITER when the call is compatible, else the in-tree kernel | `single_prefill`, `batch_prefill`, `batch_decode`, `fused_add_rmsnorm` |
+| AITER for 2-D fp16/bf16 whose weight dtype matches, else `native` | `rmsnorm` |
+| Always the in-tree `native` kernel — AITER is opt-in | `silu_and_mul`, `rope`, `append_paged_kv_cache` |
+| AITER only — no HIP kernel exists | `mla` |
+
+`single_decode_with_kv_cache` (HIP-only) and `aiter_fused_moe`
+(AITER-only) take no `backend=` argument at all.
+
+**`fused_add_rmsnorm` is in the first row, not the second.** Unlike
+`rmsnorm`, its selector inspects only the device — not rank, dtype, or
+weight dtype. A 2-D fp16 input with an fp32 `weight` therefore *does*
+reach AITER's CK kernel, which derives one dtype from the input and reads
+the weight bytes with it: the result is NaN or garbage, in place, with no
+error. Pass `backend="native"` when the weight dtype does not match.
+
+When `auto` declines AITER it falls back to the in-tree kernel and usually
+warns once with the reason. A few `batch_decode` short-circuits (CUDA-graph
+capture, `use_tensor_cores=True`) fall back silently.
+
+The three "always native" ops are that way because measurement said so,
+not because AITER is unavailable:
+
+* **`append_paged_kv_cache`** — AITER's `reshape_and_cache_flash` is
+  bit-exact against the in-tree kernel but sustains 2.86 TB/s to its 3.62
+  on identical work (gfx942, nnz=262144). Explicit `backend="aiter"`
+  additionally requires fp16/bf16 and `NHD`.
+* **`silu_and_mul`** and **`rope`** (cos/sin-cache) — the in-tree kernel
+  was the better default in experiment. The AITER C++ path is reachable
+  only via an explicit `backend="aiter"`.
+
+## Known limitations
+
+AITER constraints fall into two groups. The first errors out under
+`backend="aiter"` and triggers fallback under `backend="auto"`. The second
+is worse: the call runs, but the flag is silently dropped.
+
+`append_paged_kv_cache` sits outside both — its `auto` already resolves to
+`native`, so there is no fallback to trigger, and none of the ignored
+kwargs below are parameters of it.
+
+### Falls back to the in-tree kernel under `auto`, raises under `aiter`
+
+* GPU is not gfx942 or gfx950
+* `kv_layout` is not `NHD`
+* a custom attention mask tensor is supplied
+* `q_dtype` is not `float16` / `bfloat16` (no fp32, fp8, or int8)
+* `q_dtype != kv_dtype` — mixed-precision Q/KV is unsupported
+* `head_dim_qk != head_dim_vo` (e.g. DeepSeek-style MLA with 192/128)
+* `pos_encoding_mode != "NONE"` — AITER attention supports only `"NONE"`
+* batch decode: `use_tensor_cores=True`, or `use_cuda_graph=True` under
+  `auto`
+* the `aiter` Python package is not importable
+
+### Accepted but not honoured
+
+These kwargs are accepted by the wrapper and never reach the kernel, so
+passing them can produce **wrong results**. Switching to the in-tree
+backend fixes only the first group.
+
+**Dropped on the AITER path; pass `backend="fa2"` if you need them:**
+
+* attention sinks (`sinks`)
+* FP8 dequant scales (`scale_q` / `scale_k` / `scale_v`)
+* `use_fp16_qk_reduction`
+* RoPE scaling kwargs (`rope_scale`, `rope_theta`) — only meaningful
+  alongside `pos_encoding_mode != "NONE"`, which AITER attention rejects
+  outright, so in practice they pass through when the mode is `"NONE"`
+
+**Dropped on *both* ROCm paths — there is no backend that honours them.**
+These at least log a warning rather than failing silently:
+
+* `enable_pdl`
+* multi-modal / prefix-cache helpers (`maybe_prefix_len_ptr`,
+  `maybe_token_pos_in_items_ptr`, `maybe_max_item_len_ptr`)
+
+ALiBi is not in either list: `maybe_alibi_slopes` is filled internally
+from the head count, and the user-facing route to it is
+`pos_encoding_mode="ALIBI"`, which raises on the AITER path rather than
+being ignored.
+
+## Per-op notes
+
+### Batch prefill: page size and the flat-gather path
+
+AITER's CK FMHA kernels natively serve page sizes `{16, 1024}`, or
+`{128, 256, 1024}` on `amd-aiter >= 0.1.10`. Other sizes still work but go
+through an extra GPU gather that flattens the paged KV cache before the
+AITER call — inside the timed region, which matters when benchmarking.
+
+That list is a starting point, not a guarantee. `plan()` confirms it by
+building the kernel, and a page size the installed AITER cannot actually
+serve also falls back to the gather with a warning naming the reason.
+Builds installed from an AITER source commit (as SGLang and vLLM do) are
+the usual case where a "native" page size is rejected.
+
+Set `FLASHINFER_AITER_STRICT=1` to raise instead of falling back — useful
+in CI, where a silent slowdown is easy to absorb and hard to notice.
+
+Ragged (non-paged) batch prefill is supported through
+`BatchPrefillWithRaggedKVCacheWrapper`, with the same auto-routing rules.
+
+### Batch decode: CUDA-graph capture
+
+Graph capture on the AITER decode path is available via an explicit
+`backend="aiter"`, not `auto`. **Capture at your maximum sequence
+length**: the launch grid and `.so` variant are fixed at capture-time
+shapes and the kernel early-exits per sequence on `context_lens`, so
+replays *shorter* than captured are correct but *longer* ones are not.
+
+`fa2`'s graph path is capacity-based and carries no such constraint, which
+is why `auto` uses it under capture.
+
+### MLA
+
+* `q_data_type` must be `float16` or `bfloat16`, and must equal
+  `kv_data_type`.
+* `page_size` is not restricted by the code, but only `page_size=1` is
+  covered by the numerical tests. Treat anything larger as unverified.
+* `plan(causal=False)` **raises** when `max_seqlen_q > 1`. AITER's
+  `mla_prefill_fwd` has no causal flag and unconditionally dispatches the
+  causal ASM kernel, so honouring `causal=False` would silently return
+  causal results. This is a deliberate divergence from the CUDA wrapper,
+  which does honour it.
+* `run()` hands AITER a zero-copy view when `ckv_cache` and `kpe_cache`
+  are adjacent halves of one allocation (the vLLM / SGLang layout).
+  Otherwise it builds the combined cache with `torch.cat` on every call
+  and warns once *per wrapper* — a 60-layer model with a wrapper per layer
+  emits 60 warnings. 4-D caches are rejected outright.
+
+### Fused MoE
+
+`flashinfer.aiter_fused_moe` is AITER-only — there is no HIP MoE kernel.
+
+```python
+from flashinfer import aiter_fused_moe, shuffle_moe_weight
+
+w1s = shuffle_moe_weight(w1)
+w2s = shuffle_moe_weight(w2)
+out = aiter_fused_moe(hidden_states, w1s, w2s, topk_ids, topk_weights)
+```
+
+* `hidden_states` and the weights must be `bfloat16` or `float16`.
+* `activation` is `"silu"` or `"gelu"`. `block_m` is the CK tile height —
+  32, 64, or 128, or `"auto"` (the default), which picks from the expected
+  tokens *per expert*, not the total token count.
+* `topk_ids` is int32 in `[0, num_experts)` — there is no drop marker.
+  `topk_weights` is float32.
+* **Weights must be pre-shuffled** with `shuffle_moe_weight`, which lays
+  them out for the 16x16 MFMA tile. Passing unshuffled weights does not
+  raise: shape and dtype are unchanged, so nothing can detect it, and the
+  output is silently wrong.
+
+### HIP-only kernels
+
+These have no AITER path at all:
+
+* **Cascade attention** — two-level shared-prefix attention. A fused
+  single-kernel HIP variant is gated behind
+  `FLASHINFER_HIP_FUSED_CASCADE=1` (experimental).
+* **POD attention** — `PODWithPagedKVCacheWrapper` and
+  `BatchPODWithPagedKVCacheWrapper`. JIT-only, excluded from AOT builds,
+  matching upstream CUDA.
+* **LayerNorm / Gemma RMSNorm**, **sampling** (Top-K / Top-P / Min-P /
+  OnlineSoftmax / SamplingFromLogits), the **logits processor** pipeline,
+  and **quantization** (`packbits`, `segment_packbits`).
+
+### fp8 on the HIP path
+
+* Batch decode accepts an fp8 KV-cache (`float8_e4m3fnuz`).
+* RoPE has a fused RoPE + fp8-quantize + paged-KV-append path covering
+  `float8_e4m3fnuz` and `float8_e5m2fnuz`, alongside LLaMA and LLaMA 3.1
+  scaling.
+
+fp8 on the AITER attention paths is work in progress.
+
+## Tests
+
+Most rows in the README matrix have a matching
+`tests/rocm_tests/test_*_hip.py`. Two do not: `single_decode` is covered
+from `test_batch_decode_kernels_hip.py`, `test_sliding_window_hip.py`, and
+`test_logits_cap_hip.py`; `quantization` (`packbits`,
+`segment_packbits`) has no direct ROCm coverage.

--- a/examples/amd_flashinfer_rocm_tutorial.ipynb
+++ b/examples/amd_flashinfer_rocm_tutorial.ipynb
@@ -21,7 +21,7 @@
     "Engineers and researchers who already use PyTorch on ROCm and want a concise, runnable introduction to amd-flashinfer APIs before integrating them into larger serving systems. Familiarity with attention mechanics (queries, keys, values, heads) is assumed.\n",
     "\n",
     "**Scope**  \n",
-    "The exercises below use supported prefill and logits APIs in a single-node GPU environment. They do not cover every operator in the library. For broader feature coverage and installation matrices, see the [FlashInfer+ROCm README](https://github.com/ROCm/flashinfer/blob/main/README.md)."
+    "The exercises below use supported prefill and logits APIs in a single-node GPU environment. They do not cover every operator in the library. For broader feature coverage and installation matrices, see the [FlashInfer+ROCm README](https://github.com/AMD-Ecosystem/flashinfer/blob/amd-integration/README.md)."
    ]
   },
   {
@@ -31,7 +31,7 @@
    "source": [
     "## Setting up amd-flashinfer\n",
     "\n",
-    "The [project README](https://github.com/ROCm/flashinfer/blob/main/README.md) describes supported ROCm and PyTorch versions (e.g. ROCm 7.0.2–7.2; Torch+ROCm 2.8.0 / 2.9.1) and **Instinct** architectures (**gfx942**, **gfx950**). Align your environment with one of the following before running the cells below.\n",
+    "The [project README](https://github.com/AMD-Ecosystem/flashinfer/blob/amd-integration/README.md) describes supported ROCm and PyTorch versions (e.g. ROCm 7.0.2–7.2; Torch+ROCm 2.8.0 / 2.9.1) and **Instinct** architectures (**gfx942**, **gfx950**). Align your environment with one of the following before running the cells below.\n",
     "\n",
     "**Option 1 — Pre-built Docker image (recommended for reproducibility)**  \n",
     "AMD publishes images on Docker Hub under [`rocm/flashinfer`](https://hub.docker.com/r/rocm/flashinfer/tags). Start a container with GPU devices exposed, for example:\n",
@@ -65,7 +65,7 @@
    "source": [
     "## Verifying the runtime: PyTorch ROCm, FlashInfer, and GPU compatibility\n",
     "\n",
-    "The following cell imports amd-flashinfer and uses helpers from [`flashinfer/hip_utils.py`](https://github.com/ROCm/flashinfer/blob/main/flashinfer/hip_utils.py) to confirm that PyTorch was built with ROCm support, to report the detected ROCm version when possible, and to list GPU agents that match **FlashInfer-supported** architecture names (via `rocminfo`). It also checks that at least one accelerator is visible through the HIP runtime (`torch.cuda` on ROCm).\n",
+    "The following cell imports amd-flashinfer and uses helpers from [`flashinfer/hip_utils.py`](https://github.com/AMD-Ecosystem/flashinfer/blob/amd-integration/flashinfer/hip_utils.py) to confirm that PyTorch was built with ROCm support, to report the detected ROCm version when possible, and to list GPU agents that match **FlashInfer-supported** architecture names (via `rocminfo`). It also checks that at least one accelerator is visible through the HIP runtime (`torch.cuda` on ROCm).\n",
     "\n",
     "Run this cell **before** the worked examples; if it raises or warns, resolve the installation mismatch (README links above) before proceeding."
    ]
@@ -159,7 +159,7 @@
     "\n",
     "**Backend integration.** amd-flashinfer offers [AITER](https://github.com/ROCm/aiter)—AMD’s SOTA kernel library for large language model operators on ROCm—as an optional **`backend=\"aiter\"`**. When the `aiter` package is present and the requested operator is integrated with AITER in this port, work **delegates** to AITER; otherwise the default HIP path applies. The following cells exercise the AITER-backed prefill path.\n",
     "\n",
-    "**Requirements and layout.** Install the `aiter` package (e.g. `amd-aiter` from AMD’s PyPI); see [AITER Support](https://github.com/ROCm/flashinfer/blob/main/README.md#aiter-support) in the README. These calls expect **NHD** key/value layout (`[sequence, heads, dim]`). For batched paged prefill, allowed **page sizes** depend on your AITER build (typical CK values are listed in the README, e.g. 1, 16, 1024)."
+    "**Requirements and layout.** Install the `aiter` package (e.g. `amd-aiter` from AMD’s PyPI); see [Backends on ROCm](https://github.com/AMD-Ecosystem/flashinfer/blob/amd-integration/docs/rocm/backends.md). These calls expect **NHD** key/value layout (`[sequence, heads, dim]`). For batched paged prefill, the page sizes AITER serves natively depend on your AITER build — `{16, 1024}`, or `{128, 256, 1024}` on `amd-aiter >= 0.1.10`. Other sizes still work, via an extra gather."
    ]
   },
   {
@@ -347,7 +347,7 @@
    "source": [
     "### Batched prefill with a paged KV cache\n",
     "\n",
-    "Serving systems often store keys and values in **fixed-size pages** and index them with indirection tables. The same logical batch can then be planned once and reused across layers. Here we build a minimal paged layout—`[total_pages, 2, page_size, num_kv_heads, head_dim]` for NHD, slot `0` for K and `1` for V—and run **`BatchPrefillWithPagedKVCacheWrapper`** with `backend=\"aiter\"` in the constructor. We use `page_size=16` and a 512 MiB workspace buffer, matching the [batch prefill example](https://github.com/ROCm/flashinfer/blob/main/examples/batch_prefill_example.py). To build confidence, the first sequence in the batch is checked against the single-sequence prefill call above."
+    "Serving systems often store keys and values in **fixed-size pages** and index them with indirection tables. The same logical batch can then be planned once and reused across layers. Here we build a minimal paged layout—`[total_pages, 2, page_size, num_kv_heads, head_dim]` for NHD, slot `0` for K and `1` for V—and run **`BatchPrefillWithPagedKVCacheWrapper`** with `backend=\"aiter\"` in the constructor. We use `page_size=16` and a 512 MiB workspace buffer, matching the [batch prefill example](https://github.com/AMD-Ecosystem/flashinfer/blob/amd-integration/examples/batch_prefill_example.py). To build confidence, the first sequence in the batch is checked against the single-sequence prefill call above."
    ]
   },
   {
@@ -587,7 +587,7 @@
    "source": [
     "## Summary\n",
     "\n",
-    "This notebook introduced procedures to confirm a ROCm-enabled PyTorch stack with amd-flashinfer, including GPU and ROCm compatibility checks via `flashinfer.hip_utils`. It demonstrated **attention prefill** using the **AITER** backend for a single sequence and for **batched paged** key–value cache layouts, and it illustrated the **`LogitsPipe`** API for temperature scaling, filtering, and sampling on model logits. For supported platforms, container images, and the complete operator matrix, consult the [FlashInfer+ROCm README](https://github.com/ROCm/flashinfer/blob/main/README.md); for API details shared with upstream FlashInfer, see the [FlashInfer documentation](https://docs.flashinfer.ai)."
+    "This notebook introduced procedures to confirm a ROCm-enabled PyTorch stack with amd-flashinfer, including GPU and ROCm compatibility checks via `flashinfer.hip_utils`. It demonstrated **attention prefill** using the **AITER** backend for a single sequence and for **batched paged** key–value cache layouts, and it illustrated the **`LogitsPipe`** API for temperature scaling, filtering, and sampling on model logits. For supported platforms, container images, and the complete operator matrix, consult the [FlashInfer+ROCm README](https://github.com/AMD-Ecosystem/flashinfer/blob/amd-integration/README.md); for API details shared with upstream FlashInfer, see the [FlashInfer documentation](https://docs.flashinfer.ai)."
    ]
   }
  ],

--- a/flashinfer/arch_caps.py
+++ b/flashinfer/arch_caps.py
@@ -214,6 +214,9 @@ class Capability:
     op: str
     backend: str
     archs: Mapping[str, ArchSupport] = field(default_factory=dict)
+    # One line, rendered as the README matrix Notes column; anything longer
+    # belongs in docs/rocm/backends.md. The generator rejects a note carrying
+    # a pipe, a bare URL, inline HTML, or a newline.
     note: str = ""
     # The public ``backend=`` string to suggest when this row is unavailable.
     # Declared per row because it is not derivable: the table keys backends as
@@ -301,8 +304,20 @@ _HIP_950 = ArchSupport(Support.SUPPORTED)
 
 CAPABILITIES: Tuple[Capability, ...] = (
     # --- AITER backends: measured on both architectures --------------------
-    Capability("batch_decode", "aiter", _archs(_OK_942, _OK_950), fallback="fa2"),
-    Capability("single_prefill", "aiter", _archs(_OK_942, _OK_950), fallback="fa2"),
+    Capability(
+        "batch_decode",
+        "aiter",
+        _archs(_OK_942, _OK_950),
+        note='MHA / GQA / MQA with sliding window; fp16/bf16 + NHD. Graph capture is opt-in via `backend="aiter"`.',
+        fallback="fa2",
+    ),
+    Capability(
+        "single_prefill",
+        "aiter",
+        _archs(_OK_942, _OK_950),
+        note="MHA / GQA / MQA; fp16/bf16 + NHD, equal Q/KV dtypes and head dims, no custom mask. fp8 WIP.",
+        fallback="fa2",
+    ),
     Capability(
         "batch_prefill",
         "aiter",
@@ -315,6 +330,7 @@ CAPABILITIES: Tuple[Capability, ...] = (
                 known_bad=(_ROCM72_CAUSAL_PREFILL,),
             ),
         ),
+        note="Paged and ragged. Page sizes 128/256/1024 are native on amd-aiter >= 0.1.10; others take a flat gather.",
         fallback="fa2",
     ),
     # No alternative backend -- hence no fallback=.
@@ -322,34 +338,141 @@ CAPABILITIES: Tuple[Capability, ...] = (
         "mla",
         "aiter",
         _archs(_OK_942, ArchSupport(Support.SUPPORTED, evidence=_MEASURED_950_MLA)),
+        note="DeepSeek-style 192/128 head-dim split; fp16/bf16. No HIP kernel exists, so `auto` resolves here.",
     ),
-    Capability("rope", "aiter", _archs(_OK_942, _OK_950), fallback="native"),
     Capability(
-        "append_paged_kv_cache", "aiter", _archs(_OK_942, _OK_950), fallback="native"
+        "rope",
+        "aiter",
+        _archs(_OK_942, _OK_950),
+        note="`apply_rope_with_cos_sin_cache` and its inplace variant, linked at the C++ level. Opt-in.",
+        fallback="native",
     ),
-    Capability("rmsnorm", "aiter", _archs(_OK_942, _OK_950), fallback="native"),
     Capability(
-        "fused_add_rmsnorm", "aiter", _archs(_OK_942, _OK_950), fallback="native"
+        "append_paged_kv_cache",
+        "aiter",
+        _archs(_OK_942, _OK_950),
+        note="fp16/bf16 + NHD. Bit-exact with the in-tree kernel but slower, so `auto` picks `native`.",
+        fallback="native",
     ),
-    Capability("silu_and_mul", "aiter", _archs(_OK_942, _OK_950), fallback="native"),
+    Capability(
+        "rmsnorm",
+        "aiter",
+        _archs(_OK_942, _OK_950),
+        note="CK `rmsnorm2d`. `auto` routes only 2-D fp16/bf16 with a matching weight dtype here.",
+        fallback="native",
+    ),
+    Capability(
+        "fused_add_rmsnorm",
+        "aiter",
+        _archs(_OK_942, _OK_950),
+        note="CK `rmsnorm2d_with_add`; 2-D only. Slightly lower precision at hidden_size >= 1024.",
+        fallback="native",
+    ),
+    Capability(
+        "silu_and_mul",
+        "aiter",
+        _archs(_OK_942, _OK_950),
+        note="`aiter::silu_and_mul`, linked at the C++ level. Opt-in; matches native in fp16, lower in bf16.",
+        fallback="native",
+    ),
     # No HIP MoE kernel, so no fallback.
-    Capability("fused_moe", "aiter", _archs(_OK_942_MOE, _OK_950_MOE)),
+    Capability(
+        "fused_moe",
+        "aiter",
+        _archs(_OK_942_MOE, _OK_950_MOE),
+        note="`aiter_fused_moe`; bf16/fp16. Weights must be pre-shuffled with `shuffle_moe_weight` or results are silently wrong.",
+    ),
     # --- HIP backends: declared; per-op evidence not yet recorded ----------
-    Capability("single_decode", "hip", _archs(_HIP_942, _HIP_950)),
-    Capability("batch_decode", "hip", _archs(_HIP_942, _HIP_950)),
-    Capability("single_prefill", "hip", _archs(_HIP_942, _HIP_950)),
-    Capability("batch_prefill", "hip", _archs(_HIP_942, _HIP_950)),
-    Capability("cascade", "hip", _archs(_HIP_942, _HIP_950)),
-    Capability("pod", "hip", _archs(_HIP_942, _HIP_950)),
-    Capability("rope", "hip", _archs(_HIP_942, _HIP_950)),
-    Capability("append_paged_kv_cache", "hip", _archs(_HIP_942, _HIP_950)),
-    Capability("rmsnorm", "hip", _archs(_HIP_942, _HIP_950)),
-    Capability("fused_add_rmsnorm", "hip", _archs(_HIP_942, _HIP_950)),
-    Capability("layernorm", "hip", _archs(_HIP_942, _HIP_950)),
-    Capability("sampling", "hip", _archs(_HIP_942, _HIP_950)),
-    Capability("logits_processor", "hip", _archs(_HIP_942, _HIP_950)),
-    Capability("silu_and_mul", "hip", _archs(_HIP_942, _HIP_950)),
-    Capability("quantization", "hip", _archs(_HIP_942, _HIP_950)),
+    Capability(
+        "single_decode",
+        "hip",
+        _archs(_HIP_942, _HIP_950),
+        note="MHA / GQA / MQA.",
+    ),
+    Capability(
+        "batch_decode",
+        "hip",
+        _archs(_HIP_942, _HIP_950),
+        note="MHA / GQA / MQA; fp8 KV-cache (E4M3FNUZ) and CUDA-graph capture.",
+    ),
+    Capability(
+        "single_prefill",
+        "hip",
+        _archs(_HIP_942, _HIP_950),
+        note="MHA / GQA / MQA, including custom attention masks.",
+    ),
+    Capability(
+        "batch_prefill",
+        "hip",
+        _archs(_HIP_942, _HIP_950),
+        note="Paged and ragged; MHA / GQA / MQA, including custom attention masks.",
+    ),
+    Capability(
+        "cascade",
+        "hip",
+        _archs(_HIP_942, _HIP_950),
+        note="Two-level shared-prefix attention; a fused single-kernel variant is gated behind `FLASHINFER_HIP_FUSED_CASCADE=1`.",
+    ),
+    Capability(
+        "pod",
+        "hip",
+        _archs(_HIP_942, _HIP_950),
+        note="`PODWithPagedKVCacheWrapper` and the batch variant. JIT-only, excluded from AOT as upstream.",
+    ),
+    Capability(
+        "rope",
+        "hip",
+        _archs(_HIP_942, _HIP_950),
+        note="LLaMA and LLaMA 3.1 scaling; fused RoPE + fp8 quant + paged-KV append (E4M3FNUZ, E5M2FNUZ).",
+    ),
+    Capability(
+        "append_paged_kv_cache",
+        "hip",
+        _archs(_HIP_942, _HIP_950),
+        note="fp8 KV-cache supported. Sustains 3.62 TB/s against AITER's 2.86 on gfx942, so `auto` picks this.",
+    ),
+    Capability(
+        "rmsnorm",
+        "hip",
+        _archs(_HIP_942, _HIP_950),
+        note="The fallback for 3-D inputs, fp32, or a weight dtype that does not match the input.",
+    ),
+    Capability(
+        "fused_add_rmsnorm",
+        "hip",
+        _archs(_HIP_942, _HIP_950),
+        note="The fallback whenever the AITER path is unavailable.",
+    ),
+    Capability(
+        "layernorm",
+        "hip",
+        _archs(_HIP_942, _HIP_950),
+        note="`layernorm` plus the Gemma RMSNorm variants. No AITER path.",
+    ),
+    Capability(
+        "sampling",
+        "hip",
+        _archs(_HIP_942, _HIP_950),
+        note="Top-K / Top-P / Min-P / OnlineSoftmax / SamplingFromLogits.",
+    ),
+    Capability(
+        "logits_processor",
+        "hip",
+        _archs(_HIP_942, _HIP_950),
+        note="Composable processor pipeline (cap, mask, temperature, ...).",
+    ),
+    Capability(
+        "silu_and_mul",
+        "hip",
+        _archs(_HIP_942, _HIP_950),
+        note="SiLU and GELU with fused gating; the default for `auto`.",
+    ),
+    Capability(
+        "quantization",
+        "hip",
+        _archs(_HIP_942, _HIP_950),
+        note="`packbits` and `segment_packbits`.",
+    ),
 )
 
 
@@ -438,7 +561,7 @@ def _blocking_reason(op: str, backend: str, arch: str) -> Optional[str]:
     if entry.support is Support.UNSUPPORTED:
         return f"{backend} {op} is not supported on {arch}"
     if not entry.known_bad:
-        # The common case: 23 of 24 rows have no window, so they never pay for
+        # The common case: 24 of 25 rows have no window, so they never pay for
         # version detection at all.
         return None
 

--- a/flashinfer/arch_caps.py
+++ b/flashinfer/arch_caps.py
@@ -364,7 +364,7 @@ CAPABILITIES: Tuple[Capability, ...] = (
         "fused_add_rmsnorm",
         "aiter",
         _archs(_OK_942, _OK_950),
-        note="CK `rmsnorm2d_with_add`; 2-D only. Slightly lower precision at hidden_size >= 1024.",
+        note="CK `rmsnorm2d_with_add`; 2-D only. `auto` does NOT check weight dtype — a mismatch silently yields garbage.",
         fallback="native",
     ),
     Capability(

--- a/flashinfer/arch_caps.py
+++ b/flashinfer/arch_caps.py
@@ -185,7 +185,7 @@ class KnownBad:
 class ArchSupport:
     """How one ``(op, backend)`` behaves on one architecture.
 
-    ``evidence`` records *what was actually run* -- board, ROCm, AITER, date --
+    ``evidence`` records *what was actually run* -- board, ROCm, AITER, torch --
     rather than a bare "validated" flag. An empty string means the row is a
     declaration nobody has measured, which is a fact worth being able to render.
     """
@@ -248,12 +248,12 @@ class Capability:
 # both on torch 2.9.1+rocm7.2.0, HIP 7.2.26015, amd-aiter 0.1.10.
 # --------------------------------------------------------------------------
 
-_MEASURED_950 = "MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-19"
-_MEASURED_942 = "MI300X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-19"
+_MEASURED_950 = "MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1"
+_MEASURED_942 = "MI300X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1"
 
 # Separate from the suite strings above, which predate the MLA tests.
 _MEASURED_950_MLA = (
-    "mla: MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-24 "
+    "mla: MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 "
     "(decode + prefill, heads 16/128)"
 )
 
@@ -285,16 +285,15 @@ def _archs(gfx942: ArchSupport, gfx950: ArchSupport) -> Mapping[str, ArchSupport
 
 _OK_942 = ArchSupport(Support.SUPPORTED, evidence=_MEASURED_942)
 _OK_950 = ArchSupport(Support.SUPPORTED, evidence=_MEASURED_950)
-# Fused MoE has its own runs, so they name themselves: the README lists evidence
-# per architecture, and two bare gfx950 strings differing only by date are not
-# attributable to an op.
+# Fused MoE has its own runs, so the strings name the op: an evidence line that
+# differs from the suite runs only by board is not attributable to anything.
 _OK_942_MOE = ArchSupport(
     Support.SUPPORTED,
-    evidence="fused_moe: MI300X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-24",
+    evidence="fused_moe: MI300X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1",
 )
 _OK_950_MOE = ArchSupport(
     Support.SUPPORTED,
-    evidence="fused_moe: MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-24",
+    evidence="fused_moe: MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1",
 )
 # HIP rows: declared, not yet individually attributed. The suites above cover
 # them, but no per-op HIP measurement has been recorded, so the evidence field

--- a/flashinfer/prefill_rocm.py
+++ b/flashinfer/prefill_rocm.py
@@ -455,8 +455,8 @@ def _aiter_bootstrap_single_prefill_mha_fwd(
 
     Unlike mha_varlen_fwd, mha_fwd ships no prebuilt .so files in the aiter
     package; every (dtype, causal, has_lse) combination is JIT-built on first
-    use (~90s per variant). Bootstrapping here surfaces the build at plan time
-    rather than as a dlopen failure inside the C++ path.
+    use, which takes 20+ minutes per variant. Bootstrapping here surfaces the
+    build at plan time rather than as a dlopen failure inside the C++ path.
     """
     from aiter.ops.mha import mha_fwd
 

--- a/scripts/gen_arch_support_matrix.py
+++ b/scripts/gen_arch_support_matrix.py
@@ -85,8 +85,11 @@ LEGEND = (
 # by rewriting the generated block -- which fails --check on the very next run.
 _NOTE_BARE_URL = re.compile(r"(?<!\]\()\bhttps?://")
 _NOTE_INLINE_HTML = re.compile(r"<[A-Za-z][^>]*>")
+# MD033 and MD034 exempt code spans; MD056 does not, because GFM splits table
+# cells on `|` before it ever parses backticks.
+_CODE_SPAN = re.compile(r"`[^`]*`")
 _NOTE_RULES = (
-    ("|", "MD056: a literal pipe adds a table column. Reword, or use a comma"),
+    ("|", "MD056: a literal pipe adds a table column, even inside backticks. Reword"),
     ("\n", "the row must stay on one line"),
 )
 
@@ -170,13 +173,14 @@ def _note(where: str, text: str) -> str:
     for bad, why in _NOTE_RULES:
         if bad in text:
             raise SystemExit(f"{where}: {why}\n  note: {text!r}")
-    if _NOTE_BARE_URL.search(text):
+    prose = _CODE_SPAN.sub("", text)
+    if _NOTE_BARE_URL.search(prose):
         raise SystemExit(
             f"{where}: MD034 would rewrite a bare URL and break --check. "
-            f"Use [text](url), or move the detail to docs/rocm/backends.md\n"
-            f"  note: {text!r}"
+            f"Use [text](url) or backticks, or move the detail to "
+            f"docs/rocm/backends.md\n  note: {text!r}"
         )
-    if _NOTE_INLINE_HTML.search(text):
+    if _NOTE_INLINE_HTML.search(prose):
         raise SystemExit(
             f"{where}: MD033: wrap inline HTML in backticks\n  note: {text!r}"
         )

--- a/scripts/gen_arch_support_matrix.py
+++ b/scripts/gen_arch_support_matrix.py
@@ -67,11 +67,13 @@ UNSUPPORTED = "❌"
 LEGEND = (
     (
         VALIDATED,
-        "**validated** — a suite was run on that board, and the evidence is recorded below.",
+        "**validated** — this op was exercised on this architecture, and the board, ROCm, "
+        "AITER, and date are recorded in `flashinfer/arch_caps.py`.",
     ),
     (
         DECLARED,
-        "**declared** — supported, but no per-op measurement has been recorded on that architecture.",
+        "**supported** — the op runs here and the test suite covers it, but no run has been "
+        "recorded against this specific op and architecture.",
     ),
     (
         KNOWN_BAD,
@@ -225,19 +227,9 @@ def render(arch_caps) -> str:
             f"validated it yourself.{link}"
         )
 
-    # Evidence lines last: they are the provenance for every ✅ above, and are
-    # what makes "validated" a checkable claim rather than a badge.
-    evidence = sorted(
-        {
-            f"`{arch}` — {entry.evidence}"
-            for cap in arch_caps.CAPABILITIES
-            for arch, entry in cap.archs.items()
-            if entry.evidence
-        }
-    )
-    if evidence:
-        lines += ["", "Measured on:", ""]
-        lines += [f"{BULLET} {item}" for item in evidence]
+    # `evidence` is deliberately not rendered. It is the provenance behind a ✅
+    # and stays readable in arch_caps.py; a board-and-date list in the README
+    # dates the whole page the moment a run is not repeated.
 
     lines += ["", END]
     return "\n".join(lines)

--- a/scripts/gen_arch_support_matrix.py
+++ b/scripts/gen_arch_support_matrix.py
@@ -35,6 +35,7 @@ import argparse
 import difflib
 import importlib.util
 import pathlib
+import re
 import sys
 import types
 
@@ -62,6 +63,31 @@ VALIDATED = "✅"
 DECLARED = "◻️"
 KNOWN_BAD = "⚠️"
 UNSUPPORTED = "❌"
+
+LEGEND = (
+    (
+        VALIDATED,
+        "**validated** — a suite was run on that board, and the evidence is recorded below.",
+    ),
+    (
+        DECLARED,
+        "**declared** — supported, but no per-op measurement has been recorded on that architecture.",
+    ),
+    (
+        KNOWN_BAD,
+        "**broken on some toolchains** — usable, but not on every ROCm/AITER version; see the footnote.",
+    ),
+    (UNSUPPORTED, "**not available** on that architecture."),
+)
+
+# Note content that markdownlint would either reject with no autofix, or "fix"
+# by rewriting the generated block -- which fails --check on the very next run.
+_NOTE_BARE_URL = re.compile(r"(?<!\]\()\bhttps?://")
+_NOTE_INLINE_HTML = re.compile(r"<[A-Za-z][^>]*>")
+_NOTE_RULES = (
+    ("|", "MD056: a literal pipe adds a table column. Reword, or use a comma"),
+    ("\n", "the row must stay on one line"),
+)
 
 
 def _load_arch_caps():
@@ -134,6 +160,28 @@ def _cell(entry, footnote_ids: dict[int, int]) -> str:
     return VALIDATED if entry.evidence else DECLARED
 
 
+def _note(where: str, text: str) -> str:
+    """Reject a note markdownlint would reject or silently rewrite.
+
+    Escaping was tried first and lost: MD034 exempts code spans, MD033/MD056
+    have no autofix, and an autolinked URL swallows trailing punctuation.
+    """
+    for bad, why in _NOTE_RULES:
+        if bad in text:
+            raise SystemExit(f"{where}: {why}\n  note: {text!r}")
+    if _NOTE_BARE_URL.search(text):
+        raise SystemExit(
+            f"{where}: MD034 would rewrite a bare URL and break --check. "
+            f"Use [text](url), or move the detail to docs/rocm/backends.md\n"
+            f"  note: {text!r}"
+        )
+    if _NOTE_INLINE_HTML.search(text):
+        raise SystemExit(
+            f"{where}: MD033: wrap inline HTML in backticks\n  note: {text!r}"
+        )
+    return text.strip()
+
+
 def render(arch_caps) -> str:
     archs = _archs_in_order(arch_caps)
 
@@ -154,24 +202,19 @@ def render(arch_caps) -> str:
     lines = [
         BEGIN,
         "",
-        f"| Op | Backend | {' | '.join(ARCH_LABELS.get(a, a) for a in archs)} |",
-        f"| :--- | :--- | {' | '.join(':---:' for _ in archs)} |",
+        f"| Op | Backend | {' | '.join(ARCH_LABELS.get(a, a) for a in archs)} | Notes |",
+        f"| :--- | :--- | {' | '.join(':---:' for _ in archs)} | :--- |",
     ]
+    # Collected from the status cells, not the rendered row: a note mentioning
+    # a symbol must not resurrect a legend entry no row is actually in.
+    used = set()
     for cap in arch_caps.CAPABILITIES:
-        cells = " | ".join(_cell(cap.archs.get(a), footnote_ids) for a in archs)
-        lines.append(f"| `{cap.op}` | `{cap.backend}` | {cells} |")
+        cells = [_cell(cap.archs.get(a), footnote_ids) for a in archs]
+        used.update(s for s, _ in LEGEND for c in cells if c.startswith(s))
+        note = _note(f"{cap.op}/{cap.backend}", cap.note)
+        lines.append(f"| `{cap.op}` | `{cap.backend}` | {' | '.join(cells)} | {note} |")
 
-    lines += [
-        "",
-        f"{BULLET} {VALIDATED} **validated** — a suite was run on that board, and the "
-        "evidence is recorded below.",
-        f"{BULLET} {DECLARED} **declared** — supported, but no per-op measurement has "
-        "been recorded on that architecture.",
-        f"{BULLET} {KNOWN_BAD} **broken on some toolchains** — usable, but not on every "
-        "ROCm/AITER version; see the footnote.",
-        f"{BULLET} {UNSUPPORTED} **not available** on that architecture.",
-        "",
-    ]
+    lines += ["", *(f"{BULLET} {s} {t}" for s, t in LEGEND if s in used), ""]
 
     for number, bad, where, arch in footnotes:
         detail = bad.detail.rstrip(".")

--- a/scripts/gen_arch_support_matrix.py
+++ b/scripts/gen_arch_support_matrix.py
@@ -67,8 +67,7 @@ UNSUPPORTED = "❌"
 LEGEND = (
     (
         VALIDATED,
-        "**validated** — this op was exercised on this architecture, and the board, ROCm, "
-        "AITER, and date are recorded in `flashinfer/arch_caps.py`.",
+        "**validated** — this op has been exercised on this architecture.",
     ),
     (
         DECLARED,

--- a/tests/rocm_tests/test_arch_caps_hip.py
+++ b/tests/rocm_tests/test_arch_caps_hip.py
@@ -11,6 +11,7 @@ lets it run as a hardware-less CI job on every pull request
 (``.github/workflows/arch-caps-conformance.yml``).
 """
 
+import dataclasses
 import importlib.util
 import pathlib
 import subprocess
@@ -467,7 +468,7 @@ class TestVersionProbeIsCheap:
     with a timeout). A per-routing-decision query must not pay that repeatedly."""
 
     def test_rows_without_a_window_never_probe(self, as_arch, monkeypatch):
-        """23 of 24 rows have no ``known_bad``, so the probe is skipped outright
+        """24 of 25 rows have no ``known_bad``, so the probe is skipped outright
         rather than merely being fast the second time."""
         calls = []
 
@@ -513,3 +514,84 @@ class TestArchCapabilityError:
         """A missing aiter package is a different condition and keeps its own
         exception type."""
         assert not isinstance(arch_caps.ArchCapabilityError("x"), ImportError)
+
+
+# --------------------------------------------------------------------------
+# The README renderer. Loaded the same way and for the same reason: it also
+# refuses to import the flashinfer package, so it runs in the hardware-less job.
+# --------------------------------------------------------------------------
+
+_GEN_PATH = pathlib.Path(__file__).resolve().parents[2] / "scripts"
+_GEN_PATH = _GEN_PATH / "gen_arch_support_matrix.py"
+
+
+def _load_generator():
+    spec = importlib.util.spec_from_file_location("_arch_matrix_gen", _GEN_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gen = _load_generator()
+
+
+class TestNoteValidation:
+    """``Capability.note`` is rendered into a markdown table cell.
+
+    Escaping was tried and lost, so the generator rejects instead. Each case
+    below is a markdownlint failure reproduced against the repo config.
+    """
+
+    @pytest.mark.parametrize(
+        "note",
+        [
+            "fp16 | bf16",  # MD056, and it has no autofix
+            r"fp16 \| bf16",  # pre-escaped: escaping again re-breaks it
+            "one\ntwo",  # splits the row
+            "see https://example.com/a",  # MD034 autofix rewrites the block
+            "see https://example.com/a. Next",
+            "see (https://example.com/a) here",
+            "use `https://example.com/a` as index",
+            "returns Tensor<T> per head",  # MD033, no autofix
+        ],
+    )
+    def test_rejects_content_markdownlint_would_break_on(self, note):
+        with pytest.raises(SystemExit):
+            gen._note("op/backend", note)
+
+    @pytest.mark.parametrize(
+        "note",
+        [
+            "Slightly lower precision at hidden_size >= 1024.",
+            "`aiter_fused_moe`; bf16/fp16.",
+            "See [the backends doc](docs/rocm/backends.md).",
+            "Sustains 3.62 TB/s against AITER's 2.86 on gfx942.",
+        ],
+    )
+    def test_accepts_ordinary_prose(self, note):
+        assert gen._note("op/backend", note) == note
+
+    def test_every_row_carries_a_valid_note(self):
+        for cap in arch_caps.CAPABILITIES:
+            assert cap.note, f"{cap.op}/{cap.backend} has no note"
+            gen._note(f"{cap.op}/{cap.backend}", cap.note)
+
+
+class TestLegend:
+    """The legend explains the symbols the table uses, and only those."""
+
+    def test_a_symbol_named_only_in_a_note_gets_no_legend_entry(self):
+        rows = list(arch_caps.CAPABILITIES)
+        rows[-1] = dataclasses.replace(
+            rows[-1], note="not available on pre-CDNA3 (marked ❌)"
+        )
+        rendered = gen.render(types.SimpleNamespace(CAPABILITIES=tuple(rows)))
+        assert "**not available**" not in rendered
+
+    def test_a_symbol_used_in_a_status_cell_gets_one(self):
+        rows = list(arch_caps.CAPABILITIES)
+        archs = dict(rows[-1].archs)
+        archs["gfx942"] = arch_caps.ArchSupport(arch_caps.Support.UNSUPPORTED)
+        rows[-1] = dataclasses.replace(rows[-1], archs=archs)
+        rendered = gen.render(types.SimpleNamespace(CAPABILITIES=tuple(rows)))
+        assert "**not available**" in rendered

--- a/tests/rocm_tests/test_arch_caps_hip.py
+++ b/tests/rocm_tests/test_arch_caps_hip.py
@@ -526,7 +526,19 @@ _GEN_PATH = _GEN_PATH / "gen_arch_support_matrix.py"
 
 
 def _load_generator():
+    # The generator's own _load_arch_caps() guards the same two cases, but
+    # raises SystemExit -- right inside a pre-commit hook, wrong here, where it
+    # turns a collection error into a pytest INTERNALERROR with no test summary.
+    #
+    # A missing file already fails readably (FileNotFoundError names the path);
+    # this guard only improves the wording. A path importlib has no source
+    # loader for is the one that needs catching: spec is None, and
+    # module_from_spec(None) raises AttributeError from inside importlib.
+    if not _GEN_PATH.is_file():
+        raise RuntimeError(f"cannot read the matrix generator at {_GEN_PATH}")
     spec = importlib.util.spec_from_file_location("_arch_matrix_gen", _GEN_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"no Python source loader for {_GEN_PATH}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
@@ -591,32 +603,29 @@ class TestNoteValidation:
 class TestLegend:
     """The legend explains the symbols the table uses, and only those.
 
-    Both cases edit one named row rather than a positional one: keyed by
-    ``(op, backend)`` these stay meaningful however the table is reordered or
-    extended, and an appended row that is genuinely ❌ cannot make the first
-    case pass or fail for the wrong reason.
+    Each case renders a **one-row** table. ``used`` is accumulated across every
+    row, so rendering the full table would let an unrelated row answer for the
+    row under test -- and a future CDNA4-only row would do exactly that, since
+    a missing arch entry renders as ❌.
     """
 
     ROW = ("quantization", "hip")
 
-    def _render_with(self, **changes):
-        rows = [
-            dataclasses.replace(cap, **changes)
-            if (cap.op, cap.backend) == self.ROW
-            else cap
-            for cap in arch_caps.CAPABILITIES
-        ]
-        assert any((c.op, c.backend) == self.ROW for c in rows), (
-            f"{self.ROW} is no longer in CAPABILITIES; pick another row"
-        )
-        return gen.render(types.SimpleNamespace(CAPABILITIES=tuple(rows)))
+    def _row(self):
+        for cap in arch_caps.CAPABILITIES:
+            if (cap.op, cap.backend) == self.ROW:
+                return cap
+        raise AssertionError(f"{self.ROW} left CAPABILITIES; pick another row")
+
+    def _render_only(self, **changes):
+        cap = dataclasses.replace(self._row(), **changes)
+        return gen.render(types.SimpleNamespace(CAPABILITIES=(cap,)))
 
     def test_a_symbol_named_only_in_a_note_gets_no_legend_entry(self):
-        rendered = self._render_with(note="not available on pre-CDNA3 (marked ❌)")
+        rendered = self._render_only(note="not available on pre-CDNA3 (marked ❌)")
         assert "**not available**" not in rendered
 
     def test_a_symbol_used_in_a_status_cell_gets_one(self):
-        cap = arch_caps._BY_KEY[self.ROW]
-        archs = dict(cap.archs)
+        archs = dict(self._row().archs)
         archs["gfx942"] = arch_caps.ArchSupport(arch_caps.Support.UNSUPPORTED)
-        assert "**not available**" in self._render_with(archs=archs)
+        assert "**not available**" in self._render_only(archs=archs)

--- a/tests/rocm_tests/test_arch_caps_hip.py
+++ b/tests/rocm_tests/test_arch_caps_hip.py
@@ -589,20 +589,34 @@ class TestNoteValidation:
 
 
 class TestLegend:
-    """The legend explains the symbols the table uses, and only those."""
+    """The legend explains the symbols the table uses, and only those.
+
+    Both cases edit one named row rather than a positional one: keyed by
+    ``(op, backend)`` these stay meaningful however the table is reordered or
+    extended, and an appended row that is genuinely ❌ cannot make the first
+    case pass or fail for the wrong reason.
+    """
+
+    ROW = ("quantization", "hip")
+
+    def _render_with(self, **changes):
+        rows = [
+            dataclasses.replace(cap, **changes)
+            if (cap.op, cap.backend) == self.ROW
+            else cap
+            for cap in arch_caps.CAPABILITIES
+        ]
+        assert any((c.op, c.backend) == self.ROW for c in rows), (
+            f"{self.ROW} is no longer in CAPABILITIES; pick another row"
+        )
+        return gen.render(types.SimpleNamespace(CAPABILITIES=tuple(rows)))
 
     def test_a_symbol_named_only_in_a_note_gets_no_legend_entry(self):
-        rows = list(arch_caps.CAPABILITIES)
-        rows[-1] = dataclasses.replace(
-            rows[-1], note="not available on pre-CDNA3 (marked ❌)"
-        )
-        rendered = gen.render(types.SimpleNamespace(CAPABILITIES=tuple(rows)))
+        rendered = self._render_with(note="not available on pre-CDNA3 (marked ❌)")
         assert "**not available**" not in rendered
 
     def test_a_symbol_used_in_a_status_cell_gets_one(self):
-        rows = list(arch_caps.CAPABILITIES)
-        archs = dict(rows[-1].archs)
+        cap = arch_caps._BY_KEY[self.ROW]
+        archs = dict(cap.archs)
         archs["gfx942"] = arch_caps.ArchSupport(arch_caps.Support.UNSUPPORTED)
-        rows[-1] = dataclasses.replace(rows[-1], archs=archs)
-        rendered = gen.render(types.SimpleNamespace(CAPABILITIES=tuple(rows)))
-        assert "**not available**" in rendered
+        assert "**not available**" in self._render_with(archs=archs)

--- a/tests/rocm_tests/test_arch_caps_hip.py
+++ b/tests/rocm_tests/test_arch_caps_hip.py
@@ -551,13 +551,24 @@ class TestNoteValidation:
             "see https://example.com/a",  # MD034 autofix rewrites the block
             "see https://example.com/a. Next",
             "see (https://example.com/a) here",
-            "use `https://example.com/a` as index",
             "returns Tensor<T> per head",  # MD033, no autofix
         ],
     )
     def test_rejects_content_markdownlint_would_break_on(self, note):
         with pytest.raises(SystemExit):
             gen._note("op/backend", note)
+
+    @pytest.mark.parametrize(
+        "note",
+        [
+            "use `https://example.com/a` as index",
+            "returns `Tensor<T>` per head",
+        ],
+    )
+    def test_allows_inside_a_code_span(self, note):
+        """MD033 and MD034 exempt code spans, so rejecting these would be
+        over-strict -- and would make the error messages' own advice false."""
+        assert gen._note("op/backend", note) == note
 
     @pytest.mark.parametrize(
         "note",


### PR DESCRIPTION
## Summary

The README had grown to 585 lines and drifted from the code. This condenses it to 268, reorders it for someone *using* `amd-flashinfer` rather than building it, and corrects the claims that no longer hold. The two overlapping support tables become one generated table; the backend detail moves to a new `docs/rocm/backends.md` and the build/test material to `CONTRIBUTING.md`.

Read commit by commit — the generator change, the two new pages, the README rewrite, and the link repairs are independent.

### What changed

#### Support matrix: two tables become one

`Capability.note` has existed unused since the capability table landed (#285). Populating it and rendering it as a Notes column lets the generated matrix carry what the hand-written feature table carried by hand, so that table is deleted. Conditional routing deliberately does *not* go into a table cell — that is what made the old one unreadable. A four-row table names the four `auto` policies and links out for the rest.

- **`scripts/gen_arch_support_matrix.py`** — Notes column; note validation; legend derived from status cells.
- **`flashinfer/arch_caps.py`** — `note=` on all 25 rows.
- **`tests/rocm_tests/test_arch_caps_hip.py`** — 15 tests for the above; runs in the existing no-GPU conformance job.

#### New pages

- **`docs/rocm/backends.md`** — AITER install and pin rationale, the full `auto` routing rules, known limitations, per-op constraints, and the HIP-side facts a generated `(op, backend)` table cannot express. `docs/` is untouched upstream Sphinx and `build-doc.yml` only triggers on `main`, so `docs/rocm/` is additive and cannot break the docs job.
- **`CONTRIBUTING.md`** — dev container, wheel and editable builds, a corrected AOT section, and the pytest-invocation notes.

#### README

Adds what recent work left undocumented: fused MoE (#295) had a row in the generated matrix but no mention anywhere in prose; the testlist benchmark runner (#297) had none at all; four environment variables the package really reads were missing from the table.

### Architecture / design notes

**Notes are validated, not escaped.** Escaping was implemented first and lost. markdownlint's MD034 exempts code spans, so a backticked URL got wrapped and its closing backtick swallowed; a greedy `\S+` pulled trailing punctuation into the href; a note already containing `\|` was double-escaped into an MD056 hard-fail; and `(https://x)` slipped past the lookbehind, leaving markdownlint's autofix to rewrite the generated block and fail `--check` on the next run — the exact loop the escaping existed to prevent.

Rejecting at generation time with a message naming the row is strictly better here: notes are hand-written by repo authors, there are 25 of them, and the alternative silently corrupts a link. MD033 and embedded newlines are rejected for the same reason — neither has an autofix.

### Corrections found while verifying, not carried over

| Claim | Reality |
| :--- | :--- |
| `fused_add_rmsnorm` shares `rmsnorm`'s 2-D fp16/bf16 `auto` gate | `_auto_select_fused_add_rmsnorm_backend` (`norm.py:61`) takes only `input` — no ndim, dtype, or weight check. An fp32 weight reaches CK, which reads the bytes as fp16 and writes garbage in place, no error. Now documented as its own hazard. |
| ALiBi is silently ignored on AITER | `maybe_alibi_slopes` is filled internally from the head count; the user-facing route is `pos_encoding_mode="ALIBI"`, which raises. |
| `enable_pdl` / prefix-cache helpers are AITER-only, remedy is `backend="fa2"` | Dropped on the fa2 path too (`prefill_rocm.py:827`), and both warn. The remedy was wrong. |
| MLA is bf16-only, `page_size=1` only | fp16 is accepted (`mla_rocm.py:264`); `page_size` is not enforced anywhere, only untested above 1. `causal=False` now raises for `max_seqlen_q > 1`. |
| `setup.py` validates the arch list | No `setup.py` since #291 replaced scikit-build-core. |
| AOT is a wheel-build flag | Standalone entry point (`python -m flashinfer.aot_hip`), verified by running it. |
| Every supported row has a matching test | `quantization` and `single_decode` have no test file of their own. |
| CLAUDE.md: install torch with `--index-url`, `-f` risks a CPU-only wheel | The opposite. `repo.radeon.com/rocm/manylinux/rocm-rel-7.2/` returns 200 as a flat listing and `.../torch/` 404s, so it is not a PEP 503 index. #269 fixed the README and missed CLAUDE.md; they have contradicted each other since. |

`gqa_ratio in {16, 128}` was deliberately **not** written as an MLA constraint — `mla_rocm.py` has no head-count validation. That is measurement evidence in `arch_caps.py`, and writing it as a limit would manufacture exactly the drift this PR removes.

The tutorial notebook's links pointed at `ROCm/flashinfer` `blob/main`. `main` is a real branch, so they resolved — to a README with no `##` headings, meaning the `#aiter-support` fragment has never worked. Retargeted, and the surrounding prose repaired rather than just the link: the cell still said "in the README" for a page no longer there, and quoted CK page sizes as "1, 16, 1024", which matches neither the code nor either document.

Checked rather than assumed: the Docker tag is still the newest published on Docker Hub (no `amd.2` image exists), a `rocm7.0.2` tag exists so that support claim holds, and the devcontainer build args match. Links into `docs/`, `examples/`, and `benchmarks/` use absolute URLs — `MANIFEST.in` prunes those trees and `pyproject.toml` sets `readme = "README.md"`, so a relative link there is dead on PyPI.

## Test plan

- [x] `python3 scripts/gen_arch_support_matrix.py --check` clean on the unmodified tree first, then round-trips after — and at every commit in the series, so the history bisects.
- [x] Deliberate `|` + bare-URL note injected, regenerated, then `pre-commit run -a` **twice** with no diff on either pass — proving the lint loop converges rather than just asserting the guard exists.
- [x] `pytest tests/rocm_tests/test_arch_caps_hip.py -n auto --reruns 2 -m "not slow"` — 79 passed on gfx950 (was 64).
- [x] All 8 rejection cases fail against the escaping implementation, so the new tests are A/B-valid rather than vacuous.
- [x] `import flashinfer` smoke — `arch_caps` is imported at module scope by `hip_utils`, so a typo in a `note=` string is an import failure, not a docs bug.
- [x] Every link resolves in both directions, including inbound `README.md#anchor` references from `CLAUDE.md` and the notebook.
- [x] `README.md`, `docs/rocm/backends.md`, `CONTRIBUTING.md` rendered through `gh api /markdown -f mode=gfm` — tables, `[^kb1]` footnote, and emoji legend all survive.
- [x] Every paragraph of the old README inventoried and mapped to a destination; 34/34 substantive claims and 166 code-span tokens accounted for.
- [x] `pre-commit run -a`

**Not verified: gfx942.** This diff has no arch-dependent behaviour — `arch_caps.py` is a static table read without a GPU, so the generated output is byte-identical on both architectures, and the per-arch claims come from that table, which the conformance suite already covers.
