### PR TITLE
fix(rocm): make the custom-variant prefill JIT path usable

### DIFF
--- a/flashinfer/jit/attention/modules_hip.py
+++ b/flashinfer/jit/attention/modules_hip.py
@@ -642,7 +642,13 @@ def gen_customize_single_prefill_module(
     use_sliding_window: bool = False,
     use_logits_soft_cap: bool = False,
     use_fp16_qk_reduction: bool = False,
+    fp8_enabled: bool = False,
 ):
+    # Upstream routes fp8 through fa3-only sm90 templates; ROCm has no fp8
+    # prefill kernel, so refuse rather than silently return a bf16/fp16 one.
+    if fp8_enabled:
+        raise ValueError("fp8 prefill is not supported on ROCm")
+
     kwargs = {
         "variant_decl": variant_decl,
         "variant_name": variant_name,
@@ -871,7 +877,13 @@ def gen_customize_batch_prefill_module(
     use_sliding_window: bool = False,
     use_logits_soft_cap: bool = False,
     use_fp16_qk_reduction: bool = False,
+    fp8_enabled: bool = False,
 ):
+    # Upstream routes fp8 through fa3-only sm90 templates; ROCm has no fp8
+    # prefill kernel, so refuse rather than silently return a bf16/fp16 one.
+    if fp8_enabled:
+        raise ValueError("fp8 prefill is not supported on ROCm")
+
     kwargs = {
         "variant_decl": variant_decl,
         "variant_name": variant_name,

--- a/flashinfer/prefill_rocm.py
+++ b/flashinfer/prefill_rocm.py
@@ -1108,6 +1108,7 @@ def get_batch_prefill_jit_module(module_name: str, jit_module: Any):
         mask_mode: int,
         layout: int,
         window_left: int,
+        enable_pdl: bool,
         *args,
     ) -> None:
         ragged_run_func(
@@ -1124,6 +1125,7 @@ def get_batch_prefill_jit_module(module_name: str, jit_module: Any):
             mask_mode,
             layout,
             window_left,
+            # enable_pdl,  # Not supported by HIP kernels
             *args,
         )
 
@@ -1142,6 +1144,7 @@ def get_batch_prefill_jit_module(module_name: str, jit_module: Any):
         mask_mode: int,
         layout: int,
         window_left: int,
+        enable_pdl: bool,
         *args,
     ) -> None:
         pass
@@ -1174,6 +1177,7 @@ def get_batch_prefill_jit_module(module_name: str, jit_module: Any):
         mask_mode: int,
         layout: int,
         window_left: int,
+        enable_pdl: bool,
         *args,
     ) -> None:
         paged_run_func(
@@ -1192,6 +1196,7 @@ def get_batch_prefill_jit_module(module_name: str, jit_module: Any):
             mask_mode,
             layout,
             window_left,
+            # enable_pdl,  # Not supported by HIP kernels
             *args,
         )
 
@@ -1212,6 +1217,7 @@ def get_batch_prefill_jit_module(module_name: str, jit_module: Any):
         mask_mode: int,
         layout: int,
         window_left: int,
+        enable_pdl: bool,
         *args,
     ) -> None:
         pass

--- a/tests/rocm_tests/test_customize_prefill_signature_hip.py
+++ b/tests/rocm_tests/test_customize_prefill_signature_hip.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Signature parity for the ROCm custom-variant prefill JIT path.
+
+prefill_rocm.py forwards arguments positionally into these generators and run
+wrappers, so a parameter missing on the HIP side is a TypeError at call time.
+Upstream is read with ast because modules.py cannot be imported on ROCm.
+"""
+
+import ast
+import functools
+import inspect
+import pathlib
+
+import pytest
+
+import flashinfer
+from flashinfer.device_utils import IS_HIP
+
+pytestmark = pytest.mark.skipif(
+    not IS_HIP, reason="modules_hip is only importable on ROCm"
+)
+
+_PKG_DIR = pathlib.Path(flashinfer.__file__).parent
+
+CUSTOMIZE_PREFILL_GENERATORS = [
+    "gen_customize_single_prefill_module",
+    "gen_customize_batch_prefill_module",
+]
+
+# The JIT-path run wrappers must accept the same fixed argument prefix that the
+# non-JIT ones do, up to and including enable_pdl; everything after it is *args.
+JIT_RUN_WRAPPERS = ["ragged_run", "_fake_ragged_run", "paged_run", "_fake_paged_run"]
+
+
+@functools.cache
+def _parse(path: pathlib.Path) -> ast.Module:
+    return ast.parse(path.read_text())
+
+
+def _params(node: ast.FunctionDef) -> list[str]:
+    a = node.args
+    return [p.arg for p in (*a.posonlyargs, *a.args, *a.kwonlyargs)]
+
+
+def _positional(node: ast.FunctionDef) -> list[str]:
+    """Names callers may pass positionally — everything before any ``*``."""
+    a = node.args
+    return [p.arg for p in (*a.posonlyargs, *a.args)]
+
+
+def _find(tree: ast.AST, name: str) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found")
+
+
+def _generator(module_filename: str, func_name: str) -> ast.FunctionDef:
+    return _find(_parse(_PKG_DIR / "jit" / "attention" / module_filename), func_name)
+
+
+def _wrapper(outer: str, inner: str) -> ast.FunctionDef:
+    return _find(_find(_parse(_PKG_DIR / "prefill_rocm.py"), outer), inner)
+
+
+@pytest.mark.parametrize("func_name", CUSTOMIZE_PREFILL_GENERATORS)
+def test_hip_generator_matches_upstream_signature(func_name):
+    hip = _generator("modules_hip.py", func_name)
+    upstream = _generator("modules.py", func_name)
+
+    assert _params(hip) == _params(upstream)
+    # Names alone would still pass if HIP moved a parameter behind a `*`;
+    # prefill_rocm.py forwards all of them positionally.
+    assert _positional(hip) == _positional(upstream)
+
+
+def test_rocm_wrapper_forwards_exactly_what_the_generator_accepts():
+    from flashinfer.jit.attention import gen_customize_batch_prefill_module
+    from flashinfer.prefill_rocm import get_customize_batch_prefill_module
+
+    # get_customize_batch_prefill_module is wrapped by make_hashable_cache,
+    # which uses functools.wraps, so signature() sees the underlying function.
+    assert list(inspect.signature(get_customize_batch_prefill_module).parameters) == (
+        list(inspect.signature(gen_customize_batch_prefill_module).parameters)
+    )
+
+
+@pytest.mark.parametrize("inner", JIT_RUN_WRAPPERS)
+def test_jit_run_wrapper_takes_the_same_fixed_prefix_as_the_non_jit_one(inner):
+    node = _wrapper("get_batch_prefill_jit_module", inner)
+    jit = _positional(node)
+    non_jit = _positional(_wrapper("get_batch_prefill_module", inner))
+
+    assert jit[-1] == "enable_pdl", f"{inner} would absorb enable_pdl into *args"
+    assert jit == non_jit[: len(jit)]
+    # enable_pdl must stay positional and *args must survive to carry the
+    # variant's additional tensors/scalars; either alone passes the name check.
+    assert not node.args.kwonlyargs
+    assert node.args.vararg is not None
+
+
+@pytest.mark.parametrize("func_name", CUSTOMIZE_PREFILL_GENERATORS)
+def test_fp8_enabled_is_rejected(func_name):
+    from flashinfer.jit import attention as jit_attention
+
+    generator = getattr(jit_attention, func_name)
+    n_required = sum(
+        p.default is inspect.Parameter.empty
+        for p in inspect.signature(generator).parameters.values()
+    )
+    # The guard runs before any argument is inspected, so placeholders suffice.
+    with pytest.raises(ValueError, match="fp8"):
+        generator(*[None] * n_required, fp8_enabled=True)


### PR DESCRIPTION
## Summary

The custom-attention-variant prefill path — `BatchPrefillWith{Ragged,Paged}KVCacheWrapper(..., jit_args=...)` — has never worked on ROCm. Two argument-list mismatches sit back to back, and fixing the first only exposes the second. Both are places where a ROCm-side signature drifted from the upstream one that `prefill_rocm.py` forwards into positionally.

## Root cause

**First mismatch — the generator is one parameter short.** [`prefill_rocm.py:130`](https://github.com/AMD-Ecosystem/flashinfer/blob/amd-integration/flashinfer/prefill_rocm.py#L130) is a copy of `prefill.py:135` and accepts `fp8_enabled`, then forwards all 19 arguments positionally at `:151`. `modules_hip.gen_customize_batch_prefill_module` declared 18. Because the forwarding is positional, the caller never had to mention `fp8_enabled` for this to fire:

```
TypeError: gen_customize_batch_prefill_module() takes from 14 to 18 positional arguments but 19 were given
```

Reached from `BatchPrefillWithRaggedKVCacheWrapper.__init__` (`:2916`) and the paged one (`:1810`) whenever `jit_args` is supplied. The backend validation in both sits *after* the `jit_args` block, so nothing shielded it.

**Second mismatch — `enable_pdl` is forwarded into a C++ op that does not take it.** With the generator fixed, the module compiles and the failure moves one layer down:

```
RuntimeError: batch_prefill_flash_sigmoid_rocm::ragged_run() expected at most 15 argument(s) but received 16 argument(s)
```

`run()` puts `enable_pdl` into `run_args` unconditionally (`:2655` paged, `:3470` ragged). The four wrappers in `get_batch_prefill_jit_module` were a verbatim copy of upstream's, which end at `window_left` and let `enable_pdl` flow through `*args` into C++ — correct there, because `csrc/batch_prefill.cu` declares `bool enable_pdl ADDITIONAL_FUNC_PARAMS`. `csrc_rocm`'s declaration ends at `int64_t window_left ADDITIONAL_FUNC_PARAMS`, so on ROCm it landed in the first additional-param slot.

**Why neither was caught.** Nothing in `testpaths` reaches this code. `tests/utils/test_jit_example.py` is not in `testpaths` *and* fails collection on ROCm — it imports `flashinfer.prefill`, which pulls `gen_fmha_cutlass_sm100a_module` and `gen_trtllm_gen_fmha_module`, both defined only under `if IS_CUDA:`. No test under `tests/rocm_tests/` passes `jit_args`. mypy did not catch the first either: it analyses both the `IS_CUDA` and `IS_HIP` arms, so the merged namespace let the call resolve against upstream's generator, which does take `fp8_enabled`.

## What changed

#### Library

- **`flashinfer/jit/attention/modules_hip.py`** — `gen_customize_batch_prefill_module` and `gen_customize_single_prefill_module` gain `fp8_enabled: bool = False`, making both signatures identical to their upstream counterparts. Each rejects a true value with `ValueError`.
- **`flashinfer/prefill_rocm.py`** — the four wrappers in `get_batch_prefill_jit_module` (`ragged_run`, `paged_run` and their fake ops) name `enable_pdl` and drop it at the C++ boundary, matching what the non-JIT `get_batch_prefill_module` already does at `:889`/`:1009` and `decode_rocm.py:174`.

#### Tests

- **`tests/rocm_tests/test_customize_prefill_signature_hip.py`** (new) — 9 tests pinning both invariants. GPU-free and JIT-free; needs only a HIP torch build, like `test_comm_import_gate_hip.py`.

### Design notes

**Why the single-prefill generator is fixed too.** `gen_customize_single_prefill_module` had the same gap (17 params against 18) but has no caller in `prefill_rocm.py`, so it is latent rather than live. Both names are re-exported from `flashinfer.jit.attention`, so a caller written against the upstream signature breaks identically. Scope stops there: `gen_customize_pod_module` and `gen_customize_batch_pod_module` diverge from upstream far more deeply (20 params against 15; the HIP versions drop all four `additional_*` lists), so this is not a blanket "match every upstream signature" sweep.

**Why `fp8_enabled` is refused rather than ignored.** Upstream consults it only in its `fa3` branch and silently ignores it for `fa2`. ROCm has no fp8 prefill kernel at all, so accept-and-ignore would hand back a bf16/fp16 module for an fp8 request with no signal. `ValueError` rather than `assert`, on two counts: `modules_hip.py` uses `ValueError` for every other rejection and contains no asserts, and an assert would vanish under `python -O`.

**Why `enable_pdl` is absorbed in the wrapper rather than stripped in `run()`.** The alternative is to drop it from `run_args` in the `_jit_module` branch. That needs the change at both `run()` sites, makes `run_args`' length depend on which branch you are in — precisely the shape that produced this bug — and leaves the JIT-path and non-JIT-path ops with different arities in the case where `register_custom_op` derives a schema from the signature. Absorbing it costs one discarded parameter per wrapper and keeps both paths identical. Both `run()` methods normalise `None` to `device_support_pdl()` before building `run_args`, so the `bool` annotation never sees `None`.

**Why the tests read upstream with `ast`.** `modules.py` cannot be imported on ROCm — `modules.py:28` does `from ..core import sm90a_nvcc_flags`, defined only under `if IS_CUDA:` in `jit/core.py`. Parsing the source sidesteps that and keeps the assertion tracking upstream automatically, so the next sync surfaces drift rather than hiding it.

**Why the tests compare the pre-`*` positional list.** Comparing parameter *names* alone passes for the wrong reason: making `enable_pdl` keyword-only, or deleting `*args` outright, both yield an identical name list while breaking the positional call `run()` makes. The checks compare the positional prefix and separately assert the vararg survives with no keyword-only parameters.

### Not addressed here

- A `use_softmax = false` variant builds and runs but returns NaN on ~1.7% of elements on gfx950, with ~69% outside a 2e-2 tolerance; a standard softmax variant through the same path matches torch exactly with zero NaN. That is a kernel-level numerics defect below these signature fixes, pre-existing, and only reachable now because this PR makes the path work at all. Follow-up branch.
- `BatchPrefillWithPagedKVCacheWrapper(..., jit_args=...)` without an explicit `backend="fa2"` still fails: `backend` defaults to `"auto"`, which `modules_hip.py` rejects with `backend should not be auto when jit_args is provided`. Upstream behaves the same way; whether `auto` should resolve before the `jit_args` block is a separate design question.
- `partial_state` and `sinks` are validated and then silently dropped on the JIT-module path, and `gen_batch_prefill_module` never derives `fp8_enabled` from `dtype_q` the way upstream's does. Both pre-existing, both in code this PR does not touch.

## Test plan

- [x] Reproduced both failures on the base commit with a standalone script — `tests/utils/test_jit_example.py` cannot run on ROCm, so it served as a reference for the argument shape only.
- [x] `pytest tests/rocm_tests/test_customize_prefill_signature_hip.py` — 9 passed.
- [x] A/B per fix, not in aggregate: reverting `modules_hip.py` fails 5 of the 9; reverting `prefill_rocm.py` fails the other 4.
- [x] Mutation-checked the new assertions — moving `enable_pdl` after `*args` produces an identical name list and still fails the test, confirming it is not name-matching alone.
- [x] Confirmed `flashinfer.__file__` resolves to the worktree, not the main checkout's editable install, before each A/B.
- [x] End-to-end: a standard softmax custom variant builds through the ragged wrapper and matches `scaled_dot_product_attention` exactly (0 NaN).
- [x] `pytest -n auto --reruns 2 -m "not slow"` over the prefill, dispatch and JIT-spec suites — 3575 passed, 4210 skipped, 0 failed. The full `tests/rocm_tests/` run was not used: nothing in it reaches the `jit_args` path this touches.
- [x] `pre-commit run -a`.

Verified on **gfx950** (MI350X, ROCm 7.2.0, torch 2.9.1+rocm7.2, amd-aiter 0.1.10). **gfx942 is unverified** — no CDNA3 box was reachable for this change. The library diff is argument-list plumbing with no arch-conditional code, so both architectures take an identical path through it; what is genuinely CDNA4-only is the end-to-end result, which compiled HIP prefill kernels that had never been built on either arch.