### PR TITLE
feat(rocm): fp8 per-token expert weights for the AITER fused MoE

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ decisions the library makes. Do not edit it by hand; run
 | `fused_add_rmsnorm` | `aiter` | ✅ | ✅ | CK `rmsnorm2d_with_add`; 2-D only. `auto` does NOT check weight dtype — a mismatch silently yields garbage. |
 | `silu_and_mul` | `aiter` | ✅ | ✅ | `aiter::silu_and_mul`, linked at the C++ level. Opt-in; matches native in fp16, lower in bf16. |
 | `fused_moe` | `aiter` | ✅ | ✅ | `aiter_fused_moe`; bf16/fp16. Weights must be pre-shuffled with `shuffle_moe_weight` or results are silently wrong. |
+| `fused_moe_fp8` | `aiter` | ✅ | ✅ | `aiter_fused_moe` with fp8 weights in `moe_fp8_dtype()` plus both scales; activations are quantized per token in the shim. |
 | `single_decode` | `hip` | ◻️ | ◻️ | MHA / GQA / MQA. |
 | `batch_decode` | `hip` | ◻️ | ◻️ | MHA / GQA / MQA; fp8 KV-cache (E4M3FNUZ) and CUDA-graph capture. |
 | `single_prefill` | `hip` | ◻️ | ◻️ | MHA / GQA / MQA, including custom attention masks. |

--- a/benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py
+++ b/benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py
@@ -30,9 +30,14 @@ worth a dependency; it is skipped with a message if aiter is not importable.
 the table behind `_select_block_m`'s thresholds -- so they stay checkable rather
 than folklore.
 
+`--fp8` swaps the expert weights for per-token-quantized fp8. The activations are
+quantized inside the shim, so that cost is in the measurement; the number to read
+is the speedup over the same shape in bf16, which is what justifies the path.
+
 Run:
     python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py                  # full pipeline
     python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py --timing-only    # no profiling
+    python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py --fp8            # fp8 weights
     python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py --block-m-sweep  # tile-size table
     python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py --replot         # regenerate plot
     python benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py --counters       # PMC passes
@@ -46,7 +51,12 @@ from pathlib import Path
 import torch
 
 import flashinfer
-from flashinfer.fused_moe_rocm import _SUPPORTED_BLOCK_M, shuffle_moe_weight
+from flashinfer.fused_moe_rocm import (
+    _SUPPORTED_BLOCK_M,
+    moe_fp8_dtype,
+    quantize_moe_weight,
+    shuffle_moe_weight,
+)
 from flashinfer.jit.core import logger as _jit_logger
 
 _jit_logger.setLevel(logging.WARNING)
@@ -88,14 +98,19 @@ def _aiter_baseline():
 
 
 @torch.inference_mode()
-def _make_configs(block_m_sweep: bool = False) -> list[KernelConfig]:
-    itemsize = torch.tensor([], dtype=_DTYPE).element_size()
+def _make_configs(block_m_sweep: bool = False, fp8: bool = False) -> list[KernelConfig]:
+    itemsize = (moe_fp8_dtype() if fp8 else _DTYPE).itemsize
     configs = []
     for label, E, K, I, topk in _SHAPES:
-        w1 = shuffle_moe_weight(
-            torch.randn(E, 2 * I, K, device="cuda", dtype=_DTYPE) / 16
-        )
-        w2 = shuffle_moe_weight(torch.randn(E, K, I, device="cuda", dtype=_DTYPE) / 16)
+        w1 = torch.randn(E, 2 * I, K, device="cuda", dtype=_DTYPE) / 16
+        w2 = torch.randn(E, K, I, device="cuda", dtype=_DTYPE) / 16
+        scales = {}
+        if fp8:
+            w1, w1_scale = quantize_moe_weight(w1)
+            w2, w2_scale = quantize_moe_weight(w2)
+            scales = {"w1_scale": w1_scale, "w2_scale": w2_scale}
+        w1 = shuffle_moe_weight(w1)
+        w2 = shuffle_moe_weight(w2)
         for nt in _NUM_TOKENS:
             x = torch.randn(nt, K, device="cuda", dtype=_DTYPE) / 8
             logits = torch.randn(nt, E, device="cuda", dtype=torch.float32)
@@ -106,11 +121,12 @@ def _make_configs(block_m_sweep: bool = False) -> list[KernelConfig]:
             # Two GEMMs per (token, expert): [1,K]x[K,2I] and [1,I]x[I,K].
             theo_flops = 2 * nt * topk * (K * 2 * I + I * K)
             # Weights dominate until every expert is hit by many tokens; count the
-            # experts actually touched rather than all E.
+            # experts actually touched rather than all E. Only the weight term is
+            # fp8 -- activations reach the kernel in bf16 either way.
             experts_hit = min(E, nt * topk)
             theo_bytes = (
                 experts_hit * (2 * I * K + K * I) * itemsize
-                + nt * (K + topk * I + K) * itemsize
+                + nt * (K + topk * I + K) * _DTYPE.itemsize
             )
 
             def add(name, fn, suffix=""):
@@ -132,9 +148,16 @@ def _make_configs(block_m_sweep: bool = False) -> list[KernelConfig]:
                 for bm in _SUPPORTED_BLOCK_M:
                     add(
                         f"moe_{label}_nt{nt}_bm{bm}",
-                        lambda x=x, w1=w1, w2=w2, ids=ids, w=weights, o=out, bm=bm: (
+                        lambda x=x,
+                        w1=w1,
+                        w2=w2,
+                        ids=ids,
+                        w=weights,
+                        o=out,
+                        bm=bm,
+                        s=scales: (
                             flashinfer.aiter_fused_moe(
-                                x, w1, w2, ids, w, out=o, block_m=bm
+                                x, w1, w2, ids, w, out=o, block_m=bm, **s
                             )
                         ),
                         suffix=f" bm={bm}",
@@ -147,35 +170,49 @@ def _make_configs(block_m_sweep: bool = False) -> list[KernelConfig]:
             # exists to produce.
             add(
                 f"moe_{label}_nt{nt}",
-                lambda x=x, w1=w1, w2=w2, ids=ids, w=weights: (
-                    flashinfer.aiter_fused_moe(x, w1, w2, ids, w)
+                lambda x=x, w1=w1, w2=w2, ids=ids, w=weights, s=scales: (
+                    flashinfer.aiter_fused_moe(x, w1, w2, ids, w, **s)
                 ),
             )
             baseline = _aiter_baseline()
             if baseline is not None:
                 add(
                     f"moe_{label}_nt{nt}_aiter",
-                    lambda x=x, w1=w1, w2=w2, ids=ids, w=weights, f=baseline: (
-                        f(x, w1, w2, w, ids)
-                    ),
+                    lambda x=x,
+                    w1=w1,
+                    w2=w2,
+                    ids=ids,
+                    w=weights,
+                    f=baseline,
+                    s=scales: (f(x, w1, w2, w, ids, **_aiter_quant_kwargs(s))),
                     suffix=" [aiter baseline]",
                 )
     return configs
 
 
+def _aiter_quant_kwargs(scales):
+    """Translate our scale kwargs into aiter.fused_moe's own spelling."""
+    if not scales:
+        return {}
+    from aiter.ops.enum import QuantType
+
+    return {"quant_type": QuantType.per_Token, **scales}
+
+
 if __name__ == "__main__":
     _skip_gpu = "--replot" in sys.argv or "--list-presets" in sys.argv
+    _sweep = "--block-m-sweep" in sys.argv
+    _fp8 = "--fp8" in sys.argv
+    _label = "fused_moe_aiter_block_m" if _sweep else "fused_moe_aiter"
     profiler = RocmProfiler(
-        configs=[] if _skip_gpu else _make_configs("--block-m-sweep" in sys.argv),
+        configs=[] if _skip_gpu else _make_configs(_sweep, _fp8),
         num_warmup=3,
         dry_run_ms=100,
         repeat_ms=1000,
         counters="roofline",
-        kernel_name_regex="moe|gemm",
+        kernel_name_regex="moe|gemm|quant",
         output_dir=_OUTPUT_DIR,
-        label="fused_moe_aiter_block_m"
-        if "--block-m-sweep" in sys.argv
-        else "fused_moe_aiter",
+        label=f"{_label}_fp8" if _fp8 else _label,
         roofline=True,
     )
     profiler.run()

--- a/benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py
+++ b/benchmarks/rocm_benchmarks/bench_fused_moe_aiter.py
@@ -121,13 +121,15 @@ def _make_configs(block_m_sweep: bool = False, fp8: bool = False) -> list[Kernel
             # Two GEMMs per (token, expert): [1,K]x[K,2I] and [1,I]x[I,K].
             theo_flops = 2 * nt * topk * (K * 2 * I + I * K)
             # Weights dominate until every expert is hit by many tokens; count the
-            # experts actually touched rather than all E. Only the weight term is
-            # fp8 -- activations reach the kernel in bf16 either way.
+            # experts actually touched rather than all E.
             experts_hit = min(E, nt * topk)
-            theo_bytes = (
-                experts_hit * (2 * I * K + K * I) * itemsize
-                + nt * (K + topk * I + K) * _DTYPE.itemsize
-            )
+            # Activations cross the API boundary in bf16 either way. fp8 adds the
+            # shim's two quantization passes, each reading bf16 and writing fp8
+            # over the same elements -- timed, so counted.
+            act_bytes = nt * (K + topk * I + K) * _DTYPE.itemsize
+            if fp8:
+                act_bytes += nt * (K + topk * I) * (_DTYPE.itemsize + itemsize)
+            theo_bytes = experts_hit * (2 * I * K + K * I) * itemsize + act_bytes
 
             def add(name, fn, suffix=""):
                 configs.append(

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -194,6 +194,7 @@ elif IS_HIP:
     )
     from .fused_moe_rocm import aiter_fused_moe as aiter_fused_moe
     from .fused_moe_rocm import moe_fp8_dtype as moe_fp8_dtype
+    from .fused_moe_rocm import quantize_moe_weight as quantize_moe_weight
     from .fused_moe_rocm import shuffle_moe_weight as shuffle_moe_weight
     from .get_include_paths import get_csrc_dir, get_include
     from .norm import fused_add_rmsnorm as fused_add_rmsnorm

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -193,6 +193,7 @@ elif IS_HIP:
         single_decode_with_kv_cache as single_decode_with_kv_cache,
     )
     from .fused_moe_rocm import aiter_fused_moe as aiter_fused_moe
+    from .fused_moe_rocm import moe_fp8_dtype as moe_fp8_dtype
     from .fused_moe_rocm import shuffle_moe_weight as shuffle_moe_weight
     from .get_include_paths import get_csrc_dir, get_include
     from .norm import fused_add_rmsnorm as fused_add_rmsnorm

--- a/flashinfer/arch_caps.py
+++ b/flashinfer/arch_caps.py
@@ -295,6 +295,18 @@ _OK_950_MOE = ArchSupport(
     Support.SUPPORTED,
     evidence="fused_moe: MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1",
 )
+_OK_942_FP8_MOE = ArchSupport(
+    Support.SUPPORTED,
+    evidence=(
+        "fused_moe fp8: MI300X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-25"
+    ),
+)
+_OK_950_FP8_MOE = ArchSupport(
+    Support.SUPPORTED,
+    evidence=(
+        "fused_moe fp8: MI350X / rocm 7.2.0 / aiter 0.1.10 / torch 2.9.1 / 2026-08-25"
+    ),
+)
 # HIP rows: declared, not yet individually attributed. The suites above cover
 # them, but no per-op HIP measurement has been recorded, so the evidence field
 # stays empty rather than borrowing the AITER runs' credibility.
@@ -380,6 +392,12 @@ CAPABILITIES: Tuple[Capability, ...] = (
         "aiter",
         _archs(_OK_942_MOE, _OK_950_MOE),
         note="`aiter_fused_moe`; bf16/fp16. Weights must be pre-shuffled with `shuffle_moe_weight` or results are silently wrong.",
+    ),
+    Capability(
+        "fused_moe_fp8",
+        "aiter",
+        _archs(_OK_942_FP8_MOE, _OK_950_FP8_MOE),
+        note="`aiter_fused_moe` with fp8 weights in `moe_fp8_dtype()` plus both scales; activations are quantized per token in the shim.",
     ),
     # --- HIP backends: declared; per-op evidence not yet recorded ----------
     Capability(

--- a/flashinfer/csrc_rocm/fused_moe_aiter.cu
+++ b/flashinfer/csrc_rocm/fused_moe_aiter.cu
@@ -9,6 +9,11 @@
 // moe_sorting -> stage1 (gate/up + activation) -> stage2 (down + weighted sum).
 // The routing weights are applied in stage2, matching the `-m 2` (mulWeightStage2)
 // instances the JIT spec generates.
+//
+// With fp8 expert weights the shim also quantizes the activations per token,
+// before each GEMM, since CK's per_Token instances take fp8 on both operands.
+// Stage 1 still writes bf16/fp16 (gemm_moe_ck2stages.cu TORCH_CHECKs it), so the
+// intermediate is quantized again between the stages.
 
 #include <ATen/ATen.h>
 #include <ATen/hip/impl/HIPGuardImplMasqueradingAsCUDA.h>
@@ -16,11 +21,13 @@
 
 #include <optional>
 #include <string>
+#include <tuple>
+#include <utility>
 
 // AITER's public headers (moe_sorting.h, moe_ck.h) pull in <torch/extension.h> →
 // full pybind11, which clashes with FlashInfer's -DPy_LIMITED_API. torch::Tensor
 // is at::Tensor, so forward-declare the entry points; the linker resolves them
-// against the symbol-visible AITER .so. Both are at global namespace.
+// against the symbol-visible AITER .so. These three are at global namespace.
 void moe_sorting_fwd(at::Tensor& topk_ids, at::Tensor& topk_weights, at::Tensor& sorted_token_ids,
                      at::Tensor& sorted_weights, at::Tensor& sorted_expert_ids,
                      at::Tensor& num_valid_ids, at::Tensor& moe_buf, int num_experts, int unit_size,
@@ -43,13 +50,54 @@ void ck_moe_stage2(at::Tensor& inter_states, at::Tensor& w1, at::Tensor& w2,
                    int quant_type, int activation, std::optional<int> splitk, bool nt,
                    std::optional<std::string> dst_type);
 
+#ifdef FLASHINFER_MOE_AITER_PER_TOKEN
+// Unlike the three above, this one AITER declares inside `namespace aiter`.
+namespace aiter {
+void dynamic_per_token_scaled_quant(at::Tensor& out, at::Tensor const& input, at::Tensor& scales,
+                                    std::optional<at::Tensor> scale_ub, bool shuffle_scale,
+                                    std::optional<at::Tensor> num_rows, int num_rows_factor);
+}  // namespace aiter
+#endif
+
 namespace {
 
 // aiter_enum.h: ActivationType { No = -1, Silu = 0, Gelu = 1, Swiglu = 2 }.
 constexpr int kActivationSilu = 0;
 constexpr int kActivationGelu = 1;
-// aiter_enum.h: QuantType { No = 0, ... }.
+// aiter_enum.h: QuantType { No = 0, per_Tensor = 1, per_Token = 2, ... }.
 constexpr int kQuantNone = 0;
+constexpr int kQuantPerToken = 2;
+
+bool is_fp8(at::ScalarType t) { return t == at::kFloat8_e4m3fn || t == at::kFloat8_e4m3fnuz; }
+
+#ifdef FLASHINFER_MOE_AITER_PER_TOKEN
+// Quantize `x` row-wise into `fp8`, returning the values and their [.., 1] fp32
+// scales -- the shape AITER's own fused_moe hands to CK.
+std::pair<at::Tensor, at::Tensor> quantize_per_token(const at::Tensor& x, at::ScalarType fp8,
+                                                     int64_t num_rows_factor) {
+  auto scale_sizes = x.sizes().vec();
+  scale_sizes.back() = 1;
+  at::Tensor q = at::empty(x.sizes(), x.options().dtype(fp8));
+  at::Tensor scale = at::empty(scale_sizes, x.options().dtype(at::kFloat));
+  aiter::dynamic_per_token_scaled_quant(q, x, scale, /*scale_ub=*/std::nullopt,
+                                        /*shuffle_scale=*/false, /*num_rows=*/std::nullopt,
+                                        static_cast<int>(num_rows_factor));
+  return {q, scale};
+}
+#endif
+
+void check_weight_scale(const at::Tensor& scale, const char* name, int64_t num_experts,
+                        int64_t rows, const at::Device& device) {
+  TORCH_CHECK(scale.scalar_type() == at::kFloat, "fused_moe_aiter: ", name,
+              " must be float32, got ", scale.scalar_type());
+  TORCH_CHECK(scale.dim() == 3 && scale.size(0) == num_experts && scale.size(1) == rows &&
+                  scale.size(2) == 1,
+              "fused_moe_aiter: ", name, " must be [", num_experts, ", ", rows, ", 1], got ",
+              scale.sizes());
+  TORCH_CHECK(scale.is_contiguous(), "fused_moe_aiter: ", name, " must be contiguous");
+  TORCH_CHECK(scale.device() == device, "fused_moe_aiter: ", name, " must be on ", device, ", got ",
+              scale.device());
+}
 
 // The CK heuristic dispatch (ck2stages_moe_stage{1,2}_heuristic_dispatch.hpp)
 // enumerates exactly these and TORCH_CHECKs otherwise; reject here so the error
@@ -74,13 +122,16 @@ bool overlaps(const at::Tensor& a, const at::Tensor& b) {
 // topk_ids:      [m, topk]  int32, every value in [0, num_experts)
 // topk_weights:  [m, topk]  float32
 // out:           [m, model_dim]
+// w1_scale:      [num_experts, 2 * inter_dim, 1] float32, fp8 weights only
+// w2_scale:      [num_experts, model_dim, 1]     float32, fp8 weights only
 //
 // Caller precondition: topk_ids values are in range. Checking on device would
 // cost a synchronize per call, so out-of-range ids (a -1 drop marker, or global
 // ids against a local expert-parallel shard) index w1/w2 out of bounds instead.
 void fused_moe_aiter(at::Tensor out, at::Tensor hidden_states, at::Tensor w1, at::Tensor w2,
                      at::Tensor topk_ids, at::Tensor topk_weights, int64_t block_m,
-                     int64_t activation) {
+                     int64_t activation, std::optional<at::Tensor> w1_scale,
+                     std::optional<at::Tensor> w2_scale) {
   const c10::hip::OptionalHIPGuardMasqueradingAsCUDA device_guard(hidden_states.device());
 
   TORCH_CHECK(activation == kActivationSilu || activation == kActivationGelu,
@@ -91,11 +142,28 @@ void fused_moe_aiter(at::Tensor out, at::Tensor hidden_states, at::Tensor w1, at
   const auto dtype = hidden_states.scalar_type();
   TORCH_CHECK(dtype == at::kBFloat16 || dtype == at::kHalf,
               "fused_moe_aiter: hidden_states must be bfloat16 or float16, got ", dtype);
-  TORCH_CHECK(w1.scalar_type() == dtype && w2.scalar_type() == dtype,
-              "fused_moe_aiter: w1/w2 dtype must match hidden_states (", dtype, "), got ",
-              w1.scalar_type(), " and ", w2.scalar_type());
+  const bool quantized = is_fp8(w1.scalar_type());
+  TORCH_CHECK(w1.scalar_type() == w2.scalar_type(),
+              "fused_moe_aiter: w1 and w2 must have the same dtype, got ", w1.scalar_type(),
+              " and ", w2.scalar_type());
+  TORCH_CHECK(quantized || w1.scalar_type() == dtype,
+              "fused_moe_aiter: w1/w2 must be fp8 or match hidden_states (", dtype, "), got ",
+              w1.scalar_type());
   TORCH_CHECK(out.scalar_type() == dtype, "fused_moe_aiter: out dtype must match hidden_states (",
               dtype, "), got ", out.scalar_type());
+#ifndef FLASHINFER_MOE_AITER_PER_TOKEN
+  // Unreachable from Python, which picks the module from the weight dtype. Here
+  // so the quantized path below needs no #else arm.
+  TORCH_CHECK(!quantized, "fused_moe_aiter: this module was built without fp8 support");
+#endif
+
+  // CK gates *all* scaling on the scale pointers being non-null together, so a
+  // half-supplied pair silently runs an unscaled GEMM rather than failing.
+  TORCH_CHECK(w1_scale.has_value() == quantized && w2_scale.has_value() == quantized,
+              "fused_moe_aiter: w1_scale and w2_scale must both be given for fp8 weights "
+              "and both omitted otherwise; got w1_scale=",
+              w1_scale.has_value(), " w2_scale=", w2_scale.has_value(), " for weight dtype ",
+              w1.scalar_type());
 
   TORCH_CHECK(hidden_states.dim() == 2, "fused_moe_aiter: hidden_states must be 2-D, got ",
               hidden_states.dim(), "-D");
@@ -159,6 +227,22 @@ void fused_moe_aiter(at::Tensor out, at::Tensor hidden_states, at::Tensor w1, at
   TORCH_CHECK(!overlaps(out, w1) && !overlaps(out, w2),
               "fused_moe_aiter: out must not overlap w1 or w2");
 
+  if (quantized) {
+    check_weight_scale(*w1_scale, "w1_scale", num_experts, 2 * inter_dim, device);
+    check_weight_scale(*w2_scale, "w2_scale", num_experts, model_dim, device);
+    // Same reason as the weights: both are read after out has been zero-filled.
+    TORCH_CHECK(!overlaps(out, *w1_scale) && !overlaps(out, *w2_scale),
+                "fused_moe_aiter: out must not overlap w1_scale or w2_scale");
+  }
+
+  // An expert-parallel rank can legitimately be routed no tokens. AITER's
+  // kernels launch a zero-sized grid for that and leave a sticky HIP error that
+  // surfaces on some later, unrelated op.
+  if (num_tokens == 0) {
+    out.zero_();
+    return;
+  }
+
   // Sorting buffer sizes, mirroring aiter/fused_moe.py::moe_sorting. Note
   // num_valid_ids is 2 int32 even though moe_sorting.h comments it as [1].
   const int64_t max_num_tokens_padded = topk_ids.numel() + num_experts * block_m - topk;
@@ -188,15 +272,37 @@ void fused_moe_aiter(at::Tensor out, at::Tensor hidden_states, at::Tensor w1, at
   const int topk_i32 = static_cast<int>(topk);
   const int block_m_i32 = static_cast<int>(block_m);
   const int activation_i32 = static_cast<int>(activation);
+  const int quant_type = quantized ? kQuantPerToken : kQuantNone;
 
-  ck_moe_stage1(hidden_states, w1, w2, sorted_token_ids, sorted_expert_ids, num_valid_ids,
-                inter_states, topk_i32, kernel_name, /*w1_scale=*/std::nullopt,
-                /*a1_scale=*/std::nullopt, block_m_i32, /*sorted_weights=*/std::nullopt, kQuantNone,
-                activation_i32, /*splitk=*/1, /*nt=*/false,
+  at::Tensor stage1_in = hidden_states;
+  std::optional<at::Tensor> a1_scale;
+#ifdef FLASHINFER_MOE_AITER_PER_TOKEN
+  if (quantized) {
+    std::tie(stage1_in, a1_scale) =
+        quantize_per_token(hidden_states, w1.scalar_type(), /*num_rows_factor=*/1);
+  }
+#endif
+
+  ck_moe_stage1(stage1_in, w1, w2, sorted_token_ids, sorted_expert_ids, num_valid_ids, inter_states,
+                topk_i32, kernel_name, w1_scale, a1_scale, block_m_i32,
+                /*sorted_weights=*/std::nullopt, quant_type, activation_i32, /*splitk=*/1,
+                /*nt=*/false,
                 /*dst_type=*/std::nullopt);
 
-  ck_moe_stage2(inter_states, w1, w2, sorted_token_ids, sorted_expert_ids, num_valid_ids, out,
-                topk_i32, kernel_name, /*w2_scale=*/std::nullopt, /*a2_scale=*/std::nullopt,
-                block_m_i32, sorted_weights, kQuantNone, activation_i32, /*splitk=*/1,
+  at::Tensor stage2_in = inter_states;
+  std::optional<at::Tensor> a2_scale;
+#ifdef FLASHINFER_MOE_AITER_PER_TOKEN
+  if (quantized) {
+    // The [m, topk, inter_dim] shape is what gives each (token, expert) row its
+    // own scale; num_rows_factor only applies alongside an explicit num_rows,
+    // which expert parallelism would pass and this shim does not.
+    std::tie(stage2_in, a2_scale) =
+        quantize_per_token(inter_states, w2.scalar_type(), /*num_rows_factor=*/topk);
+  }
+#endif
+
+  ck_moe_stage2(stage2_in, w1, w2, sorted_token_ids, sorted_expert_ids, num_valid_ids, out,
+                topk_i32, kernel_name, w2_scale, a2_scale, block_m_i32, sorted_weights, quant_type,
+                activation_i32, /*splitk=*/1,
                 /*nt=*/false, /*dst_type=*/std::nullopt);
 }

--- a/flashinfer/csrc_rocm/fused_moe_aiter_jit_pybind.cu
+++ b/flashinfer/csrc_rocm/fused_moe_aiter_jit_pybind.cu
@@ -7,6 +7,7 @@
 
 void fused_moe_aiter(at::Tensor out, at::Tensor hidden_states, at::Tensor w1, at::Tensor w2,
                      at::Tensor topk_ids, at::Tensor topk_weights, int64_t block_m,
-                     int64_t activation);
+                     int64_t activation, std::optional<at::Tensor> w1_scale,
+                     std::optional<at::Tensor> w2_scale);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) { m.def("fused_moe_aiter", fused_moe_aiter); }

--- a/flashinfer/csrc_rocm/fused_moe_aiter_jit_pybind.cu
+++ b/flashinfer/csrc_rocm/fused_moe_aiter_jit_pybind.cu
@@ -3,6 +3,8 @@
 
 #include <ATen/ATen.h>
 
+#include <optional>
+
 #include "pytorch_extension_utils.h"
 
 void fused_moe_aiter(at::Tensor out, at::Tensor hidden_states, at::Tensor w1, at::Tensor w2,

--- a/flashinfer/fused_moe_rocm.py
+++ b/flashinfer/fused_moe_rocm.py
@@ -4,8 +4,8 @@
 
 Routing is the caller's responsibility: pass the selected experts and their
 weights, as with upstream's ``cutlass_fused_moe``. Expert weights may be
-unquantized bfloat16/float16 or fp8 with per-token scales; the activations are
-quantized inside the shim.
+unquantized bfloat16/float16, or fp8 with one scale per output row; the
+activations are quantized per token inside the shim.
 
 The expert weights must be pre-shuffled with :func:`shuffle_moe_weight` -- see
 that function for why this cannot be checked for you.

--- a/flashinfer/fused_moe_rocm.py
+++ b/flashinfer/fused_moe_rocm.py
@@ -3,8 +3,9 @@
 """Fused mixture-of-experts for ROCm, backed by AITER's CK two-stage kernels.
 
 Routing is the caller's responsibility: pass the selected experts and their
-weights, as with upstream's ``cutlass_fused_moe``. Only unquantized bfloat16 and
-float16 are wired up so far; the quantized paths are a follow-up.
+weights, as with upstream's ``cutlass_fused_moe``. Expert weights may be
+unquantized bfloat16/float16 or fp8 with per-token scales; the activations are
+quantized inside the shim.
 
 The expert weights must be pre-shuffled with :func:`shuffle_moe_weight` -- see
 that function for why this cannot be checked for you.
@@ -16,14 +17,20 @@ it would rebind the attribute from this function to that module.
 """
 
 import functools
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 
 import torch
 
 from .aiter_utils import require_aiter
+from .jit.aiter_source import resolve_aiter_build_arch
 from .jit.fused_moe_rocm import SUPPORTED_DTYPES, gen_fused_moe_aiter_module
 
-__all__ = ["aiter_fused_moe", "shuffle_moe_weight"]
+__all__ = [
+    "aiter_fused_moe",
+    "moe_fp8_dtype",
+    "quantize_moe_weight",
+    "shuffle_moe_weight",
+]
 
 # aiter_enum.h ActivationType, mirrored so callers need no aiter import. The keys
 # are also the supported-activation set, here and in the JIT spec.
@@ -38,6 +45,19 @@ _SUPPORTED_BLOCK_M = (32, 64, 128)
 # --block-m-sweep to regenerate.
 _BLOCK_M_THRESHOLDS = ((32, 32), (64, 64))
 
+# aiter/utility/dtypes.py: which fp8 encoding the MFMA instructions take. Both
+# exist in torch on either machine, so a wrong choice compiles and runs.
+_FP8_BY_ARCH = {
+    "gfx942": torch.float8_e4m3fnuz,
+    "gfx950": torch.float8_e4m3fn,
+}
+FP8_DTYPES = frozenset(_FP8_BY_ARCH.values())
+
+# CK builds every MoE instance with GemmSpecialization::Default -- no K padding --
+# so each GEMM's K must divide its tile exactly. fp8 doubles the tiles over bf16,
+# which is why only the quantized path needs checking. Both raise from inside CK.
+_FP8_STAGE1_K_TILE = 128
+
 
 def _select_block_m(num_tokens: int, topk: int, num_experts: int) -> int:
     """Pick the CK tile height from the average tokens routed to one expert."""
@@ -50,13 +70,88 @@ def _select_block_m(num_tokens: int, topk: int, num_experts: int) -> int:
     return _SUPPORTED_BLOCK_M[-1]
 
 
+def _fp8_stage2_k_tile(arch: str, block_m: int, inter_dim: int) -> int:
+    """CK's stage-2 K tile for fp8, mirroring aiter's heuristic dispatch."""
+    if arch == "gfx950":
+        # gfx950 builds no inter_dim <= 192 instances for fp8, so unlike gfx942
+        # there is no narrow tile to fall back to.
+        return 256 if block_m < 128 else 128
+    return 64 if inter_dim <= 192 else 128
+
+
+def _fp8_shape_problem(
+    arch: str, block_m: int, model_dim: int, inter_dim: int
+) -> Optional[str]:
+    """Why fp8 cannot serve this shape at this tile, or None if it can."""
+    if model_dim % _FP8_STAGE1_K_TILE:
+        return (
+            f"model_dim must be divisible by {_FP8_STAGE1_K_TILE} for fp8 expert "
+            f"weights, got {model_dim}; no block_m helps, since stage 1 steps K "
+            f"by {_FP8_STAGE1_K_TILE} on every tile and both architectures"
+        )
+    k_tile = _fp8_stage2_k_tile(arch, block_m, inter_dim)
+    if inter_dim % k_tile:
+        return (
+            f"inter_dim must be divisible by {k_tile} for fp8 expert weights at "
+            f"block_m={block_m} on {arch}, got {inter_dim}"
+        )
+    return None
+
+
+# Floor for a weight row's amax, so an all-zero expert does not divide by zero.
+_SCALE_EPS = 1e-12
+
 # CK's MFMA tile for the weight operand: 16 rows x 16 columns per instruction.
 _SHUFFLE_LAYOUT = (16, 16)
 
 
 @functools.cache
-def _get_module(dtype: torch.dtype, activation: str):
-    return gen_fused_moe_aiter_module(dtype, activation).build_and_load()
+def _get_module(dtype: torch.dtype, activation: str, weight_dtype: torch.dtype):
+    return gen_fused_moe_aiter_module(dtype, activation, weight_dtype).build_and_load()
+
+
+def moe_fp8_dtype() -> torch.dtype:
+    """The fp8 encoding this build's expert weights must use.
+
+    ``float8_e4m3fnuz`` on gfx942, ``float8_e4m3fn`` on gfx950; torch has both on
+    either machine, so the wrong one runs and is silently wrong. Quantizing on a
+    host without the target GPU needs ``FLASHINFER_ROCM_ARCH_LIST`` set, or this
+    answers for whatever architecture the shim resolved.
+    """
+    arch = resolve_aiter_build_arch()
+    try:
+        return _FP8_BY_ARCH[arch]
+    except KeyError:
+        raise ValueError(
+            f"fp8 fused MoE is not supported on {arch}; "
+            f"expected one of {sorted(_FP8_BY_ARCH)}"
+        ) from None
+
+
+def quantize_moe_weight(w: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Quantize an expert weight to fp8 with one scale per output row.
+
+    Produces exactly the ``(weight, scale)`` pair :func:`aiter_fused_moe` takes,
+    so callers need not reproduce the scale layout the shim then enforces. Run it
+    before :func:`shuffle_moe_weight`, at model load.
+
+    Args:
+        w: ``[num_experts, n, k]`` in any float dtype.
+
+    Returns:
+        ``(quantized, scale)`` -- ``w.shape`` in :func:`moe_fp8_dtype`, and
+        ``[num_experts, n, 1]`` float32.
+    """
+    if w.dim() != 3:
+        raise ValueError(f"expected a 3-D [num_experts, n, k] weight, got {w.dim()}-D")
+    fp8 = moe_fp8_dtype()
+    flat = w.reshape(-1, w.shape[-1]).float()
+    # clamp: an all-zero expert row is legal and would otherwise divide by zero.
+    scale = flat.abs().amax(-1, keepdim=True).clamp_min(_SCALE_EPS)
+    scale /= torch.finfo(fp8).max
+    return (flat / scale).to(fp8).view(w.shape), scale.view(
+        w.shape[0], w.shape[1], 1
+    ).contiguous()
 
 
 def shuffle_moe_weight(w: torch.Tensor) -> torch.Tensor:
@@ -102,6 +197,8 @@ def aiter_fused_moe(
     topk_ids: torch.Tensor,
     topk_weights: torch.Tensor,
     *,
+    w1_scale: Optional[torch.Tensor] = None,
+    w2_scale: Optional[torch.Tensor] = None,
     activation: str = "silu",
     block_m: Union[int, str] = "auto",
     out: Optional[torch.Tensor] = None,
@@ -114,24 +211,36 @@ def aiter_fused_moe(
 
     Both weights must have been passed through :func:`shuffle_moe_weight`; the
     parameters are named for it because the requirement cannot be checked. The
-    first call per ``(dtype, activation)`` builds two AITER modules and takes
-    minutes, then caches under ``~/.cache/flashinfer/aiter_libs/``.
+    first call per configuration builds AITER modules and takes minutes, then
+    caches under ``~/.cache/flashinfer/aiter_libs/``.
+
+    fp8 expert weights select CK's per-token path: quantize them offline into
+    :func:`moe_fp8_dtype` and pass both scales, and the activations are quantized
+    for you, once per stage.
 
     Args:
         hidden_states: ``[num_tokens, model_dim]``, bfloat16 or float16.
         w1_shuffled: ``[num_experts, 2 * inter_dim, model_dim]`` -- the gate and
             up projections concatenated along dim 1, gate first, then shuffled.
+            ``hidden_states.dtype`` or :func:`moe_fp8_dtype`.
         w2_shuffled: ``[num_experts, model_dim, inter_dim]``, the down
-            projection, shuffled.
+            projection, shuffled, same dtype as ``w1_shuffled``.
         topk_ids: ``[num_tokens, topk]`` int32, the selected experts. Every
             value must be in ``[0, num_experts)``; a drop marker such as ``-1``,
             or a global id against a local expert-parallel shard, reads out of
             bounds. Validating on device would cost a synchronize per call.
         topk_weights: ``[num_tokens, topk]`` float32, the routing weights.
+        w1_scale: ``[num_experts, 2 * inter_dim, 1]`` float32, one scale per
+            output row. Required with fp8 weights and rejected without them --
+            CK gates all scaling on the scales arriving together, so a half-set
+            pair would run unscaled and return a plausible-looking wrong answer.
+        w2_scale: ``[num_experts, model_dim, 1]`` float32, same rule.
         activation: ``"silu"`` or ``"gelu"``.
         block_m: CK tile height, one of ``(32, 64, 128)``, or ``"auto"`` to
             pick it from the average tokens per expert. Explicit values are
-            honoured unchanged.
+            honoured unchanged, except that fp8 on gfx950 rejects 32 and 64
+            unless ``inter_dim`` is a multiple of 256 -- CK has no K padding
+            there and would raise from inside the GEMM.
         out: Optional ``[num_tokens, model_dim]`` destination. Allocated if
             None. Overwritten, not accumulated into, and it may not overlap any
             input -- it is zero-filled before the activations are read.
@@ -141,11 +250,16 @@ def aiter_fused_moe(
 
     Raises:
         ValueError: The device or the aiter install cannot serve this op, or
-            ``activation``/``block_m``/the dtype is unsupported.
+            ``activation``/``block_m``/a dtype/the scale pair is unsupported.
         RuntimeError: A tensor fails the shim's shape, dtype, device,
             contiguity, or aliasing checks.
     """
-    require_aiter(hidden_states.device, "fused_moe")
+    # The fp8 path runs different CK instances and was measured separately, so it
+    # gets its own capability row rather than riding on the bf16 evidence.
+    require_aiter(
+        hidden_states.device,
+        "fused_moe_fp8" if w1_shuffled.dtype in FP8_DTYPES else "fused_moe",
+    )
 
     if activation not in _ACTIVATION_CODE:
         raise ValueError(
@@ -163,15 +277,65 @@ def aiter_fused_moe(
             f"got {hidden_states.dtype}"
         )
 
-    if block_m == "auto":
-        # Only when the ranks are sane. Indexing a degenerate shape here would
-        # raise IndexError and hide the shim's message naming the real problem.
-        if hidden_states.dim() == 2 and topk_ids.dim() == 2 and w1_shuffled.dim() == 3:
-            block_m = _select_block_m(
-                hidden_states.shape[0], topk_ids.shape[1], w1_shuffled.shape[0]
+    weight_dtype = w1_shuffled.dtype
+    quantized = weight_dtype in FP8_DTYPES
+    # Before _get_module, which keys on w1 alone: a mismatched pair would
+    # otherwise compile for minutes and only then fail in the shim.
+    if w2_shuffled.dtype != weight_dtype:
+        raise ValueError(
+            f"w1_shuffled and w2_shuffled must have the same dtype, got "
+            f"{weight_dtype} and {w2_shuffled.dtype}"
+        )
+    if quantized:
+        expected = moe_fp8_dtype()
+        if weight_dtype != expected:
+            raise ValueError(
+                f"expert weights must be {expected} on {resolve_aiter_build_arch()}, "
+                f"got {weight_dtype}; the two fp8 encodings differ in exponent "
+                "bias, so this would run and be silently wrong"
             )
-        else:
-            block_m = _SUPPORTED_BLOCK_M[0]
+    elif weight_dtype != hidden_states.dtype:
+        raise ValueError(
+            f"expert weights must be {hidden_states.dtype} or an fp8 dtype, "
+            f"got {weight_dtype}"
+        )
+    # Mirrors the shim's check so it lands before the build, not after it.
+    if (w1_scale is not None) + (w2_scale is not None) != (2 if quantized else 0):
+        raise ValueError(
+            "w1_scale and w2_scale must both be given for fp8 expert weights and "
+            f"both omitted otherwise; got weight dtype {weight_dtype} with "
+            f"w1_scale={'set' if w1_scale is not None else 'None'} and "
+            f"w2_scale={'set' if w2_scale is not None else 'None'}"
+        )
+
+    # Degenerate ranks skip the shape reads below so the shim's message names the
+    # real problem instead of an IndexError from here.
+    shapes_known = (
+        hidden_states.dim() == 2 and topk_ids.dim() == 2 and w1_shuffled.dim() == 3
+    )
+    automatic = block_m == "auto"
+    if not automatic:
+        tile = int(block_m)
+    elif shapes_known:
+        tile = _select_block_m(
+            hidden_states.shape[0], topk_ids.shape[1], w1_shuffled.shape[0]
+        )
+    else:
+        tile = _SUPPORTED_BLOCK_M[0]
+
+    if quantized and shapes_known and w2_shuffled.dim() == 3:
+        arch = resolve_aiter_build_arch()
+        model_dim, inter_dim = hidden_states.shape[1], w2_shuffled.shape[2]
+        problem = _fp8_shape_problem(arch, tile, model_dim, inter_dim)
+        if problem is not None and automatic:
+            # Another tile may divide inter_dim even when the chosen one does not;
+            # prefer a legal tile over CK's message, which names no dimension.
+            for candidate in _SUPPORTED_BLOCK_M:
+                if _fp8_shape_problem(arch, candidate, model_dim, inter_dim) is None:
+                    tile, problem = candidate, None
+                    break
+        if problem is not None:
+            raise ValueError(problem)
 
     if out is None:
         # Shaped from hidden_states only when its rank is right. Indexing a
@@ -180,7 +344,7 @@ def aiter_fused_moe(
         shape = tuple(hidden_states.shape) if hidden_states.dim() == 2 else (0, 0)
         out = torch.empty(shape, dtype=hidden_states.dtype, device=hidden_states.device)
 
-    module = _get_module(hidden_states.dtype, activation)
+    module = _get_module(hidden_states.dtype, activation, weight_dtype)
     # Skip torch custom-op dispatch, as the other AITER ROCm paths do: AITER is
     # inference-only here and torch.compile support is not required.
     module.fused_moe_aiter.default(
@@ -190,7 +354,9 @@ def aiter_fused_moe(
         w2_shuffled,
         topk_ids,
         topk_weights,
-        block_m,
+        tile,
         _ACTIVATION_CODE[activation],
+        w1_scale,
+        w2_scale,
     )
     return out

--- a/flashinfer/jit/fused_moe_rocm.py
+++ b/flashinfer/jit/fused_moe_rocm.py
@@ -6,6 +6,8 @@ Separate from ``flashinfer/jit/fused_moe.py``, which is the upstream CUTLASS /
 TRT-LLM generator and is not touched by the ROCm port.
 """
 
+from typing import Optional
+
 import torch
 
 from . import env as jit_env
@@ -21,6 +23,11 @@ _DTYPE_TAG = {
 }
 SUPPORTED_DTYPES = tuple(_DTYPE_TAG)
 
+# Both fp8 flavours generate the same CK instances -- which one is legal is a
+# property of the device, not of the codegen. The set itself lives with the
+# per-arch table in flashinfer.fused_moe_rocm, so there is only one to maintain.
+_FP8_TAG = "f8"
+
 _SUPPORTED_ACTIVATIONS = frozenset({"silu", "gelu"})
 
 # CK's routing-weight stage. 2 = apply topk weights in stage 2, which is what the
@@ -28,8 +35,23 @@ _SUPPORTED_ACTIVATIONS = frozenset({"silu", "gelu"})
 _MUL_WEIGHT_STAGE = 2
 
 
-def _ck2stages_module(dtype: torch.dtype, activation: str) -> AiterModule:
-    """A ``module_moe_ck2stages`` specialized to one dtype/activation.
+def _is_fp8(dtype: torch.dtype) -> bool:
+    # Imported here, not at module scope: flashinfer.fused_moe_rocm imports this
+    # module, so the reverse edge has to stay lazy.
+    from ..fused_moe_rocm import FP8_DTYPES
+
+    return dtype in FP8_DTYPES
+
+
+def _quant_tag(weight_dtype: torch.dtype, dtype: torch.dtype) -> str:
+    """The ``gen_instances.py -q`` value implied by the weight dtype."""
+    return "no" if weight_dtype == dtype else "per_token"
+
+
+def _ck2stages_module(
+    dtype: torch.dtype, weight_dtype: torch.dtype, activation: str
+) -> AiterModule:
+    """A ``module_moe_ck2stages`` specialized to one configuration.
 
     Mirrors AITER's own ``get_moe_stage_module`` rather than importing it, so a
     rename there surfaces as a build error instead of a silent change.
@@ -38,17 +60,19 @@ def _ck2stages_module(dtype: torch.dtype, activation: str) -> AiterModule:
     # only a real build needs the path.
     from aiter.jit.core import AITER_CSRC_DIR
 
-    a = b = c = _DTYPE_TAG[dtype]
-    act = activation
-    quant = "no"
+    b = _FP8_TAG if _is_fp8(weight_dtype) else _DTYPE_TAG[weight_dtype]
+    c = _DTYPE_TAG[dtype]
+    quant = _quant_tag(weight_dtype, dtype)
+    # No -a: gen_instances.py derives the activation dtype from -b and ignores
+    # the flag entirely.
     md_name = "_".join(
         [
             "module_moe_ck2stages",
-            a,
+            b,
             b,
             "preshuffle_off",
             c,
-            act,
+            activation,
             quant,
             f"mulWeightStage{_MUL_WEIGHT_STAGE}",
         ]
@@ -57,7 +81,7 @@ def _ck2stages_module(dtype: torch.dtype, activation: str) -> AiterModule:
     # exactly one `{}` and no other braces.
     blob_gen_cmd = (
         f"{AITER_CSRC_DIR}/ck_gemm_moe_2stages_codegen/gen_instances.py "
-        f"-a {a} -b {b} -c {c} -q {quant} -act {act} "
+        f"-b {b} -c {c} -q {quant} -act {activation} "
         f"-m {_MUL_WEIGHT_STAGE} --working_path {{}}"
     )
     return AiterModule(
@@ -65,28 +89,63 @@ def _ck2stages_module(dtype: torch.dtype, activation: str) -> AiterModule:
     )
 
 
-def gen_fused_moe_aiter_module(dtype: torch.dtype, activation: str) -> JitSpec:
-    """Build the fused-MoE shim for one dtype/activation pair."""
+def _spec_name(dtype: torch.dtype, activation: str, quant: str) -> str:
+    """The JIT module name. Unsuffixed when unquantized, so shipped caches stay valid."""
+    name = f"fused_moe_aiter_{_DTYPE_TAG[dtype]}_{activation}"
+    return name if quant == "no" else f"{name}_{quant}"
+
+
+def gen_fused_moe_aiter_module(
+    dtype: torch.dtype,
+    activation: str,
+    weight_dtype: Optional[torch.dtype] = None,
+) -> JitSpec:
+    """Build the fused-MoE shim for one (dtype, activation, weight dtype).
+
+    ``weight_dtype`` defaults to ``dtype`` (unquantized). An fp8 weight dtype
+    selects CK's ``per_Token`` instances and pulls in AITER's quantization
+    module, which the shim uses to quantize the activations.
+    """
     if dtype not in _DTYPE_TAG:
         # torch.dtype is not orderable, so list in declaration order.
         raise ValueError(f"fused MoE (aiter) supports {list(_DTYPE_TAG)}, got {dtype}")
+    if weight_dtype is None:
+        weight_dtype = dtype
+    if not _is_fp8(weight_dtype) and weight_dtype != dtype:
+        from ..fused_moe_rocm import FP8_DTYPES
+
+        raise ValueError(
+            f"fused MoE (aiter) supports expert weights in {dtype} or "
+            f"{sorted(FP8_DTYPES, key=str)}, got {weight_dtype}"
+        )
     if activation not in _SUPPORTED_ACTIVATIONS:
         raise ValueError(
             f"fused MoE (aiter) supports activations "
             f"{sorted(_SUPPORTED_ACTIVATIONS)}, got {activation!r}"
         )
 
-    extra_include_paths, extra_ldflags = aiter_jitspec_flags(
+    quant = _quant_tag(weight_dtype, dtype)
+    modules = [
         AiterModule("module_moe_sorting"),
-        _ck2stages_module(dtype, activation),
-    )
+        _ck2stages_module(dtype, weight_dtype, activation),
+    ]
+    extra_cuda_cflags = []
+    if quant != "no":
+        # aiter::dynamic_per_token_scaled_quant, which the shim uses to quantize
+        # the activations. Linked and compiled in only for the quantized specs so
+        # the shipped unquantized path gains no new way to fail to build.
+        modules.append(AiterModule("module_quant"))
+        extra_cuda_cflags.append("-DFLASHINFER_MOE_AITER_PER_TOKEN")
+
+    extra_include_paths, extra_ldflags = aiter_jitspec_flags(*modules)
     return refresh_aiter_jitspec(
         gen_jit_spec(
-            f"fused_moe_aiter_{_DTYPE_TAG[dtype]}_{activation}",
+            _spec_name(dtype, activation, quant),
             [
                 jit_env.FLASHINFER_CSRC_DIR / "fused_moe_aiter.cu",
                 jit_env.FLASHINFER_CSRC_DIR / "fused_moe_aiter_jit_pybind.cu",
             ],
+            extra_cuda_cflags=extra_cuda_cflags,
             extra_include_paths=extra_include_paths,
             extra_ldflags=extra_ldflags,
         )

--- a/tests/rocm_tests/test_aiter_module_spec_hip.py
+++ b/tests/rocm_tests/test_aiter_module_spec_hip.py
@@ -8,13 +8,15 @@ No GPU and no build: these cover the naming and flag construction that decide
 *which* lib a shim links. The ``_ck2stages_module`` tests still need ``aiter``
 importable, because the codegen command embeds AITER's own csrc path.
 
-What is being protected. Two specializations of ``module_moe_ck2stages`` (bf16
-vs fp16, silu vs gelu) are separate builds of the same AITER source tree. They
-are distinguished only by ``md_name``, which names the cached ``lib*.so``. If
-they collided on one filename the second build would be skipped and the first
-lib silently reused -- a wrong-dtype or wrong-activation kernel, with correct
-shapes and no error.
+What is being protected. Each specialization of ``module_moe_ck2stages`` (bf16
+vs fp16, silu vs gelu, unquantized vs fp8) is a separate build of the same AITER
+source tree. They are distinguished only by ``md_name``, which names the cached
+``lib*.so``. If they collided on one filename the second build would be skipped
+and the first lib silently reused -- a wrong-dtype, wrong-activation or
+unquantized kernel, with correct shapes and no error.
 """
+
+import itertools
 
 import pytest
 import torch
@@ -22,6 +24,13 @@ import torch
 from flashinfer.aiter_utils import _aiter_importable
 from flashinfer.jit.aiter_source import AiterModule, aiter_jitspec_flags
 from flashinfer.jit.fused_moe_rocm import _ck2stages_module
+
+_ACTIVATION_DTYPES = (torch.bfloat16, torch.float16)
+_ACTIVATIONS = ("silu", "gelu")
+# The weight dtype is either the activation dtype (unquantized) or fp8. Both fp8
+# encodings generate the same "f8" instances, so one stands for the pair here;
+# which one is legal is the device's business, not the codegen's.
+_WEIGHT_DTYPES = (None, torch.float8_e4m3fn)
 
 # _ck2stages_module reads aiter.jit.core.AITER_CSRC_DIR. A ROCm box without the
 # aiter package is a supported state, so skip rather than error there.
@@ -58,46 +67,64 @@ def test_unusable_lib_names_are_rejected(bad):
 
 @requires_aiter_import
 def test_specializations_do_not_collide():
-    """Every (dtype, activation) must map to a distinct cached lib."""
-    combos = [
-        (dt, act) for dt in (torch.bfloat16, torch.float16) for act in ("silu", "gelu")
-    ]
-    names = [_ck2stages_module(dt, act).lib_name for dt, act in combos]
+    """Every (dtype, activation, weight dtype) must map to a distinct cached lib."""
+    combos = list(itertools.product(_ACTIVATION_DTYPES, _WEIGHT_DTYPES, _ACTIVATIONS))
+    names = [_ck2stages_module(dt, wt or dt, act).lib_name for dt, wt, act in combos]
     assert len(set(names)) == len(combos), names
     assert all(n != "module_moe_ck2stages" for n in names), names
 
 
 @requires_aiter_import
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("activation", ["silu", "gelu"])
-def test_blob_gen_cmd_is_format_safe(dtype, activation):
+@pytest.mark.parametrize("dtype", _ACTIVATION_DTYPES)
+@pytest.mark.parametrize("weight_dtype", _WEIGHT_DTYPES)
+@pytest.mark.parametrize("activation", _ACTIVATIONS)
+def test_blob_gen_cmd_is_format_safe(dtype, weight_dtype, activation):
     """AITER runs ``blob_gen_cmd.format(blob_dir)``: exactly one ``{}``, no others."""
-    cmd = _ck2stages_module(dtype, activation).blob_gen_cmd
+    cmd = _ck2stages_module(dtype, weight_dtype or dtype, activation).blob_gen_cmd
     assert cmd.count("{") == 1 and cmd.count("}") == 1
     assert cmd.format("/tmp/blobs").endswith("--working_path /tmp/blobs")
 
 
 @requires_aiter_import
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("activation", ["silu", "gelu"])
-def test_codegen_flags_match_the_shim(dtype, activation):
+@pytest.mark.parametrize("dtype", _ACTIVATION_DTYPES)
+@pytest.mark.parametrize("weight_dtype", _WEIGHT_DTYPES)
+@pytest.mark.parametrize("activation", _ACTIVATIONS)
+def test_codegen_flags_match_the_shim(dtype, weight_dtype, activation):
     """The generated instances must match what the C++ shim asks CK for.
 
-    ``-m 2`` because the shim passes sorted_weights to stage 2, ``-q no`` because
-    it passes QuantType::No, and the dtype tags because there is one build per
-    dtype. A mismatch is a lookup miss at runtime, not a build failure.
+    ``-m 2`` because the shim passes sorted_weights to stage 2, the quant tag
+    because that selects which QuantType the shim may pass, and the dtype tags
+    because there is one build per configuration. A mismatch is a lookup miss at
+    runtime, not a build failure.
     """
     tag = {torch.bfloat16: "b16", torch.float16: "f16"}[dtype]
-    cmd = _ck2stages_module(dtype, activation).blob_gen_cmd
+    weight_tag = "f8" if weight_dtype is not None else tag
+    quant = "per_token" if weight_dtype is not None else "no"
+    cmd = _ck2stages_module(dtype, weight_dtype or dtype, activation).blob_gen_cmd
     for flag in (
-        f"-a {tag}",
-        f"-b {tag}",
+        f"-b {weight_tag}",
         f"-c {tag}",
-        "-q no",
+        f"-q {quant}",
         f"-act {activation}",
         "-m 2",
     ):
         assert flag in cmd, f"{flag!r} missing from {cmd!r}"
+    # -a is dead: gen_instances.py derives the activation dtype from -b.
+    assert " -a " not in cmd
+
+
+@requires_aiter_import
+def test_both_fp8_encodings_share_one_build():
+    """e4m3fn and e4m3fnuz differ on the device, not in the generated code.
+
+    Two libs would double a multi-minute CK build for nothing -- and only one of
+    them is ever loadable on a given machine anyway.
+    """
+    names = {
+        _ck2stages_module(torch.bfloat16, wt, "silu").lib_name
+        for wt in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+    }
+    assert len(names) == 1, names
 
 
 def test_flags_link_every_module_once(monkeypatch):

--- a/tests/rocm_tests/test_arch_caps_hip.py
+++ b/tests/rocm_tests/test_arch_caps_hip.py
@@ -261,7 +261,7 @@ class TestTableWellFormed:
         # op second, so one alternation covers them.
         pattern = re.compile(
             r"(?:require_aiter|is_aiter_available|require_capability"
-            r'|capability_available|capability_reason)\([^,()]*(?:\([^()]*\))?[^,()]*,\s*"([a-z_]+)"'
+            r'|capability_available|capability_reason)\([^,()]*(?:\([^()]*\))?[^,()]*,\s*"([a-z0-9_]+)"'
         )
         used = set()
         for src in pkg.rglob("*.py"):  # subpackages too, not just the top level
@@ -283,6 +283,10 @@ class TestTableWellFormed:
             "scan no longer sees ops called through the capability API: "
             f"{sorted({'mla', 'append_paged_kv_cache'} - used)}"
         )
+        # A digit in an op name is what silently narrowed this scan once: the
+        # character class excluded [0-9], so the whole call site stopped matching
+        # and both MoE rows vanished from `used` while the test still passed.
+        assert "fused_moe_fp8" in used, "the scan stopped seeing digit-bearing op names"
         declared = {c.op for c in arch_caps.CAPABILITIES if c.backend == "aiter"}
         assert used <= declared, (
             f"ops passed by the library but absent from the table: "

--- a/tests/rocm_tests/test_fused_moe_aiter_hip.py
+++ b/tests/rocm_tests/test_fused_moe_aiter_hip.py
@@ -19,13 +19,23 @@ import torch
 import flashinfer
 from flashinfer.fused_moe_rocm import (
     _BLOCK_M_THRESHOLDS,
+    _FP8_BY_ARCH,
+    _fp8_stage2_k_tile,
     _SUPPORTED_BLOCK_M,
     _select_block_m,
+    moe_fp8_dtype,
+    quantize_moe_weight,
     shuffle_moe_weight,
 )
+from flashinfer.jit.aiter_source import resolve_aiter_build_arch
 from tests.test_helpers.test_helpers import requires_aiter
 
 _ACT = {"silu": torch.nn.functional.silu, "gelu": torch.nn.functional.gelu}
+
+# Bound on fp8 quantization error against the dequantized-weight reference.
+# test_fp8_activation_scaling_is_per_token is what pins the *granularity*,
+# which this bound is too loose to see.
+_FP8_TOL = 0.08
 
 
 def _moe_ref(x, w1, w2, topk_ids, topk_weights, activation):
@@ -58,6 +68,21 @@ def _make_case(M, E, K, I, topk, dtype, device, seed=0xA17E3):
 
 def _rel_err(got, ref):
     return (got.float() - ref).abs().max().item() / max(ref.abs().max().item(), 1e-9)
+
+
+def _dequantize(q, scale):
+    return (q.float().view(-1, q.shape[-1]) * scale.view(-1, 1)).view(q.shape)
+
+
+def _make_fp8_case(M, E, K, I, topk, device, seed=0xA17E3):
+    """The bf16 case plus fp8 weights and the reference that dequantizes them."""
+    x, w1, w2, ids, weights = _make_case(M, E, K, I, topk, torch.bfloat16, device, seed)
+    w1q, w1s = quantize_moe_weight(w1)
+    w2q, w2s = quantize_moe_weight(w2)
+    ref = _moe_ref(
+        x, _dequantize(w1q, w1s), _dequantize(w2q, w2s), ids, weights, "silu"
+    )
+    return x, w1q, w1s, w2q, w2s, ids, weights, ref
 
 
 @requires_aiter
@@ -319,10 +344,84 @@ def test_fused_moe_rejects_bad_arguments(kwargs, cast, match):
 
 
 @requires_aiter
+def test_fused_moe_rejects_weights_of_the_wrong_dtype():
+    """A weight dtype that is neither hidden_states' nor fp8, before the build."""
+    device = torch.device("cuda:0")
+    x, w1, w2, ids, weights = _make_case(8, 8, 512, 256, 2, torch.bfloat16, device)
+
+    with pytest.raises(ValueError, match="expert weights must be"):
+        flashinfer.aiter_fused_moe(
+            x,
+            shuffle_moe_weight(w1).float(),
+            shuffle_moe_weight(w2).float(),
+            ids,
+            weights,
+        )
+
+
+@requires_aiter
+@pytest.mark.parametrize("quantize_w1", [True, False])
+def test_fused_moe_rejects_mismatched_weight_dtypes(quantize_w1):
+    """Quantizing one weight and not the other, caught before the build.
+
+    _get_module keys on w1 alone, so without this the fp8 case compiles a CK
+    module for minutes and only then fails in the shim.
+    """
+    device = torch.device("cuda:0")
+    x, w1, w2, ids, weights = _make_case(8, 8, 512, 256, 2, torch.bfloat16, device)
+    w1q, w1s = quantize_moe_weight(w1)
+    w2q, w2s = quantize_moe_weight(w2)
+    if quantize_w1:
+        pair, scales = (w1q, w2), {"w1_scale": w1s, "w2_scale": w2s}
+    else:
+        pair, scales = (w1, w2q), {}
+
+    with pytest.raises(ValueError, match="must have the same dtype"):
+        flashinfer.aiter_fused_moe(
+            x,
+            shuffle_moe_weight(pair[0]),
+            shuffle_moe_weight(pair[1]),
+            ids,
+            weights,
+            **scales,
+        )
+
+
+@requires_aiter
+@pytest.mark.parametrize(
+    "break_scale,match",
+    [
+        (lambda s: s.half(), "must be float32"),
+        (lambda s: s.squeeze(-1), r"must be \["),
+        (lambda s: s[:, :-16], r"must be \["),
+        (lambda s: s.repeat(1, 1, 2)[..., :1], "must be contiguous"),
+    ],
+)
+def test_fp8_rejects_malformed_weight_scales(break_scale, match):
+    """The shim is the only thing that validates scale dtype, shape and layout.
+
+    CK reads the scale buffer at a stride derived from the weight shape, so a
+    wrong one is out-of-bounds reads or wrong numbers, not a crash.
+    """
+    device = torch.device("cuda:0")
+    x, w1q, w1s, w2q, w2s, ids, weights, _ = _make_fp8_case(64, 8, 512, 256, 2, device)
+
+    with pytest.raises(RuntimeError, match=match):
+        flashinfer.aiter_fused_moe(
+            x,
+            shuffle_moe_weight(w1q),
+            shuffle_moe_weight(w2q),
+            ids,
+            weights,
+            w1_scale=break_scale(w1s),
+            w2_scale=w2s,
+        )
+
+
+@requires_aiter
 @pytest.mark.parametrize(
     "mutate,match",
     [
-        (lambda t: {"w1": t["w1"].float()}, "w1/w2 dtype must match"),
         (lambda t: {"ids": t["ids"].to(torch.int64)}, "topk_ids must be int32"),
         (lambda t: {"weights": t["weights"].to(torch.bfloat16)}, "must be float32"),
         (lambda t: {"w2": t["w2"][:, :, : t["w2"].shape[2] // 2]}, "expected w1"),
@@ -360,3 +459,294 @@ def test_fused_moe_rejects_bad_tensors(mutate, match):
     t.update(mutate(t))
     with pytest.raises(RuntimeError, match=match):
         flashinfer.aiter_fused_moe(t["x"], t["w1"], t["w2"], t["ids"], t["weights"])
+
+
+@requires_aiter
+@pytest.mark.parametrize(
+    "M,E,K,I,topk",
+    [
+        (1, 8, 512, 256, 2),
+        (64, 8, 512, 256, 2),
+        (256, 32, 1024, 512, 6),
+        # inter_dim=1408 is not a multiple of 256, which gfx950's fp8 stage 2
+        # needs at block_m 32 and 64 -- "auto" must step up to 128 rather than
+        # raise from inside CK.
+        (1024, 8, 4096, 1408, 2),
+    ],
+)
+def test_fp8_moe_vs_dequantized_ref(M, E, K, I, topk):
+    device = torch.device("cuda:0")
+    x, w1q, w1s, w2q, w2s, ids, weights, ref = _make_fp8_case(M, E, K, I, topk, device)
+
+    got = flashinfer.aiter_fused_moe(
+        x,
+        shuffle_moe_weight(w1q),
+        shuffle_moe_weight(w2q),
+        ids,
+        weights,
+        w1_scale=w1s,
+        w2_scale=w2s,
+    )
+
+    assert got.shape == (M, K) and got.dtype == torch.bfloat16
+    assert torch.isfinite(got).all()
+    assert _rel_err(got, ref) < _FP8_TOL
+
+
+@requires_aiter
+@pytest.mark.parametrize("activation", ["silu", "gelu"])
+@pytest.mark.parametrize("block_m", [32, 64, 128])
+def test_fp8_moe_activation_and_block_m(activation, block_m):
+    device = torch.device("cuda:0")
+    x, w1q, w1s, w2q, w2s, ids, weights, _ = _make_fp8_case(128, 8, 512, 256, 2, device)
+    ref = _moe_ref(
+        x, _dequantize(w1q, w1s), _dequantize(w2q, w2s), ids, weights, activation
+    )
+
+    got = flashinfer.aiter_fused_moe(
+        x,
+        shuffle_moe_weight(w1q),
+        shuffle_moe_weight(w2q),
+        ids,
+        weights,
+        w1_scale=w1s,
+        w2_scale=w2s,
+        activation=activation,
+        block_m=block_m,
+    )
+
+    assert _rel_err(got, ref) < _FP8_TOL
+
+
+@requires_aiter
+@pytest.mark.parametrize("drop", ["w1_scale", "w2_scale", "both"])
+def test_fp8_needs_both_scales(drop):
+    """CK gates *all* scaling on the scale pointers arriving together, so a
+    half-supplied pair silently runs an unscaled GEMM."""
+    device = torch.device("cuda:0")
+    x, w1q, w1s, w2q, w2s, ids, weights, _ = _make_fp8_case(64, 8, 512, 256, 2, device)
+    scales = {"w1_scale": w1s, "w2_scale": w2s}
+    for key in ["w1_scale", "w2_scale"] if drop == "both" else [drop]:
+        scales[key] = None
+
+    with pytest.raises(ValueError, match="must both be given"):
+        flashinfer.aiter_fused_moe(
+            x,
+            shuffle_moe_weight(w1q),
+            shuffle_moe_weight(w2q),
+            ids,
+            weights,
+            **scales,
+        )
+
+
+@requires_aiter
+def test_scales_are_rejected_without_fp8_weights():
+    """The other half of the same rule: bf16 weights take no scales."""
+    device = torch.device("cuda:0")
+    x, w1, w2, ids, weights = _make_case(64, 8, 512, 256, 2, torch.bfloat16, device)
+    ones = torch.ones(8, 512, 1, dtype=torch.float32, device=device)
+
+    with pytest.raises(ValueError, match="must both be given"):
+        flashinfer.aiter_fused_moe(
+            x,
+            shuffle_moe_weight(w1),
+            shuffle_moe_weight(w2),
+            ids,
+            weights,
+            w1_scale=ones,
+            w2_scale=ones,
+        )
+
+
+@requires_aiter
+def test_fp8_rejects_the_other_architectures_encoding():
+    """The other board's encoding quantizes, shuffles and runs; only the numbers
+    are wrong. Which one is right is a property of the device."""
+    device = torch.device("cuda:0")
+    x, w1q, w1s, w2q, w2s, ids, weights, _ = _make_fp8_case(64, 8, 512, 256, 2, device)
+    other = next(d for d in _FP8_BY_ARCH.values() if d != moe_fp8_dtype())
+
+    with pytest.raises(ValueError, match="expert weights must be"):
+        flashinfer.aiter_fused_moe(
+            x,
+            shuffle_moe_weight(w1q).view(other),
+            shuffle_moe_weight(w2q).view(other),
+            ids,
+            weights,
+            w1_scale=w1s,
+            w2_scale=w2s,
+        )
+
+
+# CK's fp8 stage-2 K tile, measured through this shim on both boards by running
+# every (inter_dim, block_m) below and recording ok / raised. gfx942 keeps a
+# narrow tile for inter_dim <= 192; gfx950 builds no such instance.
+_MEASURED_STAGE2_K_TILE = [
+    ("gfx942", 32, 192, 64),
+    ("gfx942", 32, 320, 128),
+    ("gfx942", 128, 1408, 128),
+    ("gfx950", 32, 320, 256),
+    ("gfx950", 64, 1408, 256),
+    ("gfx950", 128, 1408, 128),
+    ("gfx950", 128, 192, 128),
+]
+
+
+@pytest.mark.parametrize("arch,block_m,inter_dim,expected", _MEASURED_STAGE2_K_TILE)
+def test_fp8_stage2_k_tile_matches_measurement(arch, block_m, inter_dim, expected):
+    """Pure arithmetic: no GPU, no aiter."""
+    assert _fp8_stage2_k_tile(arch, block_m, inter_dim) == expected
+
+
+@requires_aiter
+@pytest.mark.parametrize("block_m", [32, 64, 128])
+def test_fp8_rejects_a_shape_ck_cannot_serve(block_m):
+    """inter_dim=1408 is legal on gfx942 at every tile and illegal on gfx950 below 128.
+
+    CK's own rejection names neither dimension, so this asserts the arch-specific
+    answer rather than a fixed one.
+    """
+    device = torch.device("cuda:0")
+    inter_dim = 1408
+    x, w1q, w1s, w2q, w2s, ids, weights, ref = _make_fp8_case(
+        64, 8, 512, inter_dim, 2, device
+    )
+    call = lambda: flashinfer.aiter_fused_moe(  # noqa: E731
+        x,
+        shuffle_moe_weight(w1q),
+        shuffle_moe_weight(w2q),
+        ids,
+        weights,
+        w1_scale=w1s,
+        w2_scale=w2s,
+        block_m=block_m,
+    )
+
+    if inter_dim % _fp8_stage2_k_tile(resolve_aiter_build_arch(), block_m, inter_dim):
+        with pytest.raises(ValueError, match="inter_dim must be divisible by"):
+            call()
+    else:
+        assert _rel_err(call(), ref) < _FP8_TOL
+
+
+@requires_aiter
+def test_fp8_rejects_a_model_dim_no_tile_can_serve():
+    """Stage 1 steps K by 128 on every tile and both boards, so no tile rescues this.
+
+    Reaching CK instead returns non-finite output on gfx942 rather than raising.
+    """
+    device = torch.device("cuda:0")
+    x, w1q, w1s, w2q, w2s, ids, weights, _ = _make_fp8_case(64, 8, 544, 512, 2, device)
+    assert 544 % 128 and 544 % 32 == 0  # indivisible for CK, still shuffleable
+
+    with pytest.raises(ValueError, match="model_dim must be divisible by 128"):
+        flashinfer.aiter_fused_moe(
+            x,
+            shuffle_moe_weight(w1q),
+            shuffle_moe_weight(w2q),
+            ids,
+            weights,
+            w1_scale=w1s,
+            w2_scale=w2s,
+        )
+
+
+@requires_aiter
+def test_fp8_auto_picks_a_tile_that_can_serve_the_shape():
+    """The selector wants 32 here; on gfx950 that tile cannot serve inter_dim=1408.
+
+    "auto" must find a legal tile rather than propagate the rejection, and must
+    still be correct on gfx942 where 32 was legal all along.
+    """
+    device = torch.device("cuda:0")
+    assert _select_block_m(64, 2, 8) == 32
+    x, w1q, w1s, w2q, w2s, ids, weights, ref = _make_fp8_case(
+        64, 8, 512, 1408, 2, device
+    )
+
+    got = flashinfer.aiter_fused_moe(
+        x,
+        shuffle_moe_weight(w1q),
+        shuffle_moe_weight(w2q),
+        ids,
+        weights,
+        w1_scale=w1s,
+        w2_scale=w2s,
+    )
+
+    assert _rel_err(got, ref) < _FP8_TOL
+
+
+@requires_aiter
+def test_fp8_activation_scaling_is_per_token():
+    """One token far outside fp8's exponent range, so the rest must not be crushed.
+
+    The outlier has to be this large: e4m3 spans ~2.3e5, so below that a single
+    shared scale is nearly as good as per-row and no tolerance separates the two.
+    At 1e5 per-token measures 0.06 against per-tensor's 0.75.
+    """
+    device = torch.device("cuda:0")
+    x, w1q, w1s, w2q, w2s, ids, weights, _ = _make_fp8_case(64, 8, 512, 256, 2, device)
+    x = x.clone().float()
+    x[0] *= 1e5
+    x = x.bfloat16()
+    ref = _moe_ref(x, _dequantize(w1q, w1s), _dequantize(w2q, w2s), ids, weights, "silu")
+
+    got = flashinfer.aiter_fused_moe(
+        x,
+        shuffle_moe_weight(w1q),
+        shuffle_moe_weight(w2q),
+        ids,
+        weights,
+        w1_scale=w1s,
+        w2_scale=w2s,
+    )
+
+    # Per row: the outlier's own magnitude must not mask the rows it would crush.
+    rel = (got.float() - ref).abs().amax(-1) / ref.abs().amax(-1).clamp_min(1e-9)
+    assert rel.max().item() < _FP8_TOL, rel
+
+
+@requires_aiter
+@pytest.mark.parametrize("quantized", [False, True])
+def test_zero_tokens_returns_an_empty_result(quantized):
+    """An expert-parallel rank can be routed nothing.
+
+    AITER launches a zero-sized grid for that and leaves a sticky HIP error that
+    surfaces on a later unrelated op, so the shim has to return before it.
+    """
+    device = torch.device("cuda:0")
+    x, w1, w2, _, _ = _make_case(8, 8, 512, 256, 2, torch.bfloat16, device)
+    x = x[:0].contiguous()
+    ids = torch.empty(0, 2, dtype=torch.int32, device=device)
+    weights = torch.empty(0, 2, dtype=torch.float32, device=device)
+    scales = {}
+    if quantized:
+        w1, w1s = quantize_moe_weight(w1)
+        w2, w2s = quantize_moe_weight(w2)
+        scales = {"w1_scale": w1s, "w2_scale": w2s}
+
+    got = flashinfer.aiter_fused_moe(
+        x, shuffle_moe_weight(w1), shuffle_moe_weight(w2), ids, weights, **scales
+    )
+    torch.cuda.synchronize()
+
+    assert got.shape == (0, 512)
+    # The sticky error the early return exists to prevent lands here, not above.
+    torch.zeros(4, device=device).sum().item()
+
+
+@requires_aiter
+def test_fp8_shuffle_matches_aiters_own():
+    """The lane width is 16 // element_size, so fp8 takes a different branch than
+    the bf16 path shuffle_moe_weight was written for."""
+    aiter_shuffle = pytest.importorskip("aiter.ops.shuffle").shuffle_weight
+    device = torch.device("cuda:0")
+    w = torch.randn(4, 128, 256, dtype=torch.bfloat16, device=device)
+    q, _ = quantize_moe_weight(w)
+
+    assert torch.equal(
+        shuffle_moe_weight(q).view(torch.uint8),
+        aiter_shuffle(q, layout=(16, 16)).view(torch.uint8),
+    )

--- a/tests/rocm_tests/test_fused_moe_aiter_hip.py
+++ b/tests/rocm_tests/test_fused_moe_aiter_hip.py
@@ -74,9 +74,9 @@ def _dequantize(q, scale):
     return (q.float().view(-1, q.shape[-1]) * scale.view(-1, 1)).view(q.shape)
 
 
-def _make_fp8_case(M, E, K, I, topk, device, seed=0xA17E3):
-    """The bf16 case plus fp8 weights and the reference that dequantizes them."""
-    x, w1, w2, ids, weights = _make_case(M, E, K, I, topk, torch.bfloat16, device, seed)
+def _make_fp8_case(M, E, K, I, topk, device, seed=0xA17E3, *, dtype=torch.bfloat16):
+    """The unquantized case plus fp8 weights and a dequantized-weight reference."""
+    x, w1, w2, ids, weights = _make_case(M, E, K, I, topk, dtype, device, seed)
     w1q, w1s = quantize_moe_weight(w1)
     w2q, w2s = quantize_moe_weight(w2)
     ref = _moe_ref(
@@ -679,6 +679,31 @@ def test_fp8_auto_picks_a_tile_that_can_serve_the_shape():
 
 
 @requires_aiter
+def test_fp8_with_float16_activations():
+    """fp8 weights against fp16 activations are a distinct set of CK instances.
+
+    Same weight dtype, different C type, so a separate lib and a separate
+    dispatch-table entry from the bf16 case every other fp8 test covers.
+    """
+    device = torch.device("cuda:0")
+    x, w1q, w1s, w2q, w2s, ids, weights, ref = _make_fp8_case(
+        64, 8, 512, 256, 2, device, dtype=torch.float16
+    )
+
+    got = flashinfer.aiter_fused_moe(
+        x,
+        shuffle_moe_weight(w1q),
+        shuffle_moe_weight(w2q),
+        ids,
+        weights,
+        w1_scale=w1s,
+        w2_scale=w2s,
+    )
+
+    assert _rel_err(got, ref) < _FP8_TOL
+
+
+@requires_aiter
 def test_fp8_activation_scaling_is_per_token():
     """One token far outside fp8's exponent range, so the rest must not be crushed.
 
@@ -691,7 +716,9 @@ def test_fp8_activation_scaling_is_per_token():
     x = x.clone().float()
     x[0] *= 1e5
     x = x.bfloat16()
-    ref = _moe_ref(x, _dequantize(w1q, w1s), _dequantize(w2q, w2s), ids, weights, "silu")
+    ref = _moe_ref(
+        x, _dequantize(w1q, w1s), _dequantize(w2q, w2s), ids, weights, "silu"
+    )
 
     got = flashinfer.aiter_fused_moe(
         x,

--- a/tests/rocm_tests/test_fused_moe_aiter_hip.py
+++ b/tests/rocm_tests/test_fused_moe_aiter_hip.py
@@ -189,6 +189,18 @@ def test_select_block_m_only_returns_supported_tiles():
     assert returned <= set(_SUPPORTED_BLOCK_M)
 
 
+def test_public_api_is_reachable_from_the_package():
+    """Everything in the module's __all__ must also be a flashinfer.* attribute.
+
+    The re-export is a separate line in __init__.py, so adding a helper and
+    forgetting it leaves the documented fp8 workflow half-reachable.
+    """
+    from flashinfer import fused_moe_rocm
+
+    missing = [n for n in fused_moe_rocm.__all__ if not hasattr(flashinfer, n)]
+    assert not missing, missing
+
+
 def test_select_block_m_never_divides_by_zero():
     """A degenerate weight is the shim's error to report, not ours to crash on."""
     assert _select_block_m(64, 2, 0) in _SUPPORTED_BLOCK_M


### PR DESCRIPTION
## Summary

`aiter_fused_moe` shipped bf16/fp16 only. That is the correctness spine, not the serving configuration — production MoE on MI300X/MI355X runs fp8. This wires CK's `per_Token` fp8 path through the same C++ shim: pass expert weights in `moe_fp8_dtype()` with their per-row scales and the shim quantizes the activations for you, once per stage.

**1.4–1.9× faster than bf16 at every measured point on both architectures**, and ahead of `aiter.fused_moe`'s own fp8 path at 9 of 12 points on gfx950.

### What changed

- **`flashinfer/fused_moe_rocm.py`** — `w1_scale`/`w2_scale` arguments, `moe_fp8_dtype()`, and `quantize_moe_weight()` so callers get the exact `(weight, scale)` pair the shim validates rather than reconstructing it from prose. Plus `_fp8_shape_problem`, which models CK's K-tile rule (below).
- **`flashinfer/csrc_rocm/fused_moe_aiter.cu`** — `quant_type` is a parameter; the shim calls `aiter::dynamic_per_token_scaled_quant` before each GEMM. Stage 1 still writes bf16 — `gemm_moe_ck2stages.cu` `TORCH_CHECK`s it — so the intermediate is quantized again between the stages.
- **`flashinfer/jit/fused_moe_rocm.py`** — one specialized CK module per `(dtype, activation, quant)`. `module_quant` is linked and `-DFLASHINFER_MOE_AITER_PER_TOKEN` defined only for quantized specs, so the shipped unquantized path gains no new way to fail to build, and its JIT spec name is unchanged so existing caches stay valid.
- **`flashinfer/arch_caps.py`** — `fused_moe_fp8` as its own row. It runs different CK instances and takes an arch-dependent input dtype, so it does not ride on the bf16 evidence.

### Three ways this can be silently wrong, and what each gets

**Partial scales disable *all* scaling.** `gridwise_moe_gemm.hpp:1436` gates the whole scaling block on `p_sorted_weights_0 != nullptr && p_scale_b != nullptr`, so supplying one scale of the pair runs an unscaled GEMM and returns it. Measured with the weight scales forced to 1.0: `rel_l2 = 3.8e9` at **cosine similarity 0.80** — a similarity check passes it. Rejected in Python (before the multi-minute build) and again in the shim.

**The fp8 encoding is arch-dependent** — `e4m3fnuz` on gfx942, `e4m3fn` on gfx950. torch has both on either machine, so the wrong one quantizes, shuffles and runs. Hence `moe_fp8_dtype()`.

**fp8 doubles every CK K tile, and CK has no K padding** (`GemmSpecialization::Default`), so shapes bf16 serves fine become unservable. Measured through this shim on both boards by sweeping the dimensions and recording ok/raised:

| GEMM | K | gfx942 | gfx950 |
|---|---|---|---|
| stage 1 | `model_dim` | 128, every tile | 128, every tile |
| stage 2 | `inter_dim` | 64 if `inter_dim ≤ 192` else 128 | 256 at `block_m` 32/64, 128 at 128 |

So gfx942 serves `inter_dim` 192 and 1408 that gfx950 rejects, and `model_dim = 2880` (gpt-oss-120b) fails on **both** — not hypothetical. `block_m="auto"` now picks a tile that can serve the shape instead of one that cannot; an explicit tile is rejected by name rather than by CK's `wrong! device_gemm ... does not support this GEMM problem`, which names no dimension. A `model_dim` no tile can serve is rejected outright.

**Zero tokens returns early.** An expert-parallel rank can legitimately be routed nothing, and AITER launches a zero-sized grid for it, leaving a sticky HIP `invalid configuration argument` that surfaces on some later, unrelated op.

### One trap the plan predicted and measurement disproved

`dynamic_per_token_scaled_quant` takes a per-*group* branch when the last dimension is 32, 64 or 128 (`quant_kernels.cu:688`) — but that group size *is* the row width, so the scales come out bit-identical to per-token (max relative difference `0.000e+00` at 128, 192 and 256). Guarding it would have rejected a legal shape.

## Benchmark results

bf16 vs fp8, ROCm 7.2.0 / aiter 0.1.10 / torch 2.9.1, `--timing-only`. Latency in ms; `×` is `bf16 / fp8`.

**gfx950 (MI350X)**

| shape | tokens | bf16 | fp8 | × |
|---|---|---|---|---|
| mixtral8x7b | 1 | 0.221 | 0.138 | 1.60 |
| mixtral8x7b | 8 | 0.426 | 0.276 | 1.54 |
| mixtral8x7b | 32 | 0.538 | 0.308 | 1.75 |
| mixtral8x7b | 128 | 0.564 | 0.327 | 1.72 |
| mixtral8x7b | 512 | 0.942 | 0.556 | 1.69 |
| mixtral8x7b | 2048 | 2.398 | 1.291 | **1.86** |
| qwen3-235b | 1 | 0.106 | 0.074 | 1.43 |
| qwen3-235b | 8 | 0.397 | 0.223 | 1.78 |
| qwen3-235b | 32 | 0.801 | 0.425 | **1.88** |
| qwen3-235b | 128 | 0.892 | 0.487 | 1.83 |
| qwen3-235b | 512 | 0.958 | 0.557 | 1.72 |
| qwen3-235b | 2048 | 1.600 | 0.966 | 1.66 |

**gfx942 (MI300X)**

| shape | tokens | bf16 | fp8 | × |
|---|---|---|---|---|
| mixtral8x7b | 1 | 0.271 | 0.164 | 1.65 |
| mixtral8x7b | 8 | 0.581 | 0.375 | 1.55 |
| mixtral8x7b | 32 | 0.774 | 0.429 | 1.80 |
| mixtral8x7b | 128 | 0.843 | 0.473 | 1.78 |
| mixtral8x7b | 512 | 1.378 | 0.814 | 1.69 |
| mixtral8x7b | 2048 | 3.486 | 1.929 | **1.81** |
| qwen3-235b | 1 | 0.125 | 0.085 | 1.47 |
| qwen3-235b | 8 | 0.549 | 0.313 | 1.75 |
| qwen3-235b | 32 | 1.137 | 0.643 | 1.77 |
| qwen3-235b | 128 | 1.326 | 0.713 | **1.86** |
| qwen3-235b | 512 | 1.496 | 0.843 | 1.77 |
| qwen3-235b | 2048 | 2.363 | 1.400 | 1.69 |

Against `aiter.fused_moe`'s own fp8 path we are ahead or level nearly everywhere, and it is worth saying why we sometimes win by a lot on gfx942 (mixtral 2048: 1.929 vs 3.030 ms in an earlier run): AITER's tuned config selects `run_1stage=True` there, dispatching to the asm `fmoe_g1u1` kernel rather than CK. That is a different kernel, not a better-tuned CK call.

Accuracy: `rel_l2` 0.045–0.050 against a dequantized-weight fp32 reference, matching AITER's own per-token path at 0.046 on the same inputs.

## Test plan

- [x] `pytest tests/rocm_tests/test_fused_moe_aiter_hip.py test_aiter_module_spec_hip.py test_arch_caps_hip.py` on MI300X **and** MI350X — 189 passed, 1 skipped (the two-GPU test) on each.
- [x] Every new guard A/B'd against its removal. The arch-dependent ones assert the arch-specific answer, with the shape outcomes pinned by `_MEASURED_STAGE2_K_TILE` — a row per `(arch, block_m, inter_dim)` recorded from both boards — so a single-box run cannot make them pass by accident.
- [x] `test_fp8_activation_scaling_is_per_token` exists because the accuracy bound **cannot** see quantization granularity: an A/B against a per-tensor emulation scored 0.0715 against the 0.08 bound, i.e. the obvious test would have passed on the regression it claimed to catch. Separation only appears past fp8's exponent range (e4m3 spans ~2.3e5); at 1e5 per-token measures 0.0587 against per-tensor's 0.7526.
- [x] `pre-commit run -a`

## Deliberately out of scope

fp8 **blockscale** (`per_1x128`) — different quant type, different scale shapes, and on gfx950 it routes to the asm `fmoe_fp8_blockscale_g1u1` path. int4/mxfp4 (`per_1x32`), which needs the `fp4x2` preshuffle and a different `shuffle_weight` variant. `doweight_stage1=True`, which changes which stage applies routing weights and so needs a second CK instance set.

One note on how this is validated, since it is easy to misread. The kernels *are* AITER's — the shim links AITER's C++ entry points (`moe_sorting_fwd`, `ck_moe_stage1/2`, `aiter::dynamic_per_token_scaled_quant`) and calls them directly, as the other ROCm AITER paths in this repo do. What is not usable as a test is AITER's *Python* `aiter.fused_moe` wrapper: it re-dispatches, and on gfx942 selects `run_1stage=True`, i.e. the asm `fmoe_g1u1` kernel rather than the CK two-stage path this shim calls. Comparing outputs there compares two different kernels. On gfx950 it does select CK and a bit-exact comparison passes; it was dropped rather than made arch-conditional.

Correctness therefore rests on the float32 reference fed dequantized weights — and that reference is itself pinned against AITER: AITER's own per-token fp8 path scores 0.046 against it, the same as this implementation.