### PR TITLE
fix(rocm): stop requiring a live GPU to import flashinfer, and stop pinning xdist workers to cards that do not exist

### DIFF
--- a/.github/workflows/arch-caps-conformance.yml
+++ b/.github/workflows/arch-caps-conformance.yml
@@ -10,7 +10,7 @@
 # What this protects: a row added for one architecture but not the other, a
 # gate whose op name no longer matches any call site, a known-bad window that
 # stops matching the version it was written for, or a module-scope `import torch`
-# creeping into the pre-HIP_VISIBLE_DEVICES path. All of those are currently
+# creeping into the torch-free arch-resolution path. All of those are currently
 # caught only by someone remembering to run the GPU suite.
 name: arch-caps conformance
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,8 +89,9 @@ selection. `pytest-rerunfailures` comes from the `dev` extra
 (`pip install -e ".[dev]"`).
 
 **Worker count.** `pytest -n auto` spawns **half as many xdist workers as
-physical AMD cards** (4 workers on a CPX-mode 8-card host) and pins each
-to its card via `HIP_VISIBLE_DEVICES`. One worker per card was tried first
+physical AMD cards** (4 workers on a CPX-mode 8-card host) and assigns each
+a card via `HIP_VISIBLE_DEVICES`, which is what scopes the subprocesses a
+test spawns. One worker per card was tried first
 and produced sporadic failures across rope, single_prefill, and logits_cap
 under concurrent load. Pass an explicit `-n N` to override the halving.
 

--- a/flashinfer/hip_utils.py
+++ b/flashinfer/hip_utils.py
@@ -6,8 +6,8 @@ import functools
 import logging
 
 # arch_caps imports nothing (in particular, not torch), so importing it here
-# keeps this module safe to import before the HIP runtime starts -- which
-# tests/conftest.py relies on to set HIP_VISIBLE_DEVICES first.
+# keeps this module importable without torch -- which the hardware-less
+# arch-caps conformance job relies on.
 from .arch_caps import normalize_arch
 
 logger = logging.getLogger(__name__)

--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -209,6 +209,15 @@ elif IS_HIP:
         try:
             import torch
 
+            if torch.cuda.device_count() == 0:
+                # Importing flashinfer must not require a live GPU. Keep the arch
+                # in the path anyway: build.ninja is only written when absent, so
+                # one shared directory would serve two ISAs the same objects.
+                from ..hip_utils import resolve_target_archs
+
+                archs = sorted(set(resolve_target_archs().split(",")))
+                return FLASHINFER_CACHE_DIR / flashinfer_version / "_".join(archs)
+
             props = torch.cuda.get_device_properties(torch.cuda.current_device())
             gcn_arch = props.gcnArchName
             # Extract gfx arch (e.g., "gfx942:sramecc+:xnack-" -> "gfx942").

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,10 +17,11 @@ def _worker_gpu_index(worker_idx: int, supported):
     return supported[worker_idx % len(supported)] if supported else None
 
 
-# Pin this worker to a supported GPU. PYTEST_XDIST_WORKER ("gw0", "gw1", ...) is
-# injected into each worker subprocess by pytest-xdist before any Python code runs,
-# and get_physical_card_device_indices() spreads workers one per physical card
-# (CPX systems expose four logical devices sharing one card's HBM).
+# Pin this worker to a card. PYTEST_XDIST_WORKER ("gw0", "gw1", ...) is injected
+# into each worker subprocess by pytest-xdist before any Python code runs.
+# get_physical_card_device_indices() spreads workers one per *supported* physical
+# card; the torch fallback below, reached only when rocminfo is missing,
+# guarantees neither.
 #
 # This does not re-scope *this* process -- the flashinfer import below initializes
 # HIP first, so torch has already latched the full device list. What it scopes is

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,28 +6,40 @@ from typing import Any, Dict, Set
 
 import pytest
 
-# Pin this worker to a dedicated supported GPU BEFORE torch initializes the ROCm
-# runtime.  PYTEST_XDIST_WORKER is injected into each worker subprocess by
-# pytest-xdist before any Python code runs ("gw0", "gw1", ...).
-# get_supported_device_indices() uses rocminfo (no HIP init) so it is safe to
-# call here.  We map the worker index through the supported device list so that
-# workers are pinned only to FlashInfer-supported GPUs; unsupported integrated
-# GPUs are never assigned.  Setting HIP_VISIBLE_DEVICES here makes the ROCm
-# runtime start up with exactly one device so all device-0 references inside
-# tests transparently route to the assigned physical GPU.
+
+def _worker_gpu_index(worker_idx: int, supported):
+    """Card to pin an xdist worker to, or None if there is nothing to pin to.
+
+    Workers wrap around when they outnumber the cards. Using worker_idx itself
+    names a device that need not exist, and a child process inheriting that
+    HIP_VISIBLE_DEVICES sees no GPU at all.
+    """
+    return supported[worker_idx % len(supported)] if supported else None
+
+
+# Pin this worker to a supported GPU. PYTEST_XDIST_WORKER ("gw0", "gw1", ...) is
+# injected into each worker subprocess by pytest-xdist before any Python code runs,
+# and get_physical_card_device_indices() spreads workers one per physical card
+# (CPX systems expose four logical devices sharing one card's HBM).
+#
+# This does not re-scope *this* process -- the flashinfer import below initializes
+# HIP first, so torch has already latched the full device list. What it scopes is
+# the child processes tests spawn, which is where a bad index is fatal.
 _xdist_worker = os.environ.get("PYTEST_XDIST_WORKER", "")
 if _xdist_worker.startswith("gw"):
-    _worker_idx = int(_xdist_worker[2:])
-    # Pin to one physical card per worker on CPX systems (avoids HSA crashes
-    # when multiple workers hammer the same card's HBM). On non-CPX systems
-    # the helper returns all supported devices.
+    import torch
+
     from flashinfer.hip_utils import get_physical_card_device_indices
 
-    _supported = get_physical_card_device_indices()
-    _gpu_index = (
-        _supported[_worker_idx] if _worker_idx < len(_supported) else _worker_idx
+    # rocminfo is how cards are identified; when it is missing the list comes
+    # back empty even on a populated host, so fall back to what torch can see
+    # rather than to worker indices that need not name anything.
+    _cards = get_physical_card_device_indices() or tuple(
+        range(torch.cuda.device_count())
     )
-    os.environ["HIP_VISIBLE_DEVICES"] = str(_gpu_index)
+    _gpu_index = _worker_gpu_index(int(_xdist_worker[2:]), _cards)
+    if _gpu_index is not None:
+        os.environ["HIP_VISIBLE_DEVICES"] = str(_gpu_index)
 
 import torch
 from torch.torch_version import TorchVersion

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,7 @@ def _worker_gpu_index(worker_idx: int, supported):
 # Pin this worker to a card. PYTEST_XDIST_WORKER ("gw0", "gw1", ...) is injected
 # into each worker subprocess by pytest-xdist before any Python code runs.
 # get_physical_card_device_indices() spreads workers one per *supported* physical
-# card; the torch fallback below, reached only when rocminfo is missing,
-# guarantees neither.
+# card; the torch fallback below guarantees neither.
 #
 # This does not re-scope *this* process -- the flashinfer import below initializes
 # HIP first, so torch has already latched the full device list. What it scopes is
@@ -32,8 +31,8 @@ if _xdist_worker.startswith("gw"):
 
     from flashinfer.hip_utils import get_physical_card_device_indices
 
-    # rocminfo is how cards are identified; when it is missing the list comes
-    # back empty even on a populated host, so fall back to what torch can see
+    # rocminfo is how supported cards are identified; when it reports none --
+    # missing binary, or no supported GPU -- fall back to what torch can see
     # rather than to worker indices that need not name anything.
     _cards = get_physical_card_device_indices() or tuple(
         range(torch.cuda.device_count())

--- a/tests/rocm_tests/conftest.py
+++ b/tests/rocm_tests/conftest.py
@@ -71,9 +71,9 @@ def _probe(fn, default=_UNKNOWN):
 def _devices() -> str:
     """Device indices this session runs on.
 
-    HIP_VISIBLE_DEVICES wins when set: tests/conftest.py pins each xdist worker
-    to a single card through it before torch loads, so it -- not the full card
-    list -- is what this process can actually see.
+    HIP_VISIBLE_DEVICES wins when set: tests/conftest.py assigns each xdist
+    worker a card through it, so it -- not the full card list -- is the card
+    this session is meant to be using.
     """
     visible = os.environ.get("HIP_VISIBLE_DEVICES", "").strip()
     if visible:

--- a/tests/rocm_tests/test_arch_caps_hip.py
+++ b/tests/rocm_tests/test_arch_caps_hip.py
@@ -109,10 +109,10 @@ class TestNormalizeArch:
 def test_suite_loads_without_torch():
     """Neither arch_caps nor hip_utils may import torch at module scope.
 
-    hip_utils sits on a path that must not touch torch: tests/conftest.py calls
-    it to choose a GPU *before* pinning HIP_VISIBLE_DEVICES, which is why it
-    probes with rocminfo rather than torch.cuda. arch_caps is imported by
-    hip_utils at module scope, so it inherits the same constraint.
+    hip_utils sits on a path that must not touch torch: it answers "which
+    architecture" for build hosts that have neither torch nor a GPU, which is
+    why it probes with rocminfo rather than torch.cuda. arch_caps is imported
+    by hip_utils at module scope, so it inherits the same constraint.
 
     Asserting it against *this file's* loader rather than against arch_caps
     alone covers both modules at once and pins the exact precondition the

--- a/tests/rocm_tests/test_jit_env_hip.py
+++ b/tests/rocm_tests/test_jit_env_hip.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests that importing flashinfer does not require a live GPU.
+
+``flashinfer/jit/env.py`` resolves the JIT workspace directory at import time,
+and on HIP it did so through ``torch.cuda.current_device()`` -- so any process
+without a visible device died on ``import flashinfer``. Subprocesses spawned by
+the test suite are the common victims, but a GPU-free build host is the same
+case.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+import torch
+
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(torch.version, "hip") or torch.version.hip is None,
+    reason="HIP not available",
+)
+
+# No host has this many cards, so it selects nothing on any ROCm version.
+_NO_SUCH_DEVICE = "999999"
+
+
+def test_import_succeeds_with_no_visible_device():
+    """A device index that names no card hides them all; the import must survive.
+
+    The child checks its own device count before importing, so the test cannot
+    pass because the sentinel failed to hide anything. Those checks are raises
+    rather than asserts: the parent's env is inherited, and PYTHONOPTIMIZE
+    would strip an assert and leave the test passing vacuously.
+    """
+    snippet = textwrap.dedent(
+        """\
+        import torch
+
+        if torch.cuda.device_count() != 0:
+            raise SystemExit("sentinel failed: child still sees a GPU")
+
+        import flashinfer
+        from flashinfer.jit import env as jit_env
+
+        name = jit_env.FLASHINFER_WORKSPACE_DIR.name
+        if not name.startswith("gfx"):
+            raise SystemExit(f"workspace dir dropped the arch: {name}")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        # Both layers: ROCR filters before HIP does, and an out-of-range index is
+        # unambiguous where an empty string is read as "unset" on some stacks.
+        env={
+            **os.environ,
+            "ROCR_VISIBLE_DEVICES": _NO_SUCH_DEVICE,
+            "HIP_VISIBLE_DEVICES": _NO_SUCH_DEVICE,
+        },
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, f"GPU-free import failed:\n{result.stderr}"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="No GPU available")
+def test_workspace_dir_still_names_the_device_arch():
+    """With a device present the path is unchanged -- existing caches keep working.
+
+    Read through current_device(), which is what env.py resolved the name from;
+    device 0 is a different card once a worker has been pinned.
+    """
+    from flashinfer.arch_caps import normalize_arch
+    from flashinfer.jit import env as jit_env
+
+    props = torch.cuda.get_device_properties(torch.cuda.current_device())
+    expected = normalize_arch(props.gcnArchName)
+    assert jit_env.FLASHINFER_WORKSPACE_DIR.name == expected

--- a/tests/rocm_tests/test_worker_pinning_hip.py
+++ b/tests/rocm_tests/test_worker_pinning_hip.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the xdist worker/GPU mapping in tests/conftest.py.
+
+GPU-free. The branch worth protecting is the one a well-provisioned runner
+never takes: more workers than physical cards, where handing a worker its own
+index names a device that does not exist. That value is harmless in the worker
+itself -- HIP is already initialized by then -- and fatal in every subprocess
+the worker spawns, which is what makes it hard to attribute.
+
+The conftest is loaded by path, as in test_run_header_hip.py: pytest owns
+conftest import, and a second module object can be exercised without touching
+the hooks pytest is actually running.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+_CONFTEST = pathlib.Path(__file__).parents[1] / "conftest.py"
+
+
+@pytest.fixture
+def root_conftest(monkeypatch):
+    """A private copy of tests/conftest.py, loaded with its pinning inert.
+
+    Clearing PYTEST_XDIST_WORKER first skips the module-level pinning block, so
+    loading the module cannot rewrite this session's own HIP_VISIBLE_DEVICES.
+    """
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    spec = importlib.util.spec_from_file_location("_root_conftest_isolated", _CONFTEST)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_maps_through_the_supported_list(root_conftest):
+    """Worker index is an offset into the supported cards, not a device id."""
+    assert root_conftest._worker_gpu_index(1, (2, 5)) == 5
+
+
+def test_more_workers_than_cards_wraps(root_conftest):
+    """pytest -n 4 on a one-card host: share card 0, never invent cards 1-3."""
+    assert [root_conftest._worker_gpu_index(i, (0,)) for i in range(4)] == [0, 0, 0, 0]
+
+
+def test_no_supported_card_pins_nothing(root_conftest):
+    """Nothing to pin to is not the same as pinning to device 0."""
+    assert root_conftest._worker_gpu_index(0, ()) is None
+
+
+@pytest.mark.parametrize("supported", [(0,), (0, 1), (0, 2, 4, 6), (1, 3)])
+def test_never_names_an_unsupported_card(root_conftest, supported):
+    for worker_idx in range(16):
+        assert root_conftest._worker_gpu_index(worker_idx, supported) in supported


### PR DESCRIPTION
## Summary

`tests/rocm_tests/test_torch_compile_hip.py` failed under `pytest -n 4` on a single-GPU host while passing serially — four to six of its six tests, varying by run. All six shell out to a subprocess, and the child died at `import flashinfer` with `RuntimeError: No HIP GPUs are available`. Two independent defects produced that, one in the test harness and one in the library; both are fixed here.

## Root cause

`tests/conftest.py` pins each xdist worker to a card, but does two things wrong.

First, the pin never takes effect in the worker. The line above it — `from flashinfer.hip_utils import get_physical_card_device_indices` — imports `flashinfer/__init__.py`, which evaluates `flashinfer/jit/env.py` at module scope and calls `torch.cuda.current_device()`. HIP is therefore already initialized, with every device visible, by the time `HIP_VISIBLE_DEVICES` is assigned. Measured on the gfx950 box:

```
HIP initialised by the hip_utils import? True
device_count before pinning: 1
device_count after pinning to a nonexistent card: 1
```

The variable does still reach every subprocess a test spawns, which is what makes this fatal in exactly one place and invisible everywhere else.

Second, when workers outnumber cards the mapping fell back to the raw worker index — `_supported[_worker_idx] if _worker_idx < len(_supported) else _worker_idx` — so on a one-card host `-n 4` handed gw1..gw3 the values `1`, `2` and `3`, none of which name a device. The worker shrugged; its children saw zero GPUs and could not import the library.

## What changed

#### Library

- **`flashinfer/jit/env.py`** — `_get_workspace_dir_name()` no longer requires a live device. When `torch.cuda.device_count()` is zero it resolves the arch through `hip_utils.resolve_target_archs()`, the repo's existing torch-free resolver, instead of raising. With a device present the path is derived exactly as before, so no existing JIT cache is orphaned.

#### Test harness

- **`tests/conftest.py`** — worker indices now wrap over the card list instead of falling through to an index that need not exist, and nothing is pinned when there is no card to pin to. Where `rocminfo` is unavailable the list comes back empty even on a populated host, so the card set falls back to `torch.cuda.device_count()` rather than losing the spread entirely. The mapping is extracted into `_worker_gpu_index()` so it can be tested directly.
- **`tests/rocm_tests/test_jit_env_hip.py`** (new) — asserts `import flashinfer` survives with no visible device, and that the workspace path still names the device arch when one is present.
- **`tests/rocm_tests/test_worker_pinning_hip.py`** (new) — covers the wrap, the empty-card-list case, and that no worker index can ever name a card outside the supported set.

#### Documentation

- **`flashinfer/hip_utils.py`, `tests/rocm_tests/conftest.py`, `tests/rocm_tests/test_arch_caps_hip.py`, `.github/workflows/arch-caps-conformance.yml`, `CONTRIBUTING.md`** — five places asserted that the conftest pins before the HIP runtime starts, and that this scopes the worker process. Measurement disproved both. What remains true, and is what the hardware-less arch-caps conformance job actually depends on, is that `hip_utils` and `arch_caps` import no torch at module scope; the comments now give that as the reason.

### Design notes

**Why `resolve_target_archs()` and not `"noarch"`.** Naming the device-less workspace `noarch` was the first attempt and is wrong. `build.ninja` is only written when absent (documented in `CLAUDE.md`), so a gfx942-targeted and a gfx950-targeted device-less build would share one `cached_ops` tree and the second would silently ship the first's objects. Keeping the arch in the path preserves the cache key. This branch is only reachable when there is no device, which previously raised, so nothing can already be cached under it.

**Why the new test uses raises rather than asserts.** The child inherits the parent's environment, and `PYTHONOPTIMIZE=1` strips `assert`. The first version of this test passed with the fix reverted for exactly that reason. Its sentinel also sets both `ROCR_VISIBLE_DEVICES` and `HIP_VISIBLE_DEVICES` to an out-of-range index, because an empty string is read as "unset" on some ROCm stacks.

**Deferred deliberately.** The pin still does not scope the worker's own process, so every worker falls back to `cuda:0` and one card carries the suite. That is a CI wall-time cost rather than a correctness problem — plausibly what the worker halving in `tests/rocm_tests/conftest.py` compensates for — and the route to fixing it is to set `HIP_VISIBLE_DEVICES` before the worker process exists, sharding into N pytest processes the way a serving layer assigns a rank its device, rather than deferring HIP init inside the library. It is also unobservable on a one-card host, so it does not belong in this change.

## Test plan

- [x] `pytest -n 4 tests/rocm_tests/test_torch_compile_hip.py` — reproduced the failure on the base commit (5 failed), green after the fix, repeated 3× plus a serial `-n 0` run.
- [x] A/B on both fixes: reverting `flashinfer/jit/env.py` fails `test_import_succeeds_with_no_visible_device`; reverting `tests/conftest.py` returns 11 failures across the target file and the new pinning tests.
- [x] A/B under `PYTHONOPTIMIZE=1` — fails with the fix reverted, passes with it, confirming the new test is not vacuous.
- [x] Reachable-surface regression (every test in `tests/rocm_tests/` that spawns a subprocess or reads `HIP_VISIBLE_DEVICES`, plus `test_amd_coverage.py`, `test_aot_hip.py`, `test_force_cta_tile_q_hip.py`): 83 passed, run twice after rebasing onto `ee7309cc7`.
- [x] `pre-commit run -a`.

Verified on **gfx950** (MI350X, ROCm 7.2.0, torch 2.9.1+rocm7.2, amd-aiter 0.1.10). **gfx942 is unverified** — no CDNA3 box was reachable for this change. The diff has no arch-conditional code: `_worker_gpu_index` is index arithmetic, and the `env.py` branch keys on device count rather than architecture. With workers not exceeding cards — the normal case on an 8-card gfx942 host — `supported[i % len]` is identical to the previous `supported[i]`, so the mapping is unchanged there.
