### PR TITLE
fix(rocm): let backend="auto" fall back to fa2 when AITER cannot build a kernel

### DIFF
--- a/flashinfer/aiter_utils.py
+++ b/flashinfer/aiter_utils.py
@@ -3,11 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import functools
+import os
 
 import torch
 
-from .arch_caps import capability_available, normalize_arch, require_capability
+from .arch_caps import (
+    ArchCapabilityError,
+    capability_available,
+    normalize_arch,
+    require_capability,
+)
 from .hip_utils import FLASHINFER_SUPPORTED_ROCM_ARCHS
+from .jit.core import MissingJITCacheError, logger
 
 
 @functools.lru_cache(maxsize=8)
@@ -87,3 +94,39 @@ def get_aiter_mha_module():
     from aiter.ops import mha as aiter_mha_module
 
     return aiter_mha_module
+
+
+# Failures that are never AITER's to own, so ``auto`` must not demote on them:
+# a wrong-numerics arch gate, our own missing AOT cache, a caller contract
+# violation, and a transient OOM that would otherwise cache as "unsupported".
+_AITER_PROBE_FATAL = (
+    ArchCapabilityError,
+    MissingJITCacheError,
+    ValueError,
+    torch.cuda.OutOfMemoryError,
+)
+
+
+def handle_aiter_probe_failure(exc: BaseException, *, op: str) -> str:
+    """Classify a failure raised while probing whether AITER can serve ``op``.
+
+    Re-raises when the failure is not a "this AITER install cannot build this
+    variant" condition; otherwise warns and returns the reason string for
+    ``backend_fallback_reason``. Callers must be ``lru_cache``d, since that —
+    not this function — is what stops a failing build being retried.
+    """
+    if isinstance(exc, _AITER_PROBE_FATAL):
+        raise exc
+    if os.environ.get("FLASHINFER_AITER_STRICT", "0") == "1":
+        raise exc
+
+    # Single-line and bounded: this string reaches a CSV column in the benchmark
+    # harness, where an embedded traceback would corrupt the row.
+    detail = " ".join(str(exc).split())[:200]
+    reason = (
+        f"aiter {op} kernel bootstrap failed on this install: "
+        f"{type(exc).__name__}: {detail} "
+        "(set FLASHINFER_AITER_STRICT=1 to raise instead)"
+    )
+    logger.warning("auto backend falling back to fa2: %s", reason)
+    return reason

--- a/flashinfer/decode_rocm.py
+++ b/flashinfer/decode_rocm.py
@@ -481,13 +481,16 @@ def _aiter_pa_v1_available(
     logits_soft_cap: float,
     sliding_window: int,
     partition_size: int,
+    device_idx: int,
 ) -> Tuple[Optional[Tuple[str, str]], Optional[str]]:
     """Resolve AITER PA v1 for this problem; returns ((so_path, func_name), None)
     or (None, reason) when this AITER install cannot build the variant.
 
-    Positional-only by convention: lru_cache keys kwargs by insertion order, so
-    keyword calls would make argument order a silent cache-miss hazard.
+    device_idx is in the key but unused: the resolved .so is arch-specific, and
+    this host can hold gfx942 and gfx950 at once. Positional-only by convention,
+    since lru_cache keys kwargs by insertion order.
     """
+    del device_idx
     try:
         resolved = _aiter_pa_v1_resolve(
             dtype_q=dtype_q,
@@ -979,6 +982,10 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     device=float_workspace_buffer.device,
                 )
         self._backend = backend
+        # plan() overwrites _backend with the concrete choice; a later plan()
+        # with a longer max_context_len needs a different AITER variant, so it
+        # still has to know the caller asked for auto.
+        self._backend_requested = backend
         self._backend_fallback_reason: Optional[str] = None
         # ROCm never supports PDL; cache once to avoid per-call device property lookup.
         self._pdl_supported = device_support_pdl(float_workspace_buffer.device)
@@ -1195,12 +1202,11 @@ class BatchDecodeWithPagedKVCacheWrapper:
         # capturing at the maximum sequence length. AITER decode under CUDA graph is
         # therefore opt-in via an explicit backend="aiter" (see the capture-at-max
         # warning below), not something `auto` selects silently.
-        resolved_from_auto = False
+        resolved_from_auto = self._backend_requested == "auto"
         if self._backend == "auto":
             if self.use_tensor_cores or self.is_cuda_graph_enabled:
                 self._backend = "fa2"
             else:
-                resolved_from_auto = True
                 self._backend, self._backend_fallback_reason = (
                     _auto_select_prefill_backend(
                         self.device,
@@ -1277,6 +1283,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                         logits_soft_cap,
                         aiter_sliding_window,
                         _AITER_PA_V1_PARTITION_SIZE,
+                        self.device.index if self.device.index is not None else 0,
                     )
                 else:
                     resolved = _aiter_pa_v1_resolve(

--- a/flashinfer/decode_rocm.py
+++ b/flashinfer/decode_rocm.py
@@ -31,6 +31,7 @@ from .jit import (
     get_batch_decode_uri,
     get_single_decode_uri,
 )
+from .aiter_utils import handle_aiter_probe_failure
 from .jit.core import logger
 from .page import get_seq_lens
 from .prefill_rocm import (
@@ -461,6 +462,49 @@ def _aiter_pa_v1_resolve(
     func_name = func.__name__
     so_path = f"{BUILD_DIR}/{func_name}/lib.so"
     return so_path, func_name
+
+
+# maxsize bounds a key that carries per-request max_context_len; only
+# ceil(max_context_len / (partition_size * warp_size)) reaches the compiler, so
+# the entries are near-duplicates. Caching the success also spares every later
+# plan() a round trip through AITER's compile() machinery.
+@functools.lru_cache(maxsize=128)
+def _aiter_pa_v1_available(
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+    dtype_o: torch.dtype,
+    head_dim: int,
+    num_qo_heads: int,
+    num_kv_heads: int,
+    page_size: int,
+    max_context_len: int,
+    logits_soft_cap: float,
+    sliding_window: int,
+    partition_size: int,
+) -> Tuple[Optional[Tuple[str, str]], Optional[str]]:
+    """Resolve AITER PA v1 for this problem; returns ((so_path, func_name), None)
+    or (None, reason) when this AITER install cannot build the variant.
+
+    Positional-only by convention: lru_cache keys kwargs by insertion order, so
+    keyword calls would make argument order a silent cache-miss hazard.
+    """
+    try:
+        resolved = _aiter_pa_v1_resolve(
+            dtype_q=dtype_q,
+            dtype_kv=dtype_kv,
+            dtype_o=dtype_o,
+            head_dim=head_dim,
+            num_qo_heads=num_qo_heads,
+            num_kv_heads=num_kv_heads,
+            page_size=page_size,
+            max_context_len=max_context_len,
+            logits_soft_cap=logits_soft_cap,
+            sliding_window=sliding_window,
+            partition_size=partition_size,
+        )
+    except Exception as e:
+        return None, handle_aiter_probe_failure(e, op="batch_decode")
+    return resolved, None
 
 
 def single_decode_with_kv_cache_with_jit_module(
@@ -1151,10 +1195,12 @@ class BatchDecodeWithPagedKVCacheWrapper:
         # capturing at the maximum sequence length. AITER decode under CUDA graph is
         # therefore opt-in via an explicit backend="aiter" (see the capture-at-max
         # warning below), not something `auto` selects silently.
+        resolved_from_auto = False
         if self._backend == "auto":
             if self.use_tensor_cores or self.is_cuda_graph_enabled:
                 self._backend = "fa2"
             else:
+                resolved_from_auto = True
                 self._backend, self._backend_fallback_reason = (
                     _auto_select_prefill_backend(
                         self.device,
@@ -1195,72 +1241,104 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     "captured will be incorrect. Use backend='fa2' if you need "
                     "capture-order-independent CUDA-graph decode."
                 )
-            self._max_kv_len = int(max(kv_lens_arr_host).item())
+            max_kv_len = int(max(kv_lens_arr_host).item())
             # max blocks per seq across the batch — needed to size the dense block_tables.
             npages_arr = indptr_host[1:].to(torch.int64) - indptr_host[:-1].to(
                 torch.int64
             )
-            self._aiter_max_blocks_per_seq = (
+            aiter_max_blocks_per_seq = (
                 int(npages_arr.max().item()) if batch_size > 0 else 0
             )
-            self._aiter_partition_size = _AITER_PA_V1_PARTITION_SIZE
             # Convention mapping: flashinfer's window_left = W means the query at
             # position kv_len-1 sees kv positions [kv_len-1-W, kv_len-1] (W+1 tokens).
             # AITER's sliding_window = S masks positions where local_token_idx + i <
             # context_len - S, so it admits S tokens. Therefore S = W + 1. The sentinel
             # window_left == -1 (disabled) maps to S = 0, which is also AITER's compile-
             # time "disabled" flag (sliding_window_enabled = (S > 0)).
-            self._aiter_sliding_window = 0 if window_left == -1 else window_left + 1
+            aiter_sliding_window = 0 if window_left == -1 else window_left + 1
 
-            self._cached_module = get_batch_decode_aiter_module(
-                q_data_type, kv_data_type, q_data_type, head_dim, head_dim
-            )
             # Bootstrap & resolve (so_path, func_name) — this triggers AITER's own JIT
             # build of the variant .so on first call for this template-param combination.
+            # Held in locals and committed only on success: a demotion to fa2 below must
+            # leave no half-written _aiter_* state, since run() gates on _backend alone.
+            resolved = None
+            reason = None
             with _aiter_bootstrap_lock:
-                self._aiter_so_path, self._aiter_func_name = _aiter_pa_v1_resolve(
-                    dtype_q=q_data_type,
-                    dtype_kv=kv_data_type,
-                    dtype_o=q_data_type,
-                    head_dim=head_dim,
-                    num_qo_heads=num_qo_heads,
-                    num_kv_heads=num_kv_heads,
-                    page_size=page_size,
-                    max_context_len=self._max_kv_len,
-                    logits_soft_cap=logits_soft_cap,
-                    sliding_window=self._aiter_sliding_window,
-                    partition_size=self._aiter_partition_size,
+                if resolved_from_auto:
+                    resolved, reason = _aiter_pa_v1_available(
+                        q_data_type,
+                        kv_data_type,
+                        q_data_type,
+                        head_dim,
+                        num_qo_heads,
+                        num_kv_heads,
+                        page_size,
+                        max_kv_len,
+                        logits_soft_cap,
+                        aiter_sliding_window,
+                        _AITER_PA_V1_PARTITION_SIZE,
+                    )
+                else:
+                    resolved = _aiter_pa_v1_resolve(
+                        dtype_q=q_data_type,
+                        dtype_kv=kv_data_type,
+                        dtype_o=q_data_type,
+                        head_dim=head_dim,
+                        num_qo_heads=num_qo_heads,
+                        num_kv_heads=num_kv_heads,
+                        page_size=page_size,
+                        max_context_len=max_kv_len,
+                        logits_soft_cap=logits_soft_cap,
+                        sliding_window=aiter_sliding_window,
+                        partition_size=_AITER_PA_V1_PARTITION_SIZE,
+                    )
+
+            if reason is None:
+                self._max_kv_len = max_kv_len
+                self._aiter_max_blocks_per_seq = aiter_max_blocks_per_seq
+                self._aiter_partition_size = _AITER_PA_V1_PARTITION_SIZE
+                self._aiter_sliding_window = aiter_sliding_window
+                self._cached_module = get_batch_decode_aiter_module(
+                    q_data_type, kv_data_type, q_data_type, head_dim, head_dim
                 )
-            # Skip FA2-style plan_info; AITER kernel doesn't use it.
-            self._plan_info = plan_info_vec_as_tensor(
-                [], device=self._float_workspace_buffer.device
-            )
+                self._aiter_so_path, self._aiter_func_name = resolved
+                # Skip FA2-style plan_info; AITER kernel doesn't use it.
+                self._plan_info = plan_info_vec_as_tensor(
+                    [], device=self._float_workspace_buffer.device
+                )
 
-            # FA2 shadow plan for return_lse=True; built lazily (AITER PA v1 has no LSE).
-            self._fa2_lse_module: Optional[Any] = None
-            self._fa2_lse_plan_info: Optional[torch.Tensor] = None
-            self._fa2_lse_build_args = (
-                q_data_type,
-                kv_data_type,
-                indptr.dtype,
-                head_dim,
-                pos_encoding_mode,
-                window_left,
-                logits_soft_cap,
-                indptr_host,
-                batch_size,
-                num_qo_heads,
-                num_kv_heads,
-                page_size,
-            )
+                # FA2 shadow plan for return_lse=True; built lazily (AITER PA v1 has no LSE).
+                self._fa2_lse_module: Optional[Any] = None
+                self._fa2_lse_plan_info: Optional[torch.Tensor] = None
+                self._fa2_lse_build_args = (
+                    q_data_type,
+                    kv_data_type,
+                    indptr.dtype,
+                    head_dim,
+                    pos_encoding_mode,
+                    window_left,
+                    logits_soft_cap,
+                    indptr_host,
+                    batch_size,
+                    num_qo_heads,
+                    num_kv_heads,
+                    page_size,
+                )
 
-            self._pos_encoding_mode = pos_encoding_mode
-            self._window_left = window_left
-            self._logits_soft_cap = logits_soft_cap
-            self._sm_scale = sm_scale
-            self._rope_scale = rope_scale
-            self._rope_theta = rope_theta
-            return
+                self._pos_encoding_mode = pos_encoding_mode
+                self._window_left = window_left
+                self._logits_soft_cap = logits_soft_cap
+                self._sm_scale = sm_scale
+                self._rope_scale = rope_scale
+                self._rope_theta = rope_theta
+                return
+
+            # auto promised fa2 when AITER cannot serve; fall through to it below.
+            # Reachable only from the auto path, which already excludes
+            # use_tensor_cores and CUDA graphs, so the landing site is the plain
+            # decode branch.
+            self._backend = "fa2"
+            self._backend_fallback_reason = reason
 
         if self.use_tensor_cores:
             self._max_kv_len = max(kv_lens_arr_host).item()

--- a/flashinfer/prefill_rocm.py
+++ b/flashinfer/prefill_rocm.py
@@ -1879,6 +1879,11 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._mask_indptr_buf = mask_indptr_buf
         self._max_total_num_rows = None
         self._backend = backend
+        # plan() overwrites _backend with the concrete choice, so it cannot say
+        # whether the *caller* asked for auto. Later plan() calls need that: the
+        # probe key varies per call (causal, dtype), so a wrapper that planned
+        # once on AITER can still meet an unbuildable variant later.
+        self._backend_requested = backend
         self._backend_fallback_reason: Optional[str] = None
         self._plan_info: Optional[torch.Tensor] = None
         self._cached_module = None
@@ -2226,12 +2231,11 @@ class BatchPrefillWithPagedKVCacheWrapper:
             use_fp16_qk_reduction,
         )
 
-        resolved_from_auto = False
+        resolved_from_auto = self._backend_requested == "auto"
         if self._jit_module is not None:
             self._cached_module = self._jit_module
         else:
             if self._backend == "auto":
-                resolved_from_auto = True
                 self._backend, self._backend_fallback_reason = (
                     _auto_select_prefill_backend(
                         self.device,
@@ -2291,7 +2295,13 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     # let the C++ dlopen fail inside run().  The helper compiles both
                     # has_lse variants because plan() can't know which one run() will
                     # request; causal is fixed per plan() call.
-                    if resolved_from_auto:
+                    # Demoting after a graph capture would null the flat-gather
+                    # buffers the captured graph still points at, so once they
+                    # exist under capture the failure has to stay an exception.
+                    if resolved_from_auto and not (
+                        self.is_cuda_graph_enabled
+                        and self._aiter_flat_gather_idx is not None
+                    ):
                         reason = _aiter_batch_ragged_available(
                             q_data_type, has_logits, causal, head_dim_qk, dev_idx
                         )
@@ -2951,6 +2961,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._mask_indptr_buf = mask_indptr_buf
         self._max_total_num_rows = None
         self._backend = backend
+        # See the paged wrapper: _backend goes concrete after the first plan(),
+        # so the caller's original request has to be kept separately.
+        self._backend_requested = backend
         self._backend_fallback_reason: Optional[str] = None
         self._plan_info: Optional[torch.Tensor] = None
         self._cached_module = None
@@ -3218,12 +3231,11 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             use_fp16_qk_reduction,
         )
 
-        resolved_from_auto = False
+        resolved_from_auto = self._backend_requested == "auto"
         if self._jit_module is not None:
             self._cached_module = self._jit_module
         else:
             if self._backend == "auto":
-                resolved_from_auto = True
                 self._backend, self._backend_fallback_reason = (
                     _auto_select_prefill_backend(
                         self.device,

--- a/flashinfer/prefill_rocm.py
+++ b/flashinfer/prefill_rocm.py
@@ -25,6 +25,7 @@ from types import SimpleNamespace
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union, overload
 
 import torch
+from .aiter_utils import handle_aiter_probe_failure
 from .arch_caps import capability_reason, require_capability
 from .jit.core import logger
 from .jit import (
@@ -634,6 +635,67 @@ def _aiter_native_paging_available(
         )
         return False
     return True
+
+
+# The two probes below answer a different question from _aiter_native_paging_available:
+# not "which AITER kernel", but "can this AITER install produce any kernel for this
+# variant". They return the fallback reason instead of a bool because it feeds
+# backend_fallback_reason, and it has to be memoized with the outcome or the second
+# plan() reports a demotion it cannot explain. Same lru_cache rationale as above:
+# exceptions are not memoized, so a failing build must not be retried per plan().
+
+
+@functools.lru_cache(maxsize=None)
+def _aiter_single_prefill_available(
+    dtype: torch.dtype,
+    causal: bool,
+    has_lse: bool,
+    has_logits_cap: bool,
+    head_dim: int,
+    device_idx: int,
+) -> Optional[str]:
+    """Probe whether AITER can serve single prefill here; None means it can.
+
+    amd-aiter ships no prebuilt mha_fwd .so, so this variant is JIT-built on
+    first use and can fail for reasons that are the install's, not the caller's
+    — e.g. a site-packages AITER cannot write its built module into.
+    """
+    torch.cuda.synchronize(device_idx)
+    try:
+        if has_logits_cap:
+            _aiter_bootstrap_single_prefill_varlen(dtype, causal, head_dim, device_idx)
+        else:
+            _aiter_bootstrap_single_prefill_mha_fwd(
+                dtype, causal, has_lse, head_dim, device_idx
+            )
+        torch.cuda.synchronize(device_idx)
+    except Exception as e:
+        return handle_aiter_probe_failure(e, op="single_prefill")
+    return None
+
+
+@functools.lru_cache(maxsize=None)
+def _aiter_batch_ragged_available(
+    dtype: torch.dtype,
+    has_logits_cap: bool,
+    causal: bool,
+    head_dim: int,
+    device_idx: int,
+) -> Optional[str]:
+    """Probe whether AITER can serve the varlen batch-prefill path; None means it can.
+
+    Keyed exactly like _aiter_bootstrap_batch_ragged_prefill, so the paged and
+    ragged wrappers share one cache entry per variant.
+    """
+    torch.cuda.synchronize(device_idx)
+    try:
+        _aiter_bootstrap_batch_ragged_prefill(
+            dtype, has_logits_cap, causal, head_dim, device_idx
+        )
+        torch.cuda.synchronize(device_idx)
+    except Exception as e:
+        return handle_aiter_probe_failure(e, op="batch_prefill")
+    return None
 
 
 @functools.cache
@@ -1436,6 +1498,7 @@ def single_prefill_with_kv_cache(
         if scale_v is None:
             scale_v = torch.ones(v.shape[1], dtype=torch.float32, device=q.device)
 
+    resolved_from_auto = backend == "auto"
     if backend == "auto":
         backend, _ = _auto_select_prefill_backend(
             q.device,
@@ -1450,6 +1513,8 @@ def single_prefill_with_kv_cache(
         )
 
     if backend == "aiter":
+        # Outside the probe on purpose: this raises ArchCapabilityError, which
+        # gates known-bad toolchains and must never be demoted to a silent fa2.
         _require_aiter_runtime(q.device, "single_prefill")
         if pos_encoding_mode != "NONE":
             raise ValueError(
@@ -1462,14 +1527,29 @@ def single_prefill_with_kv_cache(
         # logits_soft_cap == 0 takes the mha_fwd .so, none of whose variants are
         # pre-shipped — JIT-build the exact (dtype, causal, has_lse) we need.
         with _aiter_bootstrap_lock:
-            if logits_soft_cap > 0:
-                _aiter_bootstrap_single_prefill_varlen(
-                    q.dtype, causal, q.shape[-1], q.device.index or 0
+            if resolved_from_auto:
+                # auto promised "AITER when possible, otherwise fa2", and whether
+                # AITER can build this variant is only knowable here.
+                reason = _aiter_single_prefill_available(
+                    q.dtype,
+                    causal,
+                    return_lse,
+                    logits_soft_cap > 0,
+                    q.shape[-1],
+                    q.device.index or 0,
                 )
             else:
-                _aiter_bootstrap_single_prefill_mha_fwd(
-                    q.dtype, causal, return_lse, q.shape[-1], q.device.index or 0
-                )
+                reason = None
+                if logits_soft_cap > 0:
+                    _aiter_bootstrap_single_prefill_varlen(
+                        q.dtype, causal, q.shape[-1], q.device.index or 0
+                    )
+                else:
+                    _aiter_bootstrap_single_prefill_mha_fwd(
+                        q.dtype, causal, return_lse, q.shape[-1], q.device.index or 0
+                    )
+        if reason is not None:
+            backend = "fa2"
 
     # o_dtype should be provided for FP8 attention
     if o_dtype is None:
@@ -2131,10 +2211,27 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._cached_q_data_type = q_data_type
         self._cached_kv_data_type = kv_data_type
 
+        # Hoisted above the jit-module split: backend-independent, and the fa2
+        # re-get on an AITER demotion below needs it too.
+        get_module_args = (
+            q_data_type,
+            kv_data_type,
+            q_data_type,
+            paged_kv_indptr.dtype,
+            head_dim_qk,
+            head_dim_vo,
+            PosEncodingMode[pos_encoding_mode].value,
+            window_left >= 0,  # use_sliding_window
+            logits_soft_cap > 0,  # use_logits_soft_cap
+            use_fp16_qk_reduction,
+        )
+
+        resolved_from_auto = False
         if self._jit_module is not None:
             self._cached_module = self._jit_module
         else:
             if self._backend == "auto":
+                resolved_from_auto = True
                 self._backend, self._backend_fallback_reason = (
                     _auto_select_prefill_backend(
                         self.device,
@@ -2159,22 +2256,57 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     "use backend='fa2' or backend='auto' instead."
                 )
             if self._backend != "cudnn":
-                get_module_args = (
-                    q_data_type,
-                    kv_data_type,
-                    q_data_type,
-                    paged_kv_indptr.dtype,
-                    head_dim_qk,
-                    head_dim_vo,
-                    PosEncodingMode[pos_encoding_mode].value,
-                    window_left >= 0,  # use_sliding_window
-                    logits_soft_cap > 0,  # use_logits_soft_cap
-                    use_fp16_qk_reduction,
-                )
-
                 self._cached_module = get_batch_prefill_module(
                     self._backend, *get_module_args
                 )
+
+        # Decide native-paged vs flat-gather ONCE. run() dispatches on whether
+        # self._aiter_flat_gather_idx is set, so a single decision here is what
+        # keeps the bootstrapped .so and the kernel run() reaches in agreement.
+        # Bootstrapping AITER's lazy JIT is also the probe: it launches the real
+        # kernel, so a config the installed AITER cannot serve fails here, at
+        # plan() time, and degrades to flat-gather instead of killing run().
+        # Runs before _plan_info below, so a demotion to fa2 cannot strand plan
+        # bookkeeping built against the AITER module.
+        use_native_paging = False
+        if self._backend == "aiter":
+            dev_idx = self.device.index if self.device.index is not None else 0
+            has_logits = logits_soft_cap > 0
+            reason = None
+            with _aiter_bootstrap_lock:
+                if page_size in _aiter_native_page_sizes():
+                    use_native_paging = _aiter_native_paging_available(
+                        q_data_type,
+                        has_logits,
+                        causal,
+                        page_size,
+                        head_dim_qk,
+                        dev_idx,
+                    )
+                if not use_native_paging:
+                    # The flat-gather route dispatches through
+                    # get_aiter_mha_varlen_fwd_handle, whose .so variant is keyed on
+                    # (dtype, causal, has_lse, has_logits_cap).  AITER pre-ships only
+                    # a subset of that family, so bootstrap the rest here rather than
+                    # let the C++ dlopen fail inside run().  The helper compiles both
+                    # has_lse variants because plan() can't know which one run() will
+                    # request; causal is fixed per plan() call.
+                    if resolved_from_auto:
+                        reason = _aiter_batch_ragged_available(
+                            q_data_type, has_logits, causal, head_dim_qk, dev_idx
+                        )
+                    else:
+                        _aiter_bootstrap_batch_ragged_prefill(
+                            q_data_type,
+                            has_logits,
+                            causal,
+                            head_dim_qk,
+                            dev_idx,
+                        )
+            if reason is not None:
+                self._backend = "fa2"
+                self._backend_fallback_reason = reason
+                self._cached_module = get_batch_prefill_module("fa2", *get_module_args)
 
         self._block_tables = block_tables
 
@@ -2210,42 +2342,6 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._rope_theta = rope_theta
         self._seq_lens_kv = seq_lens
         self._seq_lens_q = seq_lens_q if seq_lens_q is not None else seq_lens
-
-        # Decide native-paged vs flat-gather ONCE. run() dispatches on whether
-        # self._aiter_flat_gather_idx is set, so a single decision here is what
-        # keeps the bootstrapped .so and the kernel run() reaches in agreement.
-        # Bootstrapping AITER's lazy JIT is also the probe: it launches the real
-        # kernel, so a config the installed AITER cannot serve fails here, at
-        # plan() time, and degrades to flat-gather instead of killing run().
-        use_native_paging = False
-        if self._backend == "aiter":
-            dev_idx = self.device.index if self.device.index is not None else 0
-            has_logits = logits_soft_cap > 0
-            with _aiter_bootstrap_lock:
-                if page_size in _aiter_native_page_sizes():
-                    use_native_paging = _aiter_native_paging_available(
-                        q_data_type,
-                        has_logits,
-                        causal,
-                        page_size,
-                        head_dim_qk,
-                        dev_idx,
-                    )
-                if not use_native_paging:
-                    # The flat-gather route dispatches through
-                    # get_aiter_mha_varlen_fwd_handle, whose .so variant is keyed on
-                    # (dtype, causal, has_lse, has_logits_cap).  AITER pre-ships only
-                    # a subset of that family, so bootstrap the rest here rather than
-                    # let the C++ dlopen fail inside run().  The helper compiles both
-                    # has_lse variants because plan() can't know which one run() will
-                    # request; causal is fixed per plan() call.
-                    _aiter_bootstrap_batch_ragged_prefill(
-                        q_data_type,
-                        has_logits,
-                        causal,
-                        head_dim_qk,
-                        dev_idx,
-                    )
 
         # Pre-compute flat-KV gather indices whenever AITER is not serving this
         # page size natively.  These are stored as GPU tensors so that the
@@ -3107,10 +3203,27 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._token_pos_in_items_len = token_pos_in_items_len
         self._max_item_len_ptr = max_item_len_ptr
 
+        # Hoisted above the jit-module split: backend-independent, and the fa2
+        # re-get on an AITER demotion below needs it too.
+        get_module_args = (
+            q_data_type,
+            kv_data_type,
+            q_data_type,
+            kv_indptr.dtype,
+            head_dim_qk,
+            head_dim_vo,
+            PosEncodingMode[pos_encoding_mode].value,
+            window_left >= 0,  # use_sliding_window
+            logits_soft_cap > 0,  # use_logits_soft_cap
+            use_fp16_qk_reduction,
+        )
+
+        resolved_from_auto = False
         if self._jit_module is not None:
             self._cached_module = self._jit_module
         else:
             if self._backend == "auto":
+                resolved_from_auto = True
                 self._backend, self._backend_fallback_reason = (
                     _auto_select_prefill_backend(
                         self.device,
@@ -3134,21 +3247,39 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     f"AITER backend only supports kv_layout='NHD'; got {self._kv_layout!r}. "
                     "use backend='fa2' or backend='auto' instead."
                 )
-            get_module_args = (
-                q_data_type,
-                kv_data_type,
-                q_data_type,
-                kv_indptr.dtype,
-                head_dim_qk,
-                head_dim_vo,
-                PosEncodingMode[pos_encoding_mode].value,
-                window_left >= 0,  # use_sliding_window
-                logits_soft_cap > 0,  # use_logits_soft_cap
-                use_fp16_qk_reduction,
-            )
             self._cached_module = get_batch_prefill_module(
                 self._backend, *get_module_args
             )
+
+        # Bootstrap AITER's lazy JIT so the C++ dlopen finds mha_varlen_fwd_*.so
+        # for the (dtype, causal, has_logits) combo this plan() call will use.
+        # Stays outside the jit-module split above -- jit_args with an explicit
+        # backend="aiter" still needs the .so -- and runs before _plan_info below
+        # so a demotion to fa2 cannot strand plan bookkeeping built for AITER.
+        if self._backend == "aiter":
+            dev_idx = self.device.index if self.device.index is not None else 0
+            reason = None
+            with _aiter_bootstrap_lock:
+                if resolved_from_auto:
+                    reason = _aiter_batch_ragged_available(
+                        q_data_type,
+                        logits_soft_cap > 0,
+                        causal,
+                        head_dim_qk,
+                        dev_idx,
+                    )
+                else:
+                    _aiter_bootstrap_batch_ragged_prefill(
+                        q_data_type,
+                        logits_soft_cap > 0,
+                        causal,
+                        head_dim_qk,
+                        dev_idx,
+                    )
+            if reason is not None:
+                self._backend = "fa2"
+                self._backend_fallback_reason = reason
+                self._cached_module = get_batch_prefill_module("fa2", *get_module_args)
 
         assert self._cached_module is not None, "cached module is not initialized"
         self._plan_info = self._cached_module.plan(
@@ -3180,19 +3311,6 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._sm_scale: float = sm_scale
         self._rope_scale: float = rope_scale
         self._rope_theta: float = rope_theta
-
-        # Bootstrap AITER's lazy JIT so the C++ dlopen finds mha_varlen_fwd_*.so
-        # for the (dtype, causal, has_logits) combo this plan() call will use.
-        if self._backend == "aiter":
-            dev_idx = self.device.index if self.device.index is not None else 0
-            with _aiter_bootstrap_lock:
-                _aiter_bootstrap_batch_ragged_prefill(
-                    q_data_type,
-                    logits_soft_cap > 0,
-                    causal,
-                    head_dim_qk,
-                    dev_idx,
-                )
 
     begin_forward = plan
 

--- a/tests/rocm_tests/test_aiter_auto_fallback_hip.py
+++ b/tests/rocm_tests/test_aiter_auto_fallback_hip.py
@@ -1,0 +1,564 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""``backend="auto"`` must demote to fa2 when AITER cannot build a kernel.
+
+The capability table and the aiter import probe both run before AITER's
+per-variant .so is built, so a build that cannot compile — or cannot install
+into a site-packages it does not own — fails only at plan()/call time. Each
+test makes the relevant AITER bootstrap raise the failure observed on gfx950
+(``ModuleNotFoundError`` after a successful compile) and requires ``auto`` to
+fall back, while explicit ``backend="aiter"`` still raises.
+
+Two harness notes, both of which silently void these tests if ignored:
+
+- The probes are ``lru_cache``d, so every test clears them in a ``finally``.
+  ``get_*_module`` memoize *successes*, so a test running after a passing AITER
+  test would otherwise never reach the patched bootstrap at all.
+- ``caplog`` does not capture flashinfer's logger. It is a
+  ``FlashInferJITLogger`` built directly at ``jit/core.py``, bypassing
+  ``logging.getLogger``, so ``.parent`` is None and records never reach the root
+  handler caplog installs. Patch ``logger.warning`` instead.
+"""
+
+import logging
+
+import pytest
+import torch
+
+import flashinfer
+import flashinfer.decode_rocm
+import flashinfer.prefill_rocm
+from flashinfer.aiter_utils import is_aiter_supported
+from flashinfer.arch_caps import ArchCapabilityError, capability_available
+from flashinfer.decode_rocm import _aiter_pa_v1_available
+from flashinfer.jit.core import MissingJITCacheError, logger
+from flashinfer.prefill_rocm import (
+    _aiter_batch_ragged_available,
+    _aiter_native_paging_available,
+    _aiter_ops_importable,
+    _aiter_single_prefill_available,
+)
+
+logger.setLevel(logging.ERROR)
+
+# The exact failure measured on gfx950: AITER's own JIT built the variant, then
+# could not install it into a site-packages owned by another user.
+_INSTALL_FAILURE = ModuleNotFoundError(
+    "No module named 'aiter.jit.module_mha_fwd_bf16_causal'"
+)
+
+_ALL_PROBES = (
+    _aiter_single_prefill_available,
+    _aiter_batch_ragged_available,
+    _aiter_pa_v1_available,
+    _aiter_native_paging_available,
+)
+
+
+def _clear_probes():
+    for probe in _ALL_PROBES:
+        probe.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def clear_probe_caches():
+    _clear_probes()
+    yield
+    _clear_probes()
+
+
+@pytest.fixture
+def device():
+    dev = torch.device("cuda:0")
+    if not is_aiter_supported(dev) or not _aiter_ops_importable():
+        pytest.skip("AITER requires a gfx942/gfx950 GPU and the aiter package")
+    return dev
+
+
+def _raiser(exc):
+    def _raise(*args, **kwargs):
+        raise exc
+
+    return _raise
+
+
+def _skip_if_op_gated(device, op):
+    """Skip when the capability table already steers auto away from AITER.
+
+    With the gate active the selector returns fa2 before any probe runs, so
+    there is no demotion left to observe. Currently hits batch_prefill on
+    gfx950/ROCm 7.2.x; single_prefill and batch_decode are ungated.
+    """
+    if not capability_available(device, op, "aiter"):
+        pytest.skip(f"capability table gates AITER {op} on this toolchain")
+
+
+# --------------------------------------------------------------------------
+# Site 1 -- single prefill
+# --------------------------------------------------------------------------
+
+
+def _single_prefill_inputs(device, dtype=torch.bfloat16):
+    torch.manual_seed(0)
+    qo_len, kv_len, num_heads, head_dim = 64, 128, 8, 128
+    q = torch.randn(qo_len, num_heads, head_dim, device=device, dtype=dtype)
+    k = torch.randn(kv_len, num_heads, head_dim, device=device, dtype=dtype)
+    v = torch.randn(kv_len, num_heads, head_dim, device=device, dtype=dtype)
+    return q, k, v
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_single_prefill_auto_demotes_to_fa2(device, monkeypatch, causal):
+    """auto must produce fa2 numerics, not raise, when the mha_fwd build fails."""
+    _skip_if_op_gated(device, "single_prefill")
+    q, k, v = _single_prefill_inputs(device)
+
+    # Record which backend actually built: single prefill is a free function with
+    # no _backend attribute, so absence of a crash is not evidence of fa2.
+    built = []
+    real_get = flashinfer.prefill_rocm.get_single_prefill_module
+
+    def _recording_get(backend, *args):
+        built.append(backend)
+        return real_get(backend, *args)
+
+    monkeypatch.setattr(
+        flashinfer.prefill_rocm,
+        "_aiter_bootstrap_single_prefill_mha_fwd",
+        _raiser(_INSTALL_FAILURE),
+    )
+    monkeypatch.setattr(
+        flashinfer.prefill_rocm, "get_single_prefill_module", _recording_get
+    )
+
+    out = flashinfer.prefill_rocm.single_prefill_with_kv_cache(
+        q, k, v, causal=causal, backend="auto"
+    )
+
+    assert built == ["fa2"], f"expected the fa2 module to be built, got {built}"
+
+    monkeypatch.undo()
+    ref = flashinfer.prefill_rocm.single_prefill_with_kv_cache(
+        q, k, v, causal=causal, backend="fa2"
+    )
+    torch.testing.assert_close(out, ref, rtol=1e-3, atol=1e-3)
+
+
+def test_single_prefill_explicit_aiter_still_raises(device, monkeypatch):
+    """The demotion is auto-only; an explicit opt-in keeps its hard error."""
+    _skip_if_op_gated(device, "single_prefill")
+    q, k, v = _single_prefill_inputs(device)
+    monkeypatch.setattr(
+        flashinfer.prefill_rocm,
+        "_aiter_bootstrap_single_prefill_mha_fwd",
+        _raiser(_INSTALL_FAILURE),
+    )
+    with pytest.raises(ModuleNotFoundError):
+        flashinfer.prefill_rocm.single_prefill_with_kv_cache(
+            q, k, v, causal=False, backend="aiter"
+        )
+
+
+def test_single_prefill_strict_env_raises(device, monkeypatch):
+    """FLASHINFER_AITER_STRICT=1 opts out of demotion entirely."""
+    _skip_if_op_gated(device, "single_prefill")
+    q, k, v = _single_prefill_inputs(device)
+    monkeypatch.setenv("FLASHINFER_AITER_STRICT", "1")
+    monkeypatch.setattr(
+        flashinfer.prefill_rocm,
+        "_aiter_bootstrap_single_prefill_mha_fwd",
+        _raiser(_INSTALL_FAILURE),
+    )
+    with pytest.raises(ModuleNotFoundError):
+        flashinfer.prefill_rocm.single_prefill_with_kv_cache(
+            q, k, v, causal=False, backend="auto"
+        )
+
+
+def test_single_prefill_warns_once(device, monkeypatch):
+    """A second call reuses the cached verdict: no rebuild, no second warning."""
+    _skip_if_op_gated(device, "single_prefill")
+    q, k, v = _single_prefill_inputs(device)
+
+    attempts = []
+
+    def _count_and_raise(*args, **kwargs):
+        attempts.append(1)
+        raise _INSTALL_FAILURE
+
+    warnings = []
+    monkeypatch.setattr(
+        flashinfer.prefill_rocm,
+        "_aiter_bootstrap_single_prefill_mha_fwd",
+        _count_and_raise,
+    )
+    # caplog cannot see this logger; patch the method instead.
+    monkeypatch.setattr(
+        flashinfer.aiter_utils.logger,
+        "warning",
+        lambda *a, **kw: warnings.append(a),
+    )
+
+    for _ in range(2):
+        flashinfer.prefill_rocm.single_prefill_with_kv_cache(
+            q, k, v, causal=False, backend="auto"
+        )
+
+    assert len(attempts) == 1, (
+        f"the failing AITER build was retried {len(attempts)} times; "
+        "the probe verdict is not being memoized"
+    )
+    assert len(warnings) == 1, f"expected one warning, got {len(warnings)}"
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ValueError("caller contract violation"),
+        torch.cuda.OutOfMemoryError("transient"),
+        ArchCapabilityError("known-bad toolchain"),
+        MissingJITCacheError("flashinfer AOT cache missing"),
+    ],
+    ids=["value", "oom", "arch_gate", "jit_cache"],
+)
+def test_non_demotable_failures_propagate(device, monkeypatch, exc):
+    """These are not "AITER cannot build this variant" and must not become fa2.
+
+    Also asserts the verdict was not cached: caching an OOM would downgrade the
+    config for the rest of the process.
+    """
+    _skip_if_op_gated(device, "single_prefill")
+    q, k, v = _single_prefill_inputs(device)
+    monkeypatch.setattr(
+        flashinfer.prefill_rocm,
+        "_aiter_bootstrap_single_prefill_mha_fwd",
+        _raiser(exc),
+    )
+    with pytest.raises(type(exc)):
+        flashinfer.prefill_rocm.single_prefill_with_kv_cache(
+            q, k, v, causal=False, backend="auto"
+        )
+    assert _aiter_single_prefill_available.cache_info().currsize == 0, (
+        "a non-demotable failure was cached as a verdict"
+    )
+
+
+# --------------------------------------------------------------------------
+# Sites 2 and 3 -- paged and ragged batch prefill
+# --------------------------------------------------------------------------
+
+
+def _paged_inputs(device, page_size=16, dtype=torch.bfloat16):
+    torch.manual_seed(0)
+    batch_size, qo_len, kv_len = 2, 16, 128
+    num_qo_heads = num_kv_heads = 8
+    head_dim = 128
+    num_pages = (kv_len + page_size - 1) // page_size
+    total_pages = num_pages * batch_size
+    q = torch.randn(
+        batch_size * qo_len, num_qo_heads, head_dim, device=device, dtype=dtype
+    )
+    kv_data = torch.randn(
+        total_pages, 2, page_size, num_kv_heads, head_dim, device=device, dtype=dtype
+    )
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * qo_len
+    )
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * num_pages
+    )
+    kv_indices = torch.arange(0, total_pages, dtype=torch.int32, device=device)
+    kv_last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device=device
+    )
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+    return (
+        q,
+        kv_data,
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        workspace,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+    )
+
+
+def test_paged_prefill_auto_demotes_to_fa2(device, monkeypatch):
+    _skip_if_op_gated(device, "batch_prefill")
+    (
+        q,
+        kv_data,
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        workspace,
+        nqo,
+        nkv,
+        head_dim,
+        page_size,
+    ) = _paged_inputs(device)
+
+    monkeypatch.setattr(
+        flashinfer.prefill_rocm,
+        "_aiter_bootstrap_batch_ragged_prefill",
+        _raiser(_INSTALL_FAILURE),
+    )
+
+    wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace, "NHD", backend="auto"
+    )
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        nqo,
+        nkv,
+        head_dim,
+        page_size,
+        causal=True,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    assert wrapper._backend == "fa2"
+    assert wrapper.backend_fallback_reason.startswith(
+        "aiter batch_prefill kernel bootstrap failed"
+    )
+    out = wrapper.run(q, kv_data)
+
+    monkeypatch.undo()
+    ref_wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace, "NHD", backend="fa2"
+    )
+    ref_wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        nqo,
+        nkv,
+        head_dim,
+        page_size,
+        causal=True,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+    )
+    torch.testing.assert_close(out, ref_wrapper.run(q, kv_data), rtol=1e-3, atol=1e-3)
+
+
+def test_ragged_prefill_auto_demotes_to_fa2(device, monkeypatch):
+    _skip_if_op_gated(device, "batch_prefill")
+    torch.manual_seed(0)
+    batch_size, qo_len, kv_len = 2, 16, 128
+    nqo = nkv = 8
+    head_dim = 128
+    dtype = torch.bfloat16
+    q = torch.randn(batch_size * qo_len, nqo, head_dim, device=device, dtype=dtype)
+    k = torch.randn(batch_size * kv_len, nkv, head_dim, device=device, dtype=dtype)
+    v = torch.randn(batch_size * kv_len, nkv, head_dim, device=device, dtype=dtype)
+    qo_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * qo_len
+    )
+    kv_indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * kv_len
+    )
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+
+    monkeypatch.setattr(
+        flashinfer.prefill_rocm,
+        "_aiter_bootstrap_batch_ragged_prefill",
+        _raiser(_INSTALL_FAILURE),
+    )
+
+    wrapper = flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper(
+        workspace, "NHD", backend="auto"
+    )
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        nqo,
+        nkv,
+        head_dim,
+        causal=True,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    assert wrapper._backend == "fa2"
+    assert wrapper.backend_fallback_reason.startswith(
+        "aiter batch_prefill kernel bootstrap failed"
+    )
+    out = wrapper.run(q, k, v)
+
+    monkeypatch.undo()
+    ref_wrapper = flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper(
+        workspace, "NHD", backend="fa2"
+    )
+    ref_wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        nqo,
+        nkv,
+        head_dim,
+        causal=True,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    torch.testing.assert_close(out, ref_wrapper.run(q, k, v), rtol=1e-3, atol=1e-3)
+
+
+def test_paged_prefill_explicit_aiter_still_raises(device, monkeypatch):
+    _skip_if_op_gated(device, "batch_prefill")
+    (
+        _q,
+        _kv,
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        workspace,
+        nqo,
+        nkv,
+        head_dim,
+        page_size,
+    ) = _paged_inputs(device)
+    monkeypatch.setattr(
+        flashinfer.prefill_rocm,
+        "_aiter_bootstrap_batch_ragged_prefill",
+        _raiser(_INSTALL_FAILURE),
+    )
+    wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        workspace, "NHD", backend="aiter"
+    )
+    with pytest.raises(ModuleNotFoundError):
+        wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            nqo,
+            nkv,
+            head_dim,
+            page_size,
+            causal=True,
+            q_data_type=torch.bfloat16,
+            kv_data_type=torch.bfloat16,
+        )
+
+
+# --------------------------------------------------------------------------
+# Site 4 -- batch decode
+# --------------------------------------------------------------------------
+
+
+def _decode_inputs(device, page_size=16, dtype=torch.bfloat16):
+    torch.manual_seed(0)
+    batch_size, kv_len = 2, 128
+    num_qo_heads = num_kv_heads = 8
+    head_dim = 128
+    num_pages = (kv_len + page_size - 1) // page_size
+    total_pages = num_pages * batch_size
+    q = torch.randn(batch_size, num_qo_heads, head_dim, device=device, dtype=dtype)
+    kv_data = torch.randn(
+        total_pages, 2, page_size, num_kv_heads, head_dim, device=device, dtype=dtype
+    )
+    indptr = (
+        torch.arange(0, batch_size + 1, dtype=torch.int32, device=device) * num_pages
+    )
+    indices = torch.arange(0, total_pages, dtype=torch.int32, device=device)
+    last_page_len = torch.full(
+        (batch_size,), (kv_len - 1) % page_size + 1, dtype=torch.int32, device=device
+    )
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+    return (
+        q,
+        kv_data,
+        indptr,
+        indices,
+        last_page_len,
+        workspace,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+    )
+
+
+def _plan_decode(wrapper, args, dtype=torch.bfloat16):
+    (_q, _kv, indptr, indices, last_page_len, _ws, nqo, nkv, head_dim, page_size) = args
+    wrapper.plan(
+        indptr,
+        indices,
+        last_page_len,
+        nqo,
+        nkv,
+        head_dim,
+        page_size,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+
+
+def test_decode_auto_demotes_to_fa2(device, monkeypatch):
+    _skip_if_op_gated(device, "batch_decode")
+    args = _decode_inputs(device)
+    q, kv_data, workspace = args[0], args[1], args[5]
+
+    monkeypatch.setattr(
+        flashinfer.decode_rocm, "_aiter_pa_v1_resolve", _raiser(_INSTALL_FAILURE)
+    )
+
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, "NHD", backend="auto", use_tensor_cores=False
+    )
+    _plan_decode(wrapper, args)
+
+    assert wrapper._backend == "fa2"
+    assert wrapper.backend_fallback_reason.startswith(
+        "aiter batch_decode kernel bootstrap failed"
+    )
+    # A demotion must leave no half-written AITER state for run() to trip over.
+    assert getattr(wrapper, "_aiter_so_path", None) is None
+    out = wrapper.run(q, kv_data)
+
+    monkeypatch.undo()
+    ref_wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, "NHD", backend="fa2", use_tensor_cores=False
+    )
+    _plan_decode(ref_wrapper, args)
+    torch.testing.assert_close(out, ref_wrapper.run(q, kv_data), rtol=1e-3, atol=1e-3)
+
+
+def test_decode_explicit_aiter_still_raises(device, monkeypatch):
+    _skip_if_op_gated(device, "batch_decode")
+    args = _decode_inputs(device)
+    workspace = args[5]
+    monkeypatch.setattr(
+        flashinfer.decode_rocm, "_aiter_pa_v1_resolve", _raiser(_INSTALL_FAILURE)
+    )
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, "NHD", backend="aiter", use_tensor_cores=False
+    )
+    with pytest.raises(ModuleNotFoundError):
+        _plan_decode(wrapper, args)
+
+
+def test_decode_strict_env_raises(device, monkeypatch):
+    _skip_if_op_gated(device, "batch_decode")
+    args = _decode_inputs(device)
+    workspace = args[5]
+    monkeypatch.setenv("FLASHINFER_AITER_STRICT", "1")
+    monkeypatch.setattr(
+        flashinfer.decode_rocm, "_aiter_pa_v1_resolve", _raiser(_INSTALL_FAILURE)
+    )
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, "NHD", backend="auto", use_tensor_cores=False
+    )
+    with pytest.raises(ModuleNotFoundError):
+        _plan_decode(wrapper, args)

--- a/tests/rocm_tests/test_aiter_auto_fallback_hip.py
+++ b/tests/rocm_tests/test_aiter_auto_fallback_hip.py
@@ -305,6 +305,16 @@ def test_paged_prefill_auto_demotes_to_fa2(device, monkeypatch):
         page_size,
     ) = _paged_inputs(device)
 
+    # Patch the native-paging bootstrap too. page_size=16 is not native on
+    # amd-aiter 0.1.10, but _aiter_native_page_sizes() falls back to {16, 1024}
+    # when the version cannot be read -- e.g. an AITER source build installed as
+    # `aiter`. There the native probe would run first and win, and this test
+    # would fail on an assertion that has nothing to do with what it covers.
+    monkeypatch.setattr(
+        flashinfer.prefill_rocm,
+        "_aiter_bootstrap_batch_prefill",
+        _raiser(_INSTALL_FAILURE),
+    )
     monkeypatch.setattr(
         flashinfer.prefill_rocm,
         "_aiter_bootstrap_batch_ragged_prefill",
@@ -371,6 +381,16 @@ def test_ragged_prefill_auto_demotes_to_fa2(device, monkeypatch):
     )
     workspace = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
 
+    # Patch the native-paging bootstrap too. page_size=16 is not native on
+    # amd-aiter 0.1.10, but _aiter_native_page_sizes() falls back to {16, 1024}
+    # when the version cannot be read -- e.g. an AITER source build installed as
+    # `aiter`. There the native probe would run first and win, and this test
+    # would fail on an assertion that has nothing to do with what it covers.
+    monkeypatch.setattr(
+        flashinfer.prefill_rocm,
+        "_aiter_bootstrap_batch_prefill",
+        _raiser(_INSTALL_FAILURE),
+    )
     monkeypatch.setattr(
         flashinfer.prefill_rocm,
         "_aiter_bootstrap_batch_ragged_prefill",
@@ -428,6 +448,16 @@ def test_paged_prefill_explicit_aiter_still_raises(device, monkeypatch):
         head_dim,
         page_size,
     ) = _paged_inputs(device)
+    # Patch the native-paging bootstrap too. page_size=16 is not native on
+    # amd-aiter 0.1.10, but _aiter_native_page_sizes() falls back to {16, 1024}
+    # when the version cannot be read -- e.g. an AITER source build installed as
+    # `aiter`. There the native probe would run first and win, and this test
+    # would fail on an assertion that has nothing to do with what it covers.
+    monkeypatch.setattr(
+        flashinfer.prefill_rocm,
+        "_aiter_bootstrap_batch_prefill",
+        _raiser(_INSTALL_FAILURE),
+    )
     monkeypatch.setattr(
         flashinfer.prefill_rocm,
         "_aiter_bootstrap_batch_ragged_prefill",
@@ -523,8 +553,10 @@ def test_decode_auto_demotes_to_fa2(device, monkeypatch):
     assert wrapper.backend_fallback_reason.startswith(
         "aiter batch_decode kernel bootstrap failed"
     )
-    # A demotion must leave no half-written AITER state for run() to trip over.
-    assert getattr(wrapper, "_aiter_so_path", None) is None
+    # A demotion must leave no half-written AITER state. hasattr, not getattr --
+    # the attribute is never defined at class level, so a `is None` check would
+    # pass no matter what plan() did.
+    assert not hasattr(wrapper, "_aiter_so_path")
     out = wrapper.run(q, kv_data)
 
     monkeypatch.undo()
@@ -533,6 +565,38 @@ def test_decode_auto_demotes_to_fa2(device, monkeypatch):
     )
     _plan_decode(ref_wrapper, args)
     torch.testing.assert_close(out, ref_wrapper.run(q, kv_data), rtol=1e-3, atol=1e-3)
+
+
+def test_decode_replan_demotes_instead_of_raising(device, monkeypatch):
+    """A wrapper that planned once on AITER must still demote on a later plan().
+
+    plan() overwrites _backend with the concrete choice, so deriving "did the
+    caller ask for auto" from _backend makes every plan() after the first take
+    the explicit path and raise. The probe key varies per plan (max_context_len
+    picks the AITER variant), so this is reachable, not theoretical.
+    """
+    _skip_if_op_gated(device, "batch_decode")
+    args = _decode_inputs(device)
+    q, kv_data, workspace = args[0], args[1], args[5]
+
+    wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, "NHD", backend="auto", use_tensor_cores=False
+    )
+    _plan_decode(wrapper, args)
+    first_backend = wrapper._backend
+
+    # Only now does AITER become unable to build; re-plan must not propagate it.
+    _clear_probes()
+    monkeypatch.setattr(
+        flashinfer.decode_rocm, "_aiter_pa_v1_resolve", _raiser(_INSTALL_FAILURE)
+    )
+    _plan_decode(wrapper, args)
+
+    assert wrapper._backend == "fa2", (
+        f"re-plan kept backend {wrapper._backend!r} after the AITER build failed "
+        f"(first plan chose {first_backend!r})"
+    )
+    wrapper.run(q, kv_data)
 
 
 def test_decode_explicit_aiter_still_raises(device, monkeypatch):


### PR DESCRIPTION
## Summary

`backend="auto"` documents "AITER when possible, otherwise fa2", but it decides that from the capability table plus an aiter import probe — both of which pass *before* AITER's per-variant `.so` is built. When that build fails the exception escaped and `auto` raised, which is the one outcome the contract rules out. This makes it demote to fa2 and record why.

Measured on gfx950: single prefill JIT-builds `mha_fwd`, because amd-aiter 0.1.10 ships zero prebuilt `mha_fwd*.so` against 58 `mha_varlen_fwd_*.so`. The build succeeded after 2h15m, then `ModuleNotFoundError` — AITER installs into `site-packages/aiter/jit/` and the container ran `--user` against a tree owned by another account. Read-only or foreign-owned site-packages is a normal deployment posture, not an exotic one.

Upstream has no equivalent problem to solve: `determine_attention_backend` picks fa3-vs-fa2 from static predicates with no runtime probe, and both of those are in-tree, built by flashinfer's own JIT. We are the only ones with a third-party package whose build can fail independently.

### What changed

- **`flashinfer/aiter_utils.py`** — new `handle_aiter_probe_failure()`, the single place that decides whether a failure is demotable.
- **`flashinfer/prefill_rocm.py`** — two `lru_cache`d probes, `_aiter_single_prefill_available` and `_aiter_batch_ragged_available`, wired into single prefill and both batch-prefill wrappers. `_backend_requested` records the caller's original ask.
- **`flashinfer/decode_rocm.py`** — `_aiter_pa_v1_available` wraps the resolver; `plan()`'s AITER block now computes into locals and commits on success, so the early `return` is guarded rather than removed.
- **`tests/rocm_tests/test_aiter_auto_fallback_hip.py`** — new; 16 tests covering all four sites.

### Architecture / design notes

**Cached probes, not try/except at the call sites.** This is not a style preference — `_aiter_native_paging_available`'s docstring already records why: *"functools.lru_cache does not memoize exceptions: inlining would re-launch a known-failing kernel, and re-warn, on every plan() call."* Here that means re-attempting a multi-hour build per `plan()`. The probes return the reason rather than a bool because it feeds `backend_fallback_reason` and has to be memoized with the verdict, or the second `plan()` reports a demotion it cannot explain.

**Demote when AITER cannot produce a kernel; raise when flashinfer cannot produce its shim.** `get_*_module` failures stay fatal. Those JIT flashinfer's own shim with hipcc and never link AITER — module generation only does `import aiter` to compute `-DFLASHINFER_AITER_JIT_DIR`, and every AITER symbol resolves later via `dlopen` in `aiter_loader.cc`. A failure there is our packaging bug, and demoting it would hide a build break behind a silent perf regression. It would also necessarily swallow `MissingJITCacheError`.

**The re-raise set is the load-bearing part.** `ArchCapabilityError` gates known-bad toolchains — the gfx950/ROCm-7.2 causal miscompile among them — so swallowing it trades a loud error for silently wrong numbers. `MissingJITCacheError` is our own AOT cache. `ValueError` is a caller contract violation. `OutOfMemoryError` is transient and must never be memoized as "unsupported", or one OOM downgrades the config for the process. `_require_aiter_runtime` deliberately stays *outside* every probe: it is what raises `ArchCapabilityError`, and keeping it out is the structural guarantee rather than a promise.

**Explicit `backend="aiter"` is untouched.** It still calls the raw bootstraps, so its error text and strict-mode behaviour are byte-identical. `FLASHINFER_AITER_STRICT=1` re-raises everything, matching the existing knob.

**Ordering.** Both prefill bootstraps now run before `_plan_info` is built, so a demotion cannot strand plan bookkeeping created against the AITER module. Site 2's bootstrap in the flat-gather arm was previously unprotected and ran after it. The ragged bootstrap stays outside the `_jit_module` split — `jit_args` with an explicit `backend="aiter"` is reachable and still needs the `.so`.

**Not in scope: `mla_rocm.py`.** It resolves `auto` to `"aiter"` unconditionally and there is no fa2 MLA kernel, so a "fallback" there could only be a `NotImplementedError` in a different hat. Excluded by construction, not by oversight.

**Known residual hole.** `aiter_loader.cc` resolves `.so`s from `site-packages/aiter/jit/`, so a bootstrap that *succeeds* into `~/.aiter/jit/build/` can still fail at `run()`. `AITER_JIT_DIR` already exists as an override. Closing it properly means reimplementing `build_so_name` in Python against the 0.1.10 ABI pin; out of scope here.

### Found by self-review before push

The last commit is a fix to the four before it, and it is the one worth reading. `resolved_from_auto` was derived from `self._backend`, which `plan()` overwrites with the concrete choice — so **every `plan()` after the first took the explicit path and raised**, i.e. the bug this series exists to fix, just moved one call later. It is reachable rather than theoretical because the probe key varies per `plan()`: decode keys on `max_context_len`, and batch prefill on `causal` and dtype. A/B'd by restoring the derived form, which fails the new re-plan test with the same `ModuleNotFoundError` that escaped in production.

Three smaller ones from the same pass: the paged wrapper now refuses to demote once a CUDA-graph capture buffer exists (nulling `_aiter_flat_gather_idx` under a captured graph would leave it pointing at freed memory); `_aiter_pa_v1_available` gained `device_idx` in its cache key, since the resolved `.so` is arch-specific and this host can hold gfx942 and gfx950 at once; and one demotion assertion was vacuous — `getattr(w, "_aiter_so_path", None) is None` cannot fail for any implementation, because the attribute has no class-level definition.

## Test plan

- [x] **gfx942 / MI300X**, ROCm 7.2.0, torch 2.9.1, amd-aiter 0.1.10 — `test_aiter_auto_fallback_hip.py` + `test_batch_prefill_kernels_hip.py` + `test_batch_decode_aiter_hip.py`: **729 passed, 114 skipped, 0 failed**.
- [x] **gfx950 / MI350X**, same toolchain — `test_aiter_auto_fallback_hip.py` + `test_batch_decode_aiter_hip.py` pass. `test_single_prefill_kernels_hip.py` has **920 failures that are pre-existing and not from this change**: the same suite on `c885d0a63` with none of this branch applied fails the same way (1636 passed / 920 failed / 1404 skipped), clustered in the large-head-dim region where AITER compiles `fmha_fwd_d192`/`d256`. Flagging it here because it is worth its own issue; it is unrelated to `auto` and reproduces on a clean checkout.
- [x] The new file alone: 16 tests, all passing on gfx942; 13 passed / 3 skipped on gfx950. The three skips are the batch-prefill tests, which the capability table already steers away from AITER on ROCm 7.2 — there is no demotion left to observe there, which is why they run on gfx942.
- [x] A/B'd twice. Making `handle_aiter_probe_failure` re-raise unconditionally fails exactly the four demotion tests and no others. Restoring the old `resolved_from_auto` derivation fails exactly the re-plan test.
- [x] Non-demotable failures are parametrized over all four re-raise classes, and additionally assert the probe cache is still empty — caching an OOM verdict would downgrade the config for the process lifetime.
- [x] `pre-commit run` over the series — clean.
- [x] `/code-review` on the changelist before pushing. It found the re-plan bug above, which the tests did not: every test planned exactly once per wrapper.

## Reviewer notes

The riskiest change is the decode `plan()` restructure. `run()` gates every `_aiter_*` and `_fa2_lse_*` read on `_backend == "aiter"`, so flipping the backend makes them unreachable — that invariant is what makes the fall-through safe, and it is worth confirming it still holds. The landing site is provably the plain fa2 decode branch, since `auto` short-circuits `use_tensor_cores` and CUDA-graph capture to fa2 before the selector runs.

Two things I deliberately did not do. `_aiter_pa_v1_available` keys on raw `max_context_len` rather than the `npar_loops` bucket that actually reaches the compiler, so near-duplicate lengths are separate cache entries; normalising would duplicate the derivation outside the resolver and drift on the next AITER bump. And the prefill sites still build the AITER shim before probing and discard it on demotion — decode does not, but fixing prefill means reordering around the `_jit_module` split for a cost paid once per process on an already-broken install.
